### PR TITLE
feat(ui): set dynamic document title from route meta

### DIFF
--- a/admin/frontend/src/router.js
+++ b/admin/frontend/src/router.js
@@ -1,21 +1,27 @@
 import { createRouter, createWebHistory } from 'vue-router'
 
 const routes = [
-  { path: '/', component: () => import('./pages/Dashboard.vue') },
-  { path: '/apps', component: () => import('./pages/Apps.vue') },
-  { path: '/sites', component: () => import('./pages/Sites.vue') },
-  { path: '/sites/:name', component: () => import('./pages/SiteDetail.vue') },
-  { path: '/processes', component: () => import('./pages/Processes.vue') },
-  { path: '/logs', component: () => import('./pages/LogList.vue') },
-  { path: '/logs/:filename', component: () => import('./pages/LogViewer.vue') },
-  { path: '/tasks', component: () => import('./pages/TaskList.vue') },
-  { path: '/tasks/:id', component: () => import('./pages/TaskDetail.vue') },
-  { path: '/database/binlogs', component: () => import('./pages/Database.vue') },
-  { path: '/database/binlogs/:name', component: () => import('./pages/BinlogDetail.vue') },
-  { path: '/database/slow-queries', component: () => import('./pages/SlowQueries.vue') },
+  { path: '/', component: () => import('./pages/Dashboard.vue'), meta: { title: 'Dashboard' } },
+  { path: '/apps', component: () => import('./pages/Apps.vue'), meta: { title: 'Apps' } },
+  { path: '/sites', component: () => import('./pages/Sites.vue'), meta: { title: 'Sites' } },
+  { path: '/sites/:name', component: () => import('./pages/SiteDetail.vue'), meta: { title: 'Sites' } },
+  { path: '/processes', component: () => import('./pages/Processes.vue'), meta: { title: 'Processes' } },
+  { path: '/logs', component: () => import('./pages/LogList.vue'), meta: { title: 'Logs' } },
+  { path: '/logs/:filename', component: () => import('./pages/LogViewer.vue'), meta: { title: 'Logs' } },
+  { path: '/tasks', component: () => import('./pages/TaskList.vue'), meta: { title: 'Tasks' } },
+  { path: '/tasks/:id', component: () => import('./pages/TaskDetail.vue'), meta: { title: 'Tasks' } },
+  { path: '/database/binlogs', component: () => import('./pages/Database.vue'), meta: { title: 'Binlogs' } },
+  { path: '/database/binlogs/:name', component: () => import('./pages/BinlogDetail.vue'), meta: { title: 'Binlogs' } },
+  { path: '/database/slow-queries', component: () => import('./pages/SlowQueries.vue'), meta: { title: 'Slow Queries' } },
 ]
 
 export const router = createRouter({
   history: createWebHistory(),
   routes,
+})
+
+router.afterEach((to) => {
+  document.title = to.meta?.title
+    ? `${to.meta.title} - Bench Admin`
+    : 'Bench Admin'
 })


### PR DESCRIPTION
## Task
Todo 1.5 - Page titles

## Summary

This PR implements a consistent page title system using Vue Router meta fields and a global route hook.

It adds `meta.title` to all routes and updates the browser tab title dynamically based on the active route.

## Changes

- Added `meta: { title }` to route definitions
- Implemented global `router.afterEach` hook for document title updates
- Uses `to.meta.title` for setting page titles
- Falls back to "Bench Admin" when no title is defined

## Implementation

```js
router.afterEach((to) => {
  document.title = to.meta?.title
    ? `${to.meta.title} - Bench Admin`
    : 'Bench Admin'
})