### PR TITLE
feat: add optional version pinning for MariaDB and Redis

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -42,7 +42,7 @@ bench new --help      # works
 
 ## Phase 1 — Config Layer + Validation
 
-**Goal:** `BenchConfig.from_file()` parses and validates `bench.yml`; all 13 validation rules are enforced; errors name the offending field.
+**Goal:** `BenchConfig.from_file()` parses and validates `bench.yml`; all 14 validation rules are enforced; errors name the offending field.
 
 ### Files
 
@@ -50,15 +50,15 @@ bench new --help      # works
 |------|---------|
 | `bench2/config/app_config.py` | `AppConfig` dataclass: `name`, `repo`, `branch` |
 | `bench2/config/site_config.py` | `SiteConfig` dataclass: `name`, `db_name`, `db_password`, `apps`, `domains`, `ssl`; `all_domains` property |
-| `bench2/config/mariadb_config.py` | `MariaDBConfig` dataclass with defaults |
-| `bench2/config/redis_config.py` | `RedisConfig` dataclass with defaults |
+| `bench2/config/mariadb_config.py` | `MariaDBConfig` dataclass with defaults; optional `version` field |
+| `bench2/config/redis_config.py` | `RedisConfig` dataclass with defaults; optional `version` field |
 | `bench2/config/worker_config.py` | `WorkerConfig` dataclass with defaults |
 | `bench2/config/nginx_config.py` | `NginxConfig` dataclass with defaults |
 | `bench2/config/letsencrypt_config.py` | `LetsEncryptConfig` dataclass with defaults |
-| `bench2/config/bench_config.py` | `BenchConfig` — `from_file()` classmethod, `validate()` with all 13 rules, `app_by_name()`, `framework_app` |
+| `bench2/config/bench_config.py` | `BenchConfig` — `from_file()` classmethod, `validate()` with all 14 rules, `app_by_name()`, `framework_app` |
 | `bench2/commands/new.py` | `NewCommand.run()` — writes starter `bench.yml` template |
 | `tests/__init__.py` | Empty |
-| `tests/test_config.py` | Unit tests: happy path, each of the 13 validation rules |
+| `tests/test_config.py` | Unit tests: happy path, each of the 14 validation rules |
 | `tests/fixtures/minimal.yml` | Minimal valid `bench.yml` |
 | `tests/fixtures/invalid_*.yml` | One fixture per validation rule |
 
@@ -89,8 +89,8 @@ bench new    # writes bench.yml
 | `bench2/core/app.py` | `App` — `is_cloned`, `clone()`, `install()`, `update()`, `build_assets()` |
 | `bench2/core/site.py` | `Site` — `exists`, `create()`, `install_app()`, `migrate()` |
 | `bench2/managers/python_env_manager.py` | `PythonEnvManager` — `ensure_python()` (deadsnakes on Ubuntu, `brew install python@X` on macOS), `create_venv()`, `install_app()`, `install_node()` (NodeSource on Ubuntu, `brew install node` on macOS) |
-| `bench2/managers/mariadb_manager.py` | `MariaDBManager` — `install()` (apt/brew), `is_installed()`, `is_running()`, `start()` (`systemctl` on Ubuntu / `brew services` on macOS), `create_database()`, `create_user()`, `_connect()` |
-| `bench2/managers/redis_manager.py` | `RedisManager` — `install()` (apt/brew), `is_installed()`, `generate_configs()` |
+| `bench2/managers/mariadb_manager.py` | `MariaDBManager` — `install()` picks `mariadb-server-<version>` (apt) or `mariadb@<version>` (brew); `start()` uses the versioned brew service name when a version is set; `is_installed()`, `is_running()`, `create_database()`, `create_user()`, `_connect()` |
+| `bench2/managers/redis_manager.py` | `RedisManager` — `install()` picks `redis@<version>` (brew) or `redis-server` (apt, version-agnostic); `is_installed()`, `generate_configs()` |
 | `bench2/managers/process_manager.py` | `ProcessManager` ABC, `ProcessDefinition` dataclass, `ProcessManagerFactory` |
 | `bench2/managers/honcho_process_manager.py` | `HonchoProcessManager` — `generate_config()` writes Procfile, `start()`, `stop()`, `is_running()` |
 | `bench2/managers/supervisor_process_manager.py` | `SupervisorProcessManager` — `generate_config()` writes supervisor.conf, `start()`/`stop()`/`is_running()`/`status()` |

--- a/README.md
+++ b/README.md
@@ -95,11 +95,13 @@ mariadb:
   port: 3306
   root_password: "your_root_password"
   admin_user: root
+  version: "10.6"           # optional — omit to use the package manager default
 
 redis:
   cache_port: 13000
   queue_port: 11000
   socketio_port: 12000
+  version: "7"              # optional — macOS only; see docs/config.md for Linux notes
 
 workers:
   default: 2

--- a/bench2/commands/new.py
+++ b/bench2/commands/new.py
@@ -24,6 +24,7 @@ mariadb:
   host: localhost
   port: 3306
   root_password: "root"
+  # version: "10.6"
 
 redis:
   cache_port: 13000

--- a/bench2/config/bench_config.py
+++ b/bench2/config/bench_config.py
@@ -17,6 +17,7 @@ from bench2.exceptions import ConfigError
 
 _BENCH_NAME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]*$")
 _EMAIL_PATTERN = re.compile(r"^[^@]+@[^@]+\.[^@]+$")
+_VERSION_PATTERN = re.compile(r"^\d+(\.\d+)*$")
 _VALID_PROCESS_MANAGERS = {"honcho", "supervisor"}
 _REDIS_PORT_MIN = 1024
 _REDIS_PORT_MAX = 65535
@@ -132,6 +133,8 @@ class BenchConfig:
         self._validate_letsencrypt_email()
         self._validate_site_domains()
         self._validate_nginx_ports_distinct()
+        self._validate_mariadb_version()
+        self._validate_redis_version()
 
     def _validate_required_fields(self) -> None:
         if not self.name:
@@ -254,6 +257,20 @@ class BenchConfig:
             raise ConfigError(
                 f"nginx.http_port and nginx.https_port must be distinct, "
                 f"but both are set to {self.nginx.http_port}."
+            )
+
+    def _validate_mariadb_version(self) -> None:
+        if self.mariadb.version and not _VERSION_PATTERN.match(self.mariadb.version):
+            raise ConfigError(
+                f"mariadb.version '{self.mariadb.version}' is invalid. "
+                "Must be a version string like '10.6' or '11.4'."
+            )
+
+    def _validate_redis_version(self) -> None:
+        if self.redis.version and not _VERSION_PATTERN.match(self.redis.version):
+            raise ConfigError(
+                f"redis.version '{self.redis.version}' is invalid. "
+                "Must be a version string like '7' or '7.0'."
             )
 
     def app_by_name(self, name: str) -> AppConfig:

--- a/bench2/config/mariadb_config.py
+++ b/bench2/config/mariadb_config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -8,3 +9,4 @@ class MariaDBConfig:
     root_password: str = ""
     admin_user: str = "root"
     socket_path: str = ""
+    version: Optional[str] = None

--- a/bench2/config/redis_config.py
+++ b/bench2/config/redis_config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -6,3 +7,4 @@ class RedisConfig:
     cache_port: int = 13000
     queue_port: int = 11000
     socketio_port: int = 12000
+    version: Optional[str] = None

--- a/bench2/managers/mariadb_manager.py
+++ b/bench2/managers/mariadb_manager.py
@@ -22,8 +22,18 @@ class MariaDBManager:
         if self.is_installed():
             return
         package_manager = get_package_manager()
-        package = "mariadb" if is_macos() else "mariadb-server"
+        package = self._brew_package() if is_macos() else self._apt_package()
         package_manager.install(package)
+
+    def _brew_package(self) -> str:
+        if self.config.version:
+            return f"mariadb@{self.config.version}"
+        return "mariadb"
+
+    def _apt_package(self) -> str:
+        if self.config.version:
+            return f"mariadb-server-{self.config.version}"
+        return "mariadb-server"
 
     def is_running(self) -> bool:
         try:
@@ -35,7 +45,7 @@ class MariaDBManager:
 
     def start(self) -> None:
         if is_macos():
-            run_command(["brew", "services", "start", "mariadb"])
+            run_command(["brew", "services", "start", self._brew_package()])
         else:
             run_command(["sudo", "systemctl", "start", "mariadb"])
 

--- a/bench2/managers/redis_manager.py
+++ b/bench2/managers/redis_manager.py
@@ -22,8 +22,13 @@ class RedisManager:
         if self.is_installed():
             return
         package_manager = get_package_manager()
-        package = "redis" if is_macos() else "redis-server"
+        package = self._brew_package() if is_macos() else "redis-server"
         package_manager.install(package)
+
+    def _brew_package(self) -> str:
+        if self.config.version:
+            return f"redis@{self.config.version}"
+        return "redis"
 
     def generate_configs(self) -> None:
         self._write_cache_config()

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -177,6 +177,9 @@ class MariaDBConfig:
     host: str = 'localhost'
     port: int = 3306
     root_password: str = ''
+    admin_user: str = 'root'
+    socket_path: str = ''
+    version: Optional[str] = None   # e.g. "10.6", "11.4"
 ```
 
 ### `RedisConfig`
@@ -187,6 +190,7 @@ class RedisConfig:
     cache_port: int = 13000
     queue_port: int = 11000
     socketio_port: int = 12000
+    version: Optional[str] = None   # e.g. "7", "7.0"
 ```
 
 ### `WorkerConfig`
@@ -304,8 +308,9 @@ class MariaDBManager:
     def install(self) -> None:
         """
         Install MariaDB via the system package manager.
-        Ubuntu: apt-get install mariadb-server
-        macOS:  brew install mariadb
+        Ubuntu: apt-get install mariadb-server[-<version>]  e.g. mariadb-server-10.6
+        macOS:  brew install mariadb[@<version>]            e.g. mariadb@10.6
+        When config.version is None, the package manager's default is used.
         """
 
     def is_installed(self) -> bool: ...
@@ -315,8 +320,9 @@ class MariaDBManager:
     def start(self) -> None:
         """
         Start the MariaDB service.
-        Ubuntu: systemctl start mariadb
-        macOS:  brew services start mariadb
+        Ubuntu: systemctl start mariadb  (service name is version-independent on Linux)
+        macOS:  brew services start mariadb[@<version>]  — uses the versioned formula name
+                so the correct service is started when a non-default version is installed.
         """
 
     def create_database(self, db_name: str) -> None:
@@ -338,8 +344,9 @@ class RedisManager:
     def install(self) -> None:
         """
         Install Redis via the system package manager.
-        Ubuntu: apt-get install redis-server
-        macOS:  brew install redis
+        Ubuntu: apt-get install redis-server  (apt has no versioned redis package names;
+                use the official Redis apt repo for version pinning before running bench init)
+        macOS:  brew install redis[@<version>]  e.g. redis@7
         Redis is not started as a system service; bench run launches it
         directly from the Procfile/supervisor config with a custom port.
         """

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,12 +36,14 @@ mariadb:
   host: localhost
   port: 3306
   root_password: "root"     # used only during bench init to create databases/users
+  version: "10.6"           # optional — pin to a specific MariaDB version
 
 # ── Redis ─────────────────────────────────────────────────────────────────────
 redis:
   cache_port: 13000
   queue_port: 11000
   socketio_port: 12000
+  version: "7"              # optional — pin to a specific Redis major version
 
 # ── Workers ───────────────────────────────────────────────────────────────────
 workers:
@@ -121,6 +123,7 @@ Each entry describes a Frappe site to create under `sites/`.
 | `host` | string | no | `localhost` | MariaDB server host. |
 | `port` | int | no | `3306` | MariaDB server port. |
 | `root_password` | string | yes | — | Root password used to create site databases and users during `bench init`. |
+| `version` | string | no | — | MariaDB version to install (e.g. `"10.6"`, `"10.11"`, `"11.4"`). On macOS, selects the `mariadb@<version>` Homebrew formula; on Ubuntu, installs the `mariadb-server-<version>` apt package. Omit to install whichever version the package manager offers by default. |
 
 ### `redis`
 
@@ -129,6 +132,7 @@ Each entry describes a Frappe site to create under `sites/`.
 | `cache_port` | int | no | `13000` | Port for the Redis cache instance. |
 | `queue_port` | int | no | `11000` | Port for the Redis queue instance. |
 | `socketio_port` | int | no | `12000` | Port for the Redis socketio instance. |
+| `version` | string | no | — | Redis version to install (e.g. `"7"`, `"7.0"`). On macOS, selects the `redis@<version>` Homebrew formula. On Ubuntu, apt has no versioned redis package names — use the official Redis apt repository for version pinning, then omit this field. |
 
 All three ports must be distinct and not in use by other processes.
 
@@ -186,6 +190,7 @@ bench2 validates `bench.yml` before executing any command. Violations produce a 
 11. `letsencrypt.email` must match a basic email pattern (`^[^@]+@[^@]+\.[^@]+$`) when present.
 12. All entries in `sites[].domains` must be valid hostnames (no spaces, no path separators).
 13. `nginx.http_port` and `nginx.https_port` must be distinct.
+14. `mariadb.version` and `redis.version`, when present, must match `^\d+(\.\d+)*$` (e.g. `"10.6"`, `"7"`, `"7.0"`).
 
 ---
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -441,3 +441,51 @@ nginx:
     with pytest.raises(ConfigError) as exc_info:
         load_from_string(yaml_string)
     assert "nginx.http_port" in str(exc_info.value) or "nginx.https_port" in str(exc_info.value)
+
+
+# ── Dependency version tests ──────────────────────────────────────────────────
+
+
+def test_mariadb_version_accepted() -> None:
+    yaml_string = MINIMAL_VALID_YAML.replace(
+        "mariadb:\n  root_password: \"root\"",
+        "mariadb:\n  root_password: \"root\"\n  version: \"10.6\"",
+    )
+    config = load_from_string(yaml_string)
+    assert config.mariadb.version == "10.6"
+
+
+def test_redis_version_accepted() -> None:
+    data = yaml.safe_load(MINIMAL_VALID_YAML)
+    data["redis"]["version"] = "7"
+    config = BenchConfig._from_dict(data)
+    config.validate()
+    assert config.redis.version == "7"
+
+
+def test_mariadb_version_defaults_to_none() -> None:
+    config = BenchConfig.from_file(FIXTURES_DIR / "minimal.yml")
+    assert config.mariadb.version is None
+
+
+def test_redis_version_defaults_to_none() -> None:
+    config = BenchConfig.from_file(FIXTURES_DIR / "minimal.yml")
+    assert config.redis.version is None
+
+
+def test_invalid_mariadb_version() -> None:
+    data = yaml.safe_load(MINIMAL_VALID_YAML)
+    data["mariadb"]["version"] = "invalid"
+    config = BenchConfig._from_dict(data)
+    with pytest.raises(ConfigError) as exc_info:
+        config.validate()
+    assert "mariadb.version" in str(exc_info.value)
+
+
+def test_invalid_redis_version() -> None:
+    data = yaml.safe_load(MINIMAL_VALID_YAML)
+    data["redis"]["version"] = "not-a-version"
+    config = BenchConfig._from_dict(data)
+    with pytest.raises(ConfigError) as exc_info:
+        config.validate()
+    assert "redis.version" in str(exc_info.value)


### PR DESCRIPTION
Adds optional version fields to MariaDBConfig and RedisConfig. Package selection in MariaDBManager and RedisManager now picks the versioned formula/package when set. Adds validation rule 14 to enforce the version string format.