### PR TITLE
vite: include feather-icons and debug in optimizeDeps

### DIFF
--- a/admin/frontend/vite.config.js
+++ b/admin/frontend/vite.config.js
@@ -33,5 +33,6 @@ export default defineConfig({
   },
   optimizeDeps: {
     exclude: ['frappe-ui'],
+    include: ['feather-icons', 'debug'],
   },
 })


### PR DESCRIPTION
Without this, Vite dev fails:

```
Uncaught SyntaxError: The requested module '/node_modules/feather-icons/...'
does not provide an export named 'default' (at FeatherIcon.vue:3:8)
```

Page does not load. Same error with `debug` after `feather-icons` is added.

Both are CommonJS and need to be in `optimizeDeps.include` for esbuild to pre-bundle them.