### PR TITLE
feat(backup): Backup Management & Scheduling + Custom worker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ htmlcov/
 # Admin
 admin/frontend/node_modules/
 admin/backend/static/dist/
+*.timestamp-*

--- a/admin/backend/cron_manager.py
+++ b/admin/backend/cron_manager.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+_MARKER_PREFIX = "# bench-backup:"
+
+
+class CronManager:
+    def __init__(self, bench_root: Path) -> None:
+        self._bench_root = bench_root
+
+    def get_schedule(self, site: str) -> str | None:
+        lines = self._read_crontab()
+        try:
+            i = lines.index(self._marker(site))
+            parts = lines[i + 1].split()
+            return " ".join(parts[:5]) if len(parts) >= 5 else None
+        except (ValueError, IndexError):
+            return None
+
+    def set_schedule(self, site: str, cron_expr: str) -> None:
+        lines = self._read_crontab()
+        marker = self._marker(site)
+        command = self._build_command(site)
+        try:
+            i = lines.index(marker)
+            lines[i + 1] = f"{cron_expr} {command}"
+        except ValueError:
+            lines += [marker, f"{cron_expr} {command}"]
+        self._write_crontab(lines)
+
+    def remove_schedule(self, site: str) -> None:
+        lines = self._read_crontab()
+        marker = self._marker(site)
+        try:
+            i = lines.index(marker)
+            del lines[i : i + 2]
+        except ValueError:
+            pass
+        self._write_crontab(lines)
+
+    def _marker(self, site: str) -> str:
+        return f"{_MARKER_PREFIX}{self._bench_root}:{site}"
+
+    def _build_command(self, site: str) -> str:
+        bench_bin = self._bench_root / "env" / "bin" / "bench"
+        sites_dir = self._bench_root / "sites"
+        log_file = self._bench_root / "logs" / f"backup-{site}.log"
+        return f"cd {sites_dir} && {bench_bin} frappe --site {site} backup >> {log_file} 2>&1"
+
+    def _read_crontab(self) -> list[str]:
+        result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
+        if result.returncode != 0:
+            return []
+        return result.stdout.splitlines()
+
+    def _write_crontab(self, lines: list[str]) -> None:
+        non_empty = [line for line in lines if line.strip()]
+        if not non_empty:
+            subprocess.run(["crontab", "-r"], capture_output=True)
+            return
+        content = "\n".join(non_empty) + "\n"
+        proc = subprocess.run(
+            ["crontab", "-"], input=content, capture_output=True, text=True
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(f"Failed to write crontab: {proc.stderr}")

--- a/admin/backend/cron_manager.py
+++ b/admin/backend/cron_manager.py
@@ -47,7 +47,7 @@ class CronManager:
         bench_bin = self._bench_root / "env" / "bin" / "bench"
         sites_dir = self._bench_root / "sites"
         log_file = self._bench_root / "logs" / f"backup-{site}.log"
-        return f"cd {sites_dir} && {bench_bin} frappe --site {site} backup >> {log_file} 2>&1"
+        return f"cd {sites_dir} && {bench_bin} frappe --site {site} backup --with-files >> {log_file} 2>&1"
 
     def _read_crontab(self) -> list[str]:
         result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)

--- a/admin/backend/cron_manager.py
+++ b/admin/backend/cron_manager.py
@@ -61,8 +61,6 @@ class CronManager:
             subprocess.run(["crontab", "-r"], capture_output=True)
             return
         content = "\n".join(non_empty) + "\n"
-        proc = subprocess.run(
-            ["crontab", "-"], input=content, capture_output=True, text=True
-        )
+        proc = subprocess.run(["crontab", "-"], input=content, capture_output=True, text=True)
         if proc.returncode != 0:
             raise RuntimeError(f"Failed to write crontab: {proc.stderr}")

--- a/admin/backend/readers/backup_reader.py
+++ b/admin/backend/readers/backup_reader.py
@@ -43,13 +43,7 @@ class BackupReader:
         result = []
         for ts in sorted(by_ts, reverse=True):
             files = sorted(by_ts[ts], key=lambda f: f.kind)
-            result.append(
-                BackupSet(
-                    timestamp=ts,
-                    created_at=files[0].created_at,
-                    files=files,
-                )
-            )
+            result.append(BackupSet(timestamp=ts, created_at=files[0].created_at, files=files))
         return result
 
     def _parse_file(self, path: Path) -> BackupFile:
@@ -71,11 +65,4 @@ class BackupReader:
         else:
             kind = "other"
 
-        return BackupFile(
-            filename=name,
-            path=str(path),
-            size_bytes=path.stat().st_size,
-            created_at=created_at,
-            kind=kind,
-            timestamp=ts,
-        )
+        return BackupFile(filename=name, path=str(path), size_bytes=path.stat().st_size, created_at=created_at, kind=kind, timestamp=ts)

--- a/admin/backend/readers/backup_reader.py
+++ b/admin/backend/readers/backup_reader.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+_TS_RE = re.compile(r"^(\d{8}_\d{6})")
+
+
+@dataclass
+class BackupFile:
+    filename: str
+    path: str
+    size_bytes: int
+    created_at: datetime
+    kind: str  # 'database' | 'files' | 'private-files' | 'other'
+    timestamp: str
+
+
+@dataclass
+class BackupSet:
+    timestamp: str
+    created_at: datetime
+    files: list[BackupFile]
+
+
+class BackupReader:
+    def __init__(self, bench_root: Path, site_name: str) -> None:
+        self._backups_dir = bench_root / "sites" / site_name / "private" / "backups"
+
+    def read_all(self) -> list[BackupSet]:
+        if not self._backups_dir.is_dir():
+            return []
+
+        by_ts: dict[str, list[BackupFile]] = {}
+        for f in self._backups_dir.iterdir():
+            if not f.is_file():
+                continue
+            bf = self._parse_file(f)
+            by_ts.setdefault(bf.timestamp, []).append(bf)
+
+        result = []
+        for ts in sorted(by_ts, reverse=True):
+            files = sorted(by_ts[ts], key=lambda f: f.kind)
+            result.append(
+                BackupSet(
+                    timestamp=ts,
+                    created_at=files[0].created_at,
+                    files=files,
+                )
+            )
+        return result
+
+    def _parse_file(self, path: Path) -> BackupFile:
+        name = path.name
+        m = _TS_RE.match(name)
+        ts = m.group(1) if m else "unknown"
+
+        try:
+            created_at = datetime.strptime(ts, "%Y%m%d_%H%M%S")
+        except ValueError:
+            created_at = datetime.fromtimestamp(path.stat().st_mtime)
+
+        if "private-files" in name:
+            kind = "private-files"
+        elif "files" in name:
+            kind = "files"
+        elif "database" in name:
+            kind = "database"
+        else:
+            kind = "other"
+
+        return BackupFile(
+            filename=name,
+            path=str(path),
+            size_bytes=path.stat().st_size,
+            created_at=created_at,
+            kind=kind,
+            timestamp=ts,
+        )

--- a/admin/backend/tasks/jobs/delete_backup_task.py
+++ b/admin/backend/tasks/jobs/delete_backup_task.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from .base_task import BaseTask
+
+
+class DeleteBackupTask(BaseTask):
+    @classmethod
+    def _parser(cls):
+        p = super()._parser()
+        p.add_argument("site")
+        p.add_argument("filenames", nargs="+")
+        return p
+
+    def __init__(self, bench, bench_root, args):
+        super().__init__(bench, bench_root, args)
+        self.site = args.site
+        self.filenames = args.filenames
+
+    def run(self) -> None:
+        backup_dir = self.bench_root / "sites" / self.site / "private" / "backups"
+        for filename in self.filenames:
+            path = backup_dir / filename
+            if path.is_file():
+                path.unlink()
+                print(f"Deleted: {filename}")
+            else:
+                print(f"Not found (skipping): {filename}")
+
+
+if __name__ == "__main__":
+    DeleteBackupTask.main()

--- a/admin/backend/tasks/jobs/new_site_from_backup_task.py
+++ b/admin/backend/tasks/jobs/new_site_from_backup_task.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from bench_cli.commands.restore_site_from_backup import NewSiteFromBackupCommand
+
+from .base_task import BaseTask
+
+
+class NewSiteFromBackupTask(BaseTask):
+    @classmethod
+    def _parser(cls):
+        p = super()._parser()
+        p.add_argument("name")
+        p.add_argument("db_file")
+        p.add_argument("--admin-password", default="admin")
+        p.add_argument("--public-files", default=None)
+        p.add_argument("--private-files", default=None)
+        return p
+
+    def __init__(self, bench, bench_root, args):
+        super().__init__(bench, bench_root, args)
+        self.name = args.name
+        self.db_file = args.db_file
+        self.admin_password = args.admin_password
+        self.public_files = args.public_files
+        self.private_files = args.private_files
+
+    def run(self) -> None:
+        NewSiteFromBackupCommand(
+            self.bench, self.name, self.db_file,
+            admin_password=self.admin_password,
+            public_files=self.public_files,
+            private_files=self.private_files,
+        ).run()
+
+
+if __name__ == "__main__":
+    NewSiteFromBackupTask.main()

--- a/admin/backend/tasks/jobs/new_site_from_backup_task.py
+++ b/admin/backend/tasks/jobs/new_site_from_backup_task.py
@@ -26,7 +26,9 @@ class NewSiteFromBackupTask(BaseTask):
 
     def run(self) -> None:
         NewSiteFromBackupCommand(
-            self.bench, self.name, self.db_file,
+            self.bench,
+            self.name,
+            self.db_file,
             admin_password=self.admin_password,
             public_files=self.public_files,
             private_files=self.private_files,

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -29,6 +29,7 @@ _WHITELIST: dict[str, list[str]] = {
     "setup-nginx": [],
     "setup-production": [],
     "setup-letsencrypt": [],
+    "new-site-from-backup": ["name", "db_file"],
 }
 
 
@@ -110,7 +111,10 @@ class TaskRunner:
         if command == "uninstall-app":
             return [bench_bin, "frappe", "--site", args["site"], "uninstall-app", args["app"], "--yes", "--no-backup"]
         if command == "backup-site":
-            return [bench_bin, "frappe", "--site", args["site"], "backup"]
+            command = [bench_bin, "frappe", "--site", args["site"], "backup"]
+            if args.get("with_files"):
+                command += ["--with-files"]
+            return command
         if command == "build":
             cmd = [bench_bin, "frappe", "build"]
             if args.get("app"):
@@ -144,6 +148,15 @@ class TaskRunner:
             return [sys.executable, "-m", "admin.backend.tasks.jobs.setup_production_task", str(self._bench_root)]
         if command == "setup-letsencrypt":
             return [sys.executable, "-m", "admin.backend.tasks.jobs.setup_letsencrypt_task", str(self._bench_root)]
+        if command == "new-site-from-backup":
+            argv = [sys.executable, "-m", "admin.backend.tasks.jobs.new_site_from_backup_task", str(self._bench_root), args["name"], args["db_file"]]
+            if args.get("admin_password"):
+                argv += ["--admin-password", args["admin_password"]]
+            if args.get("public_files"):
+                argv += ["--public-files", args["public_files"]]
+            if args.get("private_files"):
+                argv += ["--private-files", args["private_files"]]
+            return argv
 
         raise ValueError(f"Unhandled command: {command!r}")
 

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -22,7 +22,8 @@ _WHITELIST: dict[str, list[str]] = {
     "new-site": ["name"],
     "drop-site": ["site"],
     "backup-site": ["site"],
-    "build": [],        # optional: app
+    "delete-backup": ["site", "filenames"],
+    "build": [],  # optional: app
     "update": [],
     "switch-branch": ["name", "branch"],
     "setup-nginx": [],
@@ -54,7 +55,12 @@ class TaskRunner:
         (task_dir / "status").write_text("running")
 
         process = subprocess.Popen(
-            [sys.executable, "-m", "admin.backend.tasks.manager.wrapper", str(task_dir)],
+            [
+                sys.executable,
+                "-m",
+                "admin.backend.tasks.manager.wrapper",
+                str(task_dir),
+            ],
             start_new_session=True,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
@@ -71,7 +77,9 @@ class TaskRunner:
 
         status = (task_dir / "status").read_text().strip()
         if status != "running":
-            raise TaskNotRunningError(f"Task is not running: {task_id} (status={status})")
+            raise TaskNotRunningError(
+                f"Task is not running: {task_id} (status={status})"
+            )
 
         pid_text = (task_dir / "pid").read_text().strip()
         pid = int(pid_text)
@@ -86,7 +94,9 @@ class TaskRunner:
 
     def _build_argv(self, command: str, args: dict) -> list[str]:
         if command not in _WHITELIST:
-            raise ValueError(f"Unknown command: {command!r}. Allowed: {sorted(_WHITELIST)}")
+            raise ValueError(
+                f"Unknown command: {command!r}. Allowed: {sorted(_WHITELIST)}"
+            )
 
         required = _WHITELIST[command]
         for key in required:
@@ -100,7 +110,16 @@ class TaskRunner:
         if command == "clear-cache":
             return [bench_bin, "frappe", "--site", args["site"], "clear-cache"]
         if command == "uninstall-app":
-            return [bench_bin, "frappe", "--site", args["site"], "uninstall-app", args["app"], "--yes", "--no-backup"]
+            return [
+                bench_bin,
+                "frappe",
+                "--site",
+                args["site"],
+                "uninstall-app",
+                args["app"],
+                "--yes",
+                "--no-backup",
+            ]
         if command == "backup-site":
             return [bench_bin, "frappe", "--site", args["site"], "backup"]
         if command == "build":
@@ -109,29 +128,90 @@ class TaskRunner:
                 cmd += ["--app", args["app"]]
             return cmd
         if command == "update":
-            return [sys.executable, "-m", "admin.backend.tasks.jobs.update_task", str(self._bench_root)]
+            return [
+                sys.executable,
+                "-m",
+                "admin.backend.tasks.jobs.update_task",
+                str(self._bench_root),
+            ]
         if command == "get-app":
-            argv = [sys.executable, "-m", "admin.backend.tasks.jobs.get_app_task", str(self._bench_root), args["repo"]]
+            argv = [
+                sys.executable,
+                "-m",
+                "admin.backend.tasks.jobs.get_app_task",
+                str(self._bench_root),
+                args["repo"],
+            ]
             if args.get("branch"):
                 argv += ["--branch", args["branch"]]
             return argv
         if command == "new-site":
-            argv = [sys.executable, "-m", "admin.backend.tasks.jobs.new_site_task", str(self._bench_root), args["name"]]
+            argv = [
+                sys.executable,
+                "-m",
+                "admin.backend.tasks.jobs.new_site_task",
+                str(self._bench_root),
+                args["name"],
+            ]
             if args.get("admin_password"):
                 argv += ["--admin-password", args["admin_password"]]
             return argv
         if command == "drop-site":
-            return [sys.executable, "-m", "admin.backend.tasks.jobs.drop_site_task", str(self._bench_root), args["site"]]
+            return [
+                sys.executable,
+                "-m",
+                "admin.backend.tasks.jobs.drop_site_task",
+                str(self._bench_root),
+                args["site"],
+            ]
+        if command == "delete-backup":
+            return [
+                sys.executable,
+                "-m",
+                "admin.backend.tasks.jobs.delete_backup_task",
+                str(self._bench_root),
+                args["site"],
+                *args["filenames"],
+            ]
         if command == "install-app":
-            return [sys.executable, "-m", "admin.backend.tasks.jobs.install_app_task", str(self._bench_root), args["site"], args["app"]]
+            return [
+                sys.executable,
+                "-m",
+                "admin.backend.tasks.jobs.install_app_task",
+                str(self._bench_root),
+                args["site"],
+                args["app"],
+            ]
         if command == "switch-branch":
-            return [sys.executable, "-m", "admin.backend.tasks.jobs.switch_branch_task", str(self._bench_root), args["name"], args["branch"]]
+            return [
+                sys.executable,
+                "-m",
+                "admin.backend.tasks.jobs.switch_branch_task",
+                str(self._bench_root),
+                args["name"],
+                args["branch"],
+            ]
         if command == "setup-nginx":
-            return [sys.executable, "-m", "admin.backend.tasks.jobs.setup_nginx_task", str(self._bench_root)]
+            return [
+                sys.executable,
+                "-m",
+                "admin.backend.tasks.jobs.setup_nginx_task",
+                str(self._bench_root),
+            ]
         if command == "setup-production":
-            return [sys.executable, "-m", "admin.backend.tasks.jobs.setup_production_task", str(self._bench_root)]
+            return [
+                sys.executable,
+                "-m",
+                "admin.backend.tasks.jobs.setup_production_task",
+                str(self._bench_root),
+            ]
         if command == "setup-letsencrypt":
-            return [sys.executable, "-m", "admin.backend.tasks.jobs.setup_letsencrypt_task", str(self._bench_root)]
+            return [
+                sys.executable,
+                "-m",
+                "admin.backend.tasks.jobs.setup_letsencrypt_task",
+                str(self._bench_root),
+            ]
 
         raise ValueError(f"Unhandled command: {command!r}")
 
@@ -147,7 +227,8 @@ class TaskRunner:
         completed = [
             entry
             for entry in tasks_dir.iterdir()
-            if entry.is_dir() and (entry / "status").exists()
+            if entry.is_dir()
+            and (entry / "status").exists()
             and (entry / "status").read_text().strip() != "running"
         ]
 
@@ -158,4 +239,5 @@ class TaskRunner:
         to_delete = completed[: len(completed) - TASK_RETENTION_LIMIT]
         for entry in to_delete:
             import shutil
+
             shutil.rmtree(entry)

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -110,108 +110,31 @@ class TaskRunner:
         if command == "clear-cache":
             return [bench_bin, "frappe", "--site", args["site"], "clear-cache"]
         if command == "uninstall-app":
-            return [
-                bench_bin,
-                "frappe",
-                "--site",
-                args["site"],
-                "uninstall-app",
-                args["app"],
-                "--yes",
-                "--no-backup",
-            ]
+            return [bench_bin, "frappe", "--site", args["site"], "uninstall-app", args["app"], "--yes", "--no-backup"]
         if command == "backup-site":
             return [bench_bin, "frappe", "--site", args["site"], "backup"]
         if command == "build":
-            cmd = [bench_bin, "frappe", "build"]
-            if args.get("app"):
-                cmd += ["--app", args["app"]]
-            return cmd
+            return [bench_bin, "frappe", "build"] + (["--app", args["app"]] if args.get("app") else [])
         if command == "update":
-            return [
-                sys.executable,
-                "-m",
-                "admin.backend.tasks.jobs.update_task",
-                str(self._bench_root),
-            ]
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.update_task", str(self._bench_root)]
         if command == "get-app":
-            argv = [
-                sys.executable,
-                "-m",
-                "admin.backend.tasks.jobs.get_app_task",
-                str(self._bench_root),
-                args["repo"],
-            ]
-            if args.get("branch"):
-                argv += ["--branch", args["branch"]]
-            return argv
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.get_app_task", str(self._bench_root), args["repo"]] + (["--branch", args["branch"]] if args.get("branch") else [])
         if command == "new-site":
-            argv = [
-                sys.executable,
-                "-m",
-                "admin.backend.tasks.jobs.new_site_task",
-                str(self._bench_root),
-                args["name"],
-            ]
-            if args.get("admin_password"):
-                argv += ["--admin-password", args["admin_password"]]
-            return argv
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.new_site_task", str(self._bench_root), args["name"]] + (["--admin-password", args["admin_password"]] if args.get("admin_password") else [])
         if command == "drop-site":
-            return [
-                sys.executable,
-                "-m",
-                "admin.backend.tasks.jobs.drop_site_task",
-                str(self._bench_root),
-                args["site"],
-            ]
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.drop_site_task", str(self._bench_root), args["site"]]
         if command == "delete-backup":
-            return [
-                sys.executable,
-                "-m",
-                "admin.backend.tasks.jobs.delete_backup_task",
-                str(self._bench_root),
-                args["site"],
-                *args["filenames"],
-            ]
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.delete_backup_task", str(self._bench_root), args["site"], *args["filenames"]]
         if command == "install-app":
-            return [
-                sys.executable,
-                "-m",
-                "admin.backend.tasks.jobs.install_app_task",
-                str(self._bench_root),
-                args["site"],
-                args["app"],
-            ]
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.install_app_task", str(self._bench_root), args["site"], args["app"]]
         if command == "switch-branch":
-            return [
-                sys.executable,
-                "-m",
-                "admin.backend.tasks.jobs.switch_branch_task",
-                str(self._bench_root),
-                args["name"],
-                args["branch"],
-            ]
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.switch_branch_task", str(self._bench_root), args["name"], args["branch"]]
         if command == "setup-nginx":
-            return [
-                sys.executable,
-                "-m",
-                "admin.backend.tasks.jobs.setup_nginx_task",
-                str(self._bench_root),
-            ]
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.setup_nginx_task", str(self._bench_root)]
         if command == "setup-production":
-            return [
-                sys.executable,
-                "-m",
-                "admin.backend.tasks.jobs.setup_production_task",
-                str(self._bench_root),
-            ]
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.setup_production_task", str(self._bench_root)]
         if command == "setup-letsencrypt":
-            return [
-                sys.executable,
-                "-m",
-                "admin.backend.tasks.jobs.setup_letsencrypt_task",
-                str(self._bench_root),
-            ]
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.setup_letsencrypt_task", str(self._bench_root)]
 
         raise ValueError(f"Unhandled command: {command!r}")
 

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -78,9 +78,7 @@ class TaskRunner:
 
         status = (task_dir / "status").read_text().strip()
         if status != "running":
-            raise TaskNotRunningError(
-                f"Task is not running: {task_id} (status={status})"
-            )
+            raise TaskNotRunningError(f"Task is not running: {task_id} (status={status})")
 
         pid_text = (task_dir / "pid").read_text().strip()
         pid = int(pid_text)
@@ -135,9 +133,7 @@ class TaskRunner:
         if command == "drop-site":
             return [sys.executable, "-m", "admin.backend.tasks.jobs.drop_site_task", str(self._bench_root), args["site"]]
         if command == "delete-backup":
-            return [
-                sys.executable, "-m", "admin.backend.tasks.jobs.delete_backup_task", str(self._bench_root), args["site"], *args["filenames"]
-            ]
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.delete_backup_task", str(self._bench_root), args["site"], *args["filenames"]]
         if command == "install-app":
             return [sys.executable, "-m", "admin.backend.tasks.jobs.install_app_task", str(self._bench_root), args["site"], args["app"]]
         if command == "switch-branch":
@@ -169,13 +165,7 @@ class TaskRunner:
         if not tasks_dir.exists():
             return
 
-        completed = [
-            entry
-            for entry in tasks_dir.iterdir()
-            if entry.is_dir()
-            and (entry / "status").exists()
-            and (entry / "status").read_text().strip() != "running"
-        ]
+        completed = [entry for entry in tasks_dir.iterdir() if entry.is_dir() and (entry / "status").exists() and (entry / "status").read_text().strip() != "running"]
 
         if len(completed) <= TASK_RETENTION_LIMIT:
             return

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -56,12 +56,7 @@ class TaskRunner:
         (task_dir / "status").write_text("running")
 
         process = subprocess.Popen(
-            [
-                sys.executable,
-                "-m",
-                "admin.backend.tasks.manager.wrapper",
-                str(task_dir),
-            ],
+            [sys.executable, "-m", "admin.backend.tasks.manager.wrapper", str(task_dir)],
             start_new_session=True,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -94,9 +94,7 @@ class TaskRunner:
 
     def _build_argv(self, command: str, args: dict) -> list[str]:
         if command not in _WHITELIST:
-            raise ValueError(
-                f"Unknown command: {command!r}. Allowed: {sorted(_WHITELIST)}"
-            )
+            raise ValueError(f"Unknown command: {command!r}. Allowed: {sorted(_WHITELIST)}")
 
         required = _WHITELIST[command]
         for key in required:
@@ -114,17 +112,28 @@ class TaskRunner:
         if command == "backup-site":
             return [bench_bin, "frappe", "--site", args["site"], "backup"]
         if command == "build":
-            return [bench_bin, "frappe", "build"] + (["--app", args["app"]] if args.get("app") else [])
+            cmd = [bench_bin, "frappe", "build"]
+            if args.get("app"):
+                cmd += ["--app", args["app"]]
+            return cmd
         if command == "update":
             return [sys.executable, "-m", "admin.backend.tasks.jobs.update_task", str(self._bench_root)]
         if command == "get-app":
-            return [sys.executable, "-m", "admin.backend.tasks.jobs.get_app_task", str(self._bench_root), args["repo"]] + (["--branch", args["branch"]] if args.get("branch") else [])
+            argv = [sys.executable, "-m", "admin.backend.tasks.jobs.get_app_task", str(self._bench_root), args["repo"]]
+            if args.get("branch"):
+                argv += ["--branch", args["branch"]]
+            return argv
         if command == "new-site":
-            return [sys.executable, "-m", "admin.backend.tasks.jobs.new_site_task", str(self._bench_root), args["name"]] + (["--admin-password", args["admin_password"]] if args.get("admin_password") else [])
+            argv = [sys.executable, "-m", "admin.backend.tasks.jobs.new_site_task", str(self._bench_root), args["name"]]
+            if args.get("admin_password"):
+                argv += ["--admin-password", args["admin_password"]]
+            return argv
         if command == "drop-site":
             return [sys.executable, "-m", "admin.backend.tasks.jobs.drop_site_task", str(self._bench_root), args["site"]]
         if command == "delete-backup":
-            return [sys.executable, "-m", "admin.backend.tasks.jobs.delete_backup_task", str(self._bench_root), args["site"], *args["filenames"]]
+            return [
+                sys.executable, "-m", "admin.backend.tasks.jobs.delete_backup_task", str(self._bench_root), args["site"], *args["filenames"]
+            ]
         if command == "install-app":
             return [sys.executable, "-m", "admin.backend.tasks.jobs.install_app_task", str(self._bench_root), args["site"], args["app"]]
         if command == "switch-branch":

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import secrets
 from dataclasses import asdict
 from pathlib import Path
 
@@ -76,6 +77,48 @@ def create():
     return jsonify({"ok": True, "task_id": task_id})
 
 
+@sites_bp.route("/create-from-upload", methods=["POST"])
+def create_from_upload():
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    name = (request.form.get("name") or "").strip()
+    admin_password = (request.form.get("admin_password") or "admin").strip() or "admin"
+
+    if not name:
+        return jsonify({"ok": False, "error": "Site name is required."})
+    if (bench_root / "sites" / name / "site_config.json").exists():
+        return jsonify({"ok": False, "error": f"Site '{name}' already exists."})
+
+    db_upload = request.files.get("db_file")
+    if not db_upload:
+        return jsonify({"ok": False, "error": "Database backup file is required."})
+
+    upload_dir = bench_root / "tmp" / "uploads" / secrets.token_hex(8)
+    upload_dir.mkdir(parents=True)
+
+    db_path = upload_dir / db_upload.filename
+    db_upload.save(str(db_path))
+
+    args = {"name": name, "admin_password": admin_password, "db_file": str(db_path)}
+
+    pub_upload = request.files.get("public_files")
+    if pub_upload:
+        pub_path = upload_dir / pub_upload.filename
+        pub_upload.save(str(pub_path))
+        args["public_files"] = str(pub_path)
+
+    priv_upload = request.files.get("private_files")
+    if priv_upload:
+        priv_path = upload_dir / priv_upload.filename
+        priv_upload.save(str(priv_path))
+        args["private_files"] = str(priv_path)
+
+    try:
+        task_id = TaskRunner(bench_root).run("new-site-from-backup", args)
+    except Exception as e:
+        return jsonify({"ok": False, "error": str(e)})
+    return jsonify({"ok": True, "task_id": task_id})
+
+
 @sites_bp.route("/<name>/drop", methods=["POST"])
 def drop_site(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
@@ -90,7 +133,7 @@ def drop_site(name: str):
 def backup_site(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     try:
-        task_id = TaskRunner(bench_root).run("backup-site", {"site": name})
+        task_id = TaskRunner(bench_root).run("backup-site", {"site": name, "with_files": True})
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)})
     return jsonify({"ok": True, "task_id": task_id})

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -48,9 +48,7 @@ def detail(name: str):
 
     site_dict = asdict(site)
     site_dict["site_config"] = _mask_password(site.site_config)
-    return jsonify(
-        {"site": site_dict, "installable_apps": installable, "http_port": http_port}
-    )
+    return jsonify({"site": site_dict, "installable_apps": installable, "http_port": http_port})
 
 
 @sites_bp.route("/create", methods=["POST"])
@@ -68,9 +66,7 @@ def create():
         return jsonify({"ok": False, "error": f"Site '{name}' already exists."})
 
     try:
-        task_id = TaskRunner(bench_root).run(
-            "new-site", {"name": name, "admin_password": admin_password}
-        )
+        task_id = TaskRunner(bench_root).run("new-site", {"name": name, "admin_password": admin_password})
     except Exception as e:
         return jsonify({"ok": False, "error": f"Could not start new-site: {e}"})
 
@@ -161,9 +157,7 @@ def uninstall_app(name: str):
     if not app:
         return jsonify({"ok": False, "error": "App name is required."})
     try:
-        task_id = TaskRunner(bench_root).run(
-            "uninstall-app", {"site": name, "app": app}
-        )
+        task_id = TaskRunner(bench_root).run("uninstall-app", {"site": name, "app": app})
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)})
     return jsonify({"ok": True, "task_id": task_id})

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -39,6 +39,7 @@ def detail(name: str):
         installable = []
 
     from bench_cli.config.bench_config import BenchConfig
+
     try:
         http_port = BenchConfig.from_file(bench_root / "bench.toml").http_port
     except Exception:
@@ -46,7 +47,9 @@ def detail(name: str):
 
     site_dict = asdict(site)
     site_dict["site_config"] = _mask_password(site.site_config)
-    return jsonify({"site": site_dict, "installable_apps": installable, "http_port": http_port})
+    return jsonify(
+        {"site": site_dict, "installable_apps": installable, "http_port": http_port}
+    )
 
 
 @sites_bp.route("/create", methods=["POST"])
@@ -115,7 +118,9 @@ def uninstall_app(name: str):
     if not app:
         return jsonify({"ok": False, "error": "App name is required."})
     try:
-        task_id = TaskRunner(bench_root).run("uninstall-app", {"site": name, "app": app})
+        task_id = TaskRunner(bench_root).run(
+            "uninstall-app", {"site": name, "app": app}
+        )
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)})
     return jsonify({"ok": True, "task_id": task_id})
@@ -182,6 +187,7 @@ def enable_ssl(name: str):
         return jsonify({"ok": False, "error": "Site not found."}), 404
 
     import json
+
     current = json.loads(config_path.read_text())
     current["ssl"] = True
     config_path.write_text(json.dumps(current, indent=1))
@@ -205,6 +211,7 @@ def update_config(name: str):
         return jsonify({"ok": False, "error": "Invalid JSON body."}), 400
 
     import json
+
     current = json.loads(config_path.read_text())
 
     # Preserve the real db_password if the masked sentinel came back
@@ -216,6 +223,75 @@ def update_config(name: str):
             del data["db_password"]
 
     config_path.write_text(json.dumps(data, indent=1))
+    return jsonify({"ok": True})
+
+
+@sites_bp.route("/<name>/backups")
+def list_backups(name: str):
+    from ..readers.backup_reader import BackupReader
+
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    try:
+        sets = BackupReader(bench_root, name).read_all()
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    return jsonify(
+        [
+            {
+                "timestamp": s.timestamp,
+                "created_at": s.created_at.isoformat(),
+                "files": [
+                    {
+                        "filename": f.filename,
+                        "path": f.path,
+                        "size_bytes": f.size_bytes,
+                        "kind": f.kind,
+                    }
+                    for f in s.files
+                ],
+            }
+            for s in sets
+        ]
+    )
+
+
+@sites_bp.route("/<name>/backup-schedule", methods=["GET"])
+def get_backup_schedule(name: str):
+    from ..cron_manager import CronManager
+
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    try:
+        schedule = CronManager(bench_root).get_schedule(name)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    return jsonify({"schedule": schedule})
+
+
+@sites_bp.route("/<name>/backup-schedule", methods=["POST"])
+def set_backup_schedule(name: str):
+    from ..cron_manager import CronManager
+
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    data = request.get_json(silent=True) or {}
+    schedule = (data.get("schedule") or "").strip()
+    if not schedule:
+        return jsonify({"ok": False, "error": "Schedule expression is required."})
+    try:
+        CronManager(bench_root).set_schedule(name, schedule)
+    except Exception as e:
+        return jsonify({"ok": False, "error": str(e)})
+    return jsonify({"ok": True})
+
+
+@sites_bp.route("/<name>/backup-schedule", methods=["DELETE"])
+def delete_backup_schedule(name: str):
+    from ..cron_manager import CronManager
+
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    try:
+        CronManager(bench_root).remove_schedule(name)
+    except Exception as e:
+        return jsonify({"ok": False, "error": str(e)})
     return jsonify({"ok": True})
 
 

--- a/admin/frontend/components.d.ts
+++ b/admin/frontend/components.d.ts
@@ -10,6 +10,7 @@ declare module 'vue' {
   export interface GlobalComponents {
     AppLayout: typeof import('./src/components/AppLayout.vue')['default']
     AppSidebar: typeof import('./src/components/AppSidebar.vue')['default']
+    FilePickerField: typeof import('./src/components/FilePickerField.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     TerminalOutput: typeof import('./src/components/TerminalOutput.vue')['default']

--- a/admin/frontend/src/components/FilePickerField.vue
+++ b/admin/frontend/src/components/FilePickerField.vue
@@ -1,0 +1,79 @@
+<script setup>
+import { ref } from 'vue'
+import { FeatherIcon } from 'frappe-ui'
+
+const props = defineProps({
+  label: { type: String, required: true },
+  accept: { type: String, default: '' },
+  file: { type: File, default: null },
+  required: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['change'])
+const input = ref(null)
+const dragging = ref(false)
+
+function openPicker() {
+  input.value.click()
+}
+
+function onFileChange(event) {
+  emit('change', event.target.files[0] ?? null)
+}
+
+function onDrop(event) {
+  dragging.value = false
+  const file = event.dataTransfer.files[0]
+  if (file) emit('change', file)
+}
+
+function formatSize(bytes) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function clear() {
+  emit('change', null)
+  input.value.value = ''
+}
+</script>
+
+<template>
+  <div>
+    <p class="mb-1.5 text-xs font-medium text-ink-gray-6">
+      {{ label }}<span v-if="required" class="ml-0.5 text-ink-red-4">*</span>
+    </p>
+
+    <!-- Selected state -->
+    <div v-if="file"
+      class="flex items-center gap-3 rounded-lg border border-outline-gray-2 bg-surface-gray-1 px-3 py-2.5">
+      <div class="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-surface-gray-3">
+        <FeatherIcon name="file-text" class="h-4 w-4 text-ink-gray-6" />
+      </div>
+      <div class="min-w-0 flex-1">
+        <p class="truncate text-sm font-medium text-ink-gray-8">{{ file.name }}</p>
+        <p class="text-xs text-ink-gray-5">{{ formatSize(file.size) }}</p>
+      </div>
+      <button type="button"
+        class="shrink-0 rounded p-1 text-ink-gray-4 transition hover:bg-surface-gray-3 hover:text-ink-gray-7"
+        @click="clear">
+        <FeatherIcon name="x" class="h-3.5 w-3.5" />
+      </button>
+    </div>
+
+    <!-- Empty / drop zone -->
+    <button v-else type="button" class="w-full rounded-lg border-2 border-dashed px-4 py-6 text-center transition"
+      :class="dragging
+        ? 'border-outline-gray-4 bg-surface-gray-2'
+        : 'border-outline-gray-2 bg-surface-gray-1 hover:border-outline-gray-3 hover:bg-surface-gray-2'"
+      @click="openPicker" @dragover.prevent="dragging = true" @dragleave.prevent="dragging = false"
+      @drop.prevent="onDrop">
+      <FeatherIcon name="upload-cloud" class="mx-auto mb-2 h-6 w-6 text-ink-gray-4" />
+      <p class="text-sm text-ink-gray-6">Drag & drop or <span class="font-medium text-ink-gray-8">click to browse</span>
+      </p>
+    </button>
+
+    <input ref="input" type="file" :accept="accept" class="hidden" @change="onFileChange" />
+  </div>
+</template>

--- a/admin/frontend/src/pages/Apps.vue
+++ b/admin/frontend/src/pages/Apps.vue
@@ -3,7 +3,7 @@ import { h, ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   Button, Badge, Dialog, ListView, FormControl,
-  LoadingText, ErrorMessage, TextInput, MultiSelect, Select,
+  LoadingText, ErrorMessage, TextInput, Select,
 } from 'frappe-ui'
 
 const router = useRouter()
@@ -96,13 +96,6 @@ const rows = computed(() =>
   }))
 )
 
-// Options for MultiSelect — branches as {label, value}
-const pickerBranchOptions = computed(() =>
-  pickerBranches.value.map(b => ({ label: b, value: b }))
-)
-const manualBranchOptions = computed(() =>
-  manualBranches.value.map(b => ({ label: b, value: b }))
-)
 const activeBranchOptions = computed(() =>
   pickerBranches.value.map(b => ({ label: b, value: b }))
 )
@@ -183,20 +176,6 @@ function onManualBranchKeydown(e) {
   }
 }
 
-// MultiSelect v-model syncs branches list; keep activeBranch valid
-function onPickerBranchesChange(val) {
-  pickerBranches.value = val
-  if (!val.includes(pickerActiveBranch.value)) {
-    pickerActiveBranch.value = val[0] || ''
-  }
-}
-
-function onManualBranchesChange(val) {
-  manualBranches.value = val
-  if (!val.includes(manualActiveBranch.value)) {
-    manualActiveBranch.value = val[0] || ''
-  }
-}
 
 function openSwitch(app, branch) {
   switchApp.value = app
@@ -306,40 +285,24 @@ onMounted(() => { load(); loadRegistry() })
 
           <!-- Branch configuration for selected app -->
           <div v-if="selectedApp" class="border-t border-outline-gray-1 pt-3 flex flex-col gap-3">
-            <div class="flex gap-4">
-              <!-- Active branch -->
-              <div class="flex-1">
-                <Select
-                  label="Active Branch"
-                  :options="activeBranchOptions"
-                  v-model="pickerActiveBranch"
-                  placeholder="Select active branch"
-                />
-              </div>
-              <!-- Available branches (MultiSelect) -->
-              <div class="flex-1">
-                <p class="mb-1.5 text-xs text-ink-gray-5">Available Branches</p>
-                <MultiSelect
-                  :options="pickerBranchOptions"
-                  :modelValue="pickerBranches"
-                  placeholder="Branches…"
-                  @update:modelValue="onPickerBranchesChange"
-                />
-              </div>
-            </div>
-            <!-- Add a custom branch not in the registry -->
-            <div class="flex gap-2 items-end">
-              <div class="flex-1">
+            <div>
+              <p class="mb-1.5 text-xs text-ink-gray-5">Custom Branch</p>
+              <div class="flex gap-2">
                 <TextInput
+                  class="flex-1"
                   v-model="pickerBranchInput"
-                  placeholder="Add custom branch…"
+                  placeholder="e.g. version-14, develop"
                   @keydown="onPickerBranchKeydown"
                 />
+                <Button variant="subtle" @click="addPickerBranch" :disabled="!pickerBranchInput.trim()">Add</Button>
               </div>
-              <Button variant="subtle" @click="addPickerBranch" :disabled="!pickerBranchInput.trim()">
-                Add
-              </Button>
             </div>
+            <Select
+              label="Active Branch"
+              :options="activeBranchOptions"
+              v-model="pickerActiveBranch"
+              placeholder="Select active branch"
+            />
           </div>
 
           <ErrorMessage :message="addError" class="mt-2" />
@@ -364,41 +327,25 @@ onMounted(() => { load(); loadRegistry() })
           <div class="flex flex-col gap-3">
             <FormControl label="Name" type="text" v-model="manualName" placeholder="my_app" />
             <FormControl label="Repository URL" type="text" v-model="manualRepo" placeholder="https://github.com/org/repo" />
-
-            <!-- Branch tag input -->
-            <div class="flex gap-2 items-end">
-              <div class="flex-1">
+            <div>
+              <p class="mb-1.5 text-xs text-ink-gray-5">Add Branch</p>
+              <div class="flex gap-2">
                 <TextInput
+                  class="flex-1"
                   v-model="manualBranchInput"
-                  placeholder="Add branch (e.g. main, develop)…"
+                  placeholder="e.g. main, develop"
                   @keydown="onManualBranchKeydown"
                 />
-              </div>
-              <Button variant="subtle" @click="addManualBranch" :disabled="!manualBranchInput.trim()">
-                Add
-              </Button>
-            </div>
-
-            <!-- Branch tags + active selector -->
-            <div v-if="manualBranches.length" class="flex gap-4">
-              <div class="flex-1">
-                <p class="mb-1.5 text-xs text-ink-gray-5">Available Branches</p>
-                <MultiSelect
-                  :options="manualBranchOptions"
-                  :modelValue="manualBranches"
-                  placeholder="Branches…"
-                  @update:modelValue="onManualBranchesChange"
-                />
-              </div>
-              <div class="flex-1">
-                <Select
-                  label="Active Branch"
-                  :options="manualActiveBranchOptions"
-                  v-model="manualActiveBranch"
-                  placeholder="Select active branch"
-                />
+                <Button variant="subtle" @click="addManualBranch" :disabled="!manualBranchInput.trim()">Add</Button>
               </div>
             </div>
+            <Select
+              v-if="manualBranches.length"
+              label="Active Branch"
+              :options="manualActiveBranchOptions"
+              v-model="manualActiveBranch"
+              placeholder="Select active branch"
+            />
           </div>
 
           <ErrorMessage :message="addError" class="mt-2" />

--- a/admin/frontend/src/pages/SiteDetail.vue
+++ b/admin/frontend/src/pages/SiteDetail.vue
@@ -454,8 +454,8 @@ onMounted(() => { load(); loadRegistry() })
             </div>
 
             <!-- History -->
-            <div>
-              <div class="mb-2 flex items-center justify-between">
+            <div class="rounded border p-4">
+              <div class="mb-3 flex items-center justify-between">
                 <h3 class="text-sm font-semibold text-ink-gray-9">Backup History</h3>
                 <Button variant="ghost" size="sm" @click="loadBackups">Refresh</Button>
               </div>

--- a/admin/frontend/src/pages/SiteDetail.vue
+++ b/admin/frontend/src/pages/SiteDetail.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onMounted } from 'vue'
+import { ref, computed, watch, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Button, Badge, Dialog, FormControl, LoadingText, ErrorMessage, Tabs } from 'frappe-ui'
 import LucideDatabase from '~icons/lucide/database'
@@ -122,8 +122,133 @@ const activeTab = ref(0)
 const tabs = [
   { label: 'Apps' },
   { label: 'Config' },
+  { label: 'Backups' },
   { label: 'Danger Zone' },
 ]
+
+// ── Backups tab ──────────────────────────────────────────────────────────────
+const backups = ref([])
+const backupsLoading = ref(false)
+const backupsError = ref('')
+const backupsTabLoaded = ref(false)
+
+const currentSchedule = ref(null)
+const scheduleInput = ref('')
+const scheduleLoading = ref(false)
+const scheduleSaving = ref(false)
+const scheduleRemoving = ref(false)
+const scheduleError = ref('')
+
+const showDeleteBackup = ref(false)
+const deleteBackupTarget = ref(null)
+const deletingBackup = ref(false)
+const deleteBackupError = ref('')
+
+async function deleteBackupSet() {
+  deletingBackup.value = true
+  deleteBackupError.value = ''
+  try {
+    const filenames = deleteBackupTarget.value.files.map(f => f.filename)
+    const res = await fetch('/api/tasks/run', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ command: 'delete-backup', site: siteName, filenames }),
+    })
+    const d = await res.json()
+    if (d.ok) { showDeleteBackup.value = false; router.push(`/tasks/${d.task_id}`) }
+    else deleteBackupError.value = d.error
+  } catch (e) {
+    deleteBackupError.value = e.message
+  } finally {
+    deletingBackup.value = false
+  }
+}
+
+const schedulePresets = [
+  { label: 'Daily midnight', value: '0 0 * * *' },
+  { label: 'Daily 2am', value: '0 2 * * *' },
+  { label: 'Weekly (Sun 2am)', value: '0 2 * * 0' },
+  { label: 'Monthly (1st 2am)', value: '0 2 1 * *' },
+]
+
+watch(activeTab, (idx) => {
+  if (tabs[idx]?.label === 'Backups' && !backupsTabLoaded.value) {
+    backupsTabLoaded.value = true
+    loadBackups()
+    loadSchedule()
+  }
+})
+
+async function loadBackups() {
+  backupsLoading.value = true
+  backupsError.value = ''
+  try {
+    const res = await fetch(`/api/sites/${siteName}/backups`)
+    const d = await res.json()
+    if (d.error) backupsError.value = d.error
+    else backups.value = d
+  } catch (e) {
+    backupsError.value = e.message
+  } finally {
+    backupsLoading.value = false
+  }
+}
+
+async function loadSchedule() {
+  scheduleLoading.value = true
+  try {
+    const res = await fetch(`/api/sites/${siteName}/backup-schedule`)
+    const d = await res.json()
+    currentSchedule.value = d.schedule ?? null
+    scheduleInput.value = d.schedule ?? ''
+  } finally {
+    scheduleLoading.value = false
+  }
+}
+
+async function saveSchedule() {
+  scheduleError.value = ''
+  scheduleSaving.value = true
+  try {
+    const res = await fetch(`/api/sites/${siteName}/backup-schedule`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ schedule: scheduleInput.value }),
+    })
+    const d = await res.json()
+    if (d.ok) await loadSchedule()
+    else scheduleError.value = d.error
+  } catch (e) {
+    scheduleError.value = e.message
+  } finally {
+    scheduleSaving.value = false
+  }
+}
+
+async function removeSchedule() {
+  scheduleError.value = ''
+  scheduleRemoving.value = true
+  try {
+    const res = await fetch(`/api/sites/${siteName}/backup-schedule`, { method: 'DELETE' })
+    const d = await res.json()
+    if (d.ok) { currentSchedule.value = null; scheduleInput.value = '' }
+    else scheduleError.value = d.error
+  } catch (e) {
+    scheduleError.value = e.message
+  } finally {
+    scheduleRemoving.value = false
+  }
+}
+
+function formatSize(bytes) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function formatBackupDate(iso) {
+  return new Date(iso).toLocaleString()
+}
 
 const COLORS = ['#4f46e5', '#0891b2', '#059669', '#d97706', '#dc2626', '#7c3aed']
 function hashColor(name) {
@@ -293,6 +418,76 @@ onMounted(() => { load(); loadRegistry() })
             </div>
           </div>
 
+          <!-- Backups -->
+          <div v-else-if="tab.label === 'Backups'" class="pt-4 flex flex-col gap-4">
+            <!-- Schedule -->
+            <div class="rounded border p-4">
+              <h3 class="mb-3 text-sm font-semibold text-ink-gray-9">Backup Schedule</h3>
+              <div v-if="scheduleLoading" class="text-sm text-ink-gray-5">Loading…</div>
+              <div v-else class="flex flex-col gap-3">
+                <p class="text-sm text-ink-gray-7">
+                  <span v-if="currentSchedule">
+                    Active:
+                    <code class="rounded bg-surface-gray-2 px-1 py-0.5 font-mono text-xs">{{ currentSchedule }}</code>
+                  </span>
+                  <span v-else class="text-ink-gray-5">No scheduled backups.</span>
+                </p>
+                <div class="flex flex-wrap gap-1.5">
+                  <button
+                    v-for="p in schedulePresets"
+                    :key="p.value"
+                    class="rounded bg-surface-gray-2 px-2 py-1 text-xs text-ink-gray-7 hover:bg-surface-gray-3"
+                    @click="scheduleInput = p.value"
+                  >{{ p.label }}</button>
+                </div>
+                <div class="flex gap-2">
+                  <input
+                    v-model="scheduleInput"
+                    placeholder="e.g. 0 2 * * *"
+                    class="flex-1 rounded border px-2 py-1.5 font-mono text-sm focus:outline-none focus:ring-1 focus:ring-gray-400"
+                  />
+                  <Button variant="outline" size="sm" :loading="scheduleSaving" :disabled="!scheduleInput" @click="saveSchedule">Save</Button>
+                  <Button v-if="currentSchedule" variant="ghost" size="sm" theme="red" :loading="scheduleRemoving" @click="removeSchedule">Remove</Button>
+                </div>
+                <ErrorMessage :message="scheduleError" />
+              </div>
+            </div>
+
+            <!-- History -->
+            <div>
+              <div class="mb-2 flex items-center justify-between">
+                <h3 class="text-sm font-semibold text-ink-gray-9">Backup History</h3>
+                <Button variant="ghost" size="sm" @click="loadBackups">Refresh</Button>
+              </div>
+              <div v-if="backupsLoading" class="py-6 text-center text-sm text-ink-gray-5">Loading…</div>
+              <div v-else-if="backupsError">
+                <ErrorMessage :message="backupsError" />
+              </div>
+              <div v-else-if="!backups.length" class="py-10 text-center text-sm text-ink-gray-4">
+                No backups found.
+              </div>
+              <div v-else class="flex flex-col gap-2">
+                <div v-for="set in backups" :key="set.timestamp" class="rounded border p-3">
+                  <div class="mb-2 flex items-center justify-between">
+                    <p class="text-sm font-medium text-ink-gray-8">{{ formatBackupDate(set.created_at) }}</p>
+                    <Button variant="ghost" theme="red" size="sm"
+                      @click="deleteBackupTarget = set; showDeleteBackup = true">Delete</Button>
+                  </div>
+                  <div class="flex flex-col gap-1">
+                    <div
+                      v-for="file in set.files"
+                      :key="file.filename"
+                      class="flex items-center justify-between gap-2 text-xs"
+                    >
+                      <span class="truncate font-mono text-ink-gray-7">{{ file.filename }}</span>
+                      <span class="shrink-0 text-ink-gray-4">{{ formatSize(file.size_bytes) }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <!-- Danger Zone -->
           <div v-else-if="tab.label === 'Danger Zone'" class="pt-4">
             <div class="rounded border border-red-200 p-4">
@@ -384,6 +579,20 @@ onMounted(() => { load(); loadRegistry() })
             <Button variant="ghost" @click="showEditConfig = false">Cancel</Button>
             <Button variant="solid" :loading="editConfigLoading" @click="saveConfig">Save</Button>
           </div>
+        </div>
+      </template>
+    </Dialog>
+
+    <!-- Delete Backup dialog -->
+    <Dialog v-model="showDeleteBackup" :options="{ title: 'Delete Backup', size: 'sm' }">
+      <template #body-content>
+        <p class="text-sm leading-relaxed text-ink-gray-7">
+          Delete the backup from <strong>{{ deleteBackupTarget ? formatBackupDate(deleteBackupTarget.created_at) : '' }}</strong>? This cannot be undone.
+        </p>
+        <ErrorMessage v-if="deleteBackupError" :message="deleteBackupError" class="mt-2" />
+        <div class="mt-4 flex justify-end gap-2">
+          <Button variant="ghost" @click="showDeleteBackup = false">Cancel</Button>
+          <Button variant="solid" theme="red" :loading="deletingBackup" @click="deleteBackupSet">Delete</Button>
         </div>
       </template>
     </Dialog>

--- a/admin/frontend/src/pages/Sites.vue
+++ b/admin/frontend/src/pages/Sites.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { h, ref, computed, onMounted } from 'vue'
+import { h, ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { Button, Badge, Dialog, ListView, FormControl, LoadingText, ErrorMessage } from 'frappe-ui'
 
@@ -14,6 +14,15 @@ const siteName = ref('')
 const adminPassword = ref('')
 const creating = ref(false)
 const createError = ref('')
+const restoreFromBackup = ref(false)
+const restoreMode = ref('existing')
+const backupSourceSite = ref('')
+const loadingBackups = ref(false)
+const backupSets = ref([])
+const selectedBackupTs = ref('')
+const uploadDb = ref(null)
+const uploadPublic = ref(null)
+const uploadPrivate = ref(null)
 
 const logoMap = computed(() => Object.fromEntries(registry.value.map(a => [a.name, a.logo_url])))
 
@@ -77,16 +86,62 @@ async function loadRegistry() {
   } catch { registry.value = [] }
 }
 
+function formatBackupDate(isoStr) {
+  return new Date(isoStr).toLocaleString()
+}
+
+watch(backupSourceSite, async (site) => {
+  selectedBackupTs.value = ''
+  backupSets.value = []
+  if (!site) return
+  loadingBackups.value = true
+  try {
+    const res = await fetch(`/api/sites/${encodeURIComponent(site)}/backups`)
+    backupSets.value = await res.json()
+  } catch { backupSets.value = [] }
+  finally { loadingBackups.value = false }
+})
+
 async function createSite() {
   if (!siteName.value.trim()) { createError.value = 'Site name is required.'; return }
+  if (restoreFromBackup.value) {
+    if (restoreMode.value === 'existing') {
+      if (!backupSourceSite.value) { createError.value = 'Select a source site.'; return }
+      if (!selectedBackupTs.value) { createError.value = 'Select a backup.'; return }
+    } else if (!uploadDb.value) {
+      createError.value = 'Database backup file is required.'
+      return
+    }
+  }
   creating.value = true
   createError.value = ''
   try {
-    const res = await fetch('/api/sites/create', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: siteName.value.trim(), admin_password: adminPassword.value.trim() }),
-    })
+    let res
+    if (!restoreFromBackup.value) {
+      res = await fetch('/api/sites/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: siteName.value.trim(), admin_password: adminPassword.value.trim() }),
+      })
+    } else if (restoreMode.value === 'existing') {
+      const set = backupSets.value.find(s => s.timestamp === selectedBackupTs.value)
+      const db = set.files.find(f => f.kind === 'database')
+      const pub = set.files.find(f => f.kind === 'files')
+      const priv = set.files.find(f => f.kind === 'private-files')
+      const body = { command: 'new-site-from-backup', name: siteName.value.trim(), db_file: db.path }
+      if (adminPassword.value.trim()) body.admin_password = adminPassword.value.trim()
+      if (pub) body.public_files = pub.path
+      if (priv) body.private_files = priv.path
+      res = await fetch('/api/tasks/run', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
+    } else {
+      const fd = new FormData()
+      fd.append('name', siteName.value.trim())
+      fd.append('admin_password', adminPassword.value.trim())
+      fd.append('db_file', uploadDb.value)
+      if (uploadPublic.value) fd.append('public_files', uploadPublic.value)
+      if (uploadPrivate.value) fd.append('private_files', uploadPrivate.value)
+      res = await fetch('/api/sites/create-from-upload', { method: 'POST', body: fd })
+    }
     const d = await res.json()
     if (d.ok) { showCreate.value = false; router.push(`/tasks/${d.task_id}`) }
     else createError.value = d.error
@@ -102,6 +157,14 @@ function openCreate() {
   siteName.value = ''
   adminPassword.value = ''
   createError.value = ''
+  restoreFromBackup.value = false
+  restoreMode.value = 'existing'
+  backupSourceSite.value = ''
+  backupSets.value = []
+  selectedBackupTs.value = ''
+  uploadDb.value = null
+  uploadPublic.value = null
+  uploadPrivate.value = null
 }
 
 onMounted(() => { load(); loadRegistry() })
@@ -134,7 +197,57 @@ onMounted(() => { load(); loadRegistry() })
         <div @pointerdown.stop class="flex flex-col gap-3">
           <FormControl label="Site Name" type="text" v-model="siteName" placeholder="mysite.localhost" @keyup.enter="createSite" />
           <FormControl label="Admin Password" type="password" v-model="adminPassword" placeholder="admin" description="Leave blank to use 'admin'" />
-          <ErrorMessage :message="createError" />
+          <div class="border-t pt-3">
+            <label class="flex cursor-pointer select-none items-center gap-2">
+              <input type="checkbox" v-model="restoreFromBackup" class="h-3.5 w-3.5 rounded" />
+              <span class="text-sm font-medium text-ink-gray-7">Restore from backup</span>
+            </label>
+            <div v-if="restoreFromBackup" class="mt-3 flex flex-col gap-3">
+              <div class="flex gap-4 text-sm">
+                <label class="flex cursor-pointer select-none items-center gap-1.5">
+                  <input type="radio" v-model="restoreMode" value="existing" class="h-3.5 w-3.5" />
+                  <span class="text-ink-gray-7">From this bench</span>
+                </label>
+                <label class="flex cursor-pointer select-none items-center gap-1.5">
+                  <input type="radio" v-model="restoreMode" value="upload" class="h-3.5 w-3.5" />
+                  <span class="text-ink-gray-7">Upload files</span>
+                </label>
+              </div>
+              <template v-if="restoreMode === 'existing'">
+                <FormControl
+                  label="Source Site"
+                  type="select"
+                  v-model="backupSourceSite"
+                  :options="[{ label: '— select site —', value: '' }, ...sites.map(s => ({ label: s.name, value: s.name }))]"
+                />
+                <div v-if="backupSourceSite">
+                  <LoadingText v-if="loadingBackups" />
+                  <FormControl
+                    v-else
+                    label="Backup"
+                    type="select"
+                    v-model="selectedBackupTs"
+                    :options="[{ label: '— select backup —', value: '' }, ...backupSets.map(s => ({ label: formatBackupDate(s.created_at), value: s.timestamp }))]"
+                  />
+                </div>
+              </template>
+              <template v-else>
+                <div>
+                  <p class="mb-1 text-xs text-ink-gray-6">Database backup (.sql.gz) *</p>
+                  <input type="file" accept=".gz" @change="uploadDb = $event.target.files[0]" class="w-full text-sm text-ink-gray-8" />
+                </div>
+                <div>
+                  <p class="mb-1 text-xs text-ink-gray-6">Public files (.tar.gz)</p>
+                  <input type="file" accept=".gz" @change="uploadPublic = $event.target.files[0]" class="w-full text-sm text-ink-gray-8" />
+                </div>
+                <div>
+                  <p class="mb-1 text-xs text-ink-gray-6">Private files (.tar.gz)</p>
+                  <input type="file" accept=".gz" @change="uploadPrivate = $event.target.files[0]" class="w-full text-sm text-ink-gray-8" />
+                </div>
+              </template>
+            </div>
+          </div>
+          <ErrorMessage v-if="createError" :message="createError" />
           <div class="mt-1 flex justify-end gap-2">
             <Button variant="ghost" @click="showCreate = false">Cancel</Button>
             <Button variant="solid" :loading="creating" @click="createSite">Create Site</Button>

--- a/admin/frontend/src/pages/Sites.vue
+++ b/admin/frontend/src/pages/Sites.vue
@@ -1,7 +1,8 @@
 <script setup>
 import { h, ref, computed, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { Button, Badge, Dialog, ListView, FormControl, LoadingText, ErrorMessage } from 'frappe-ui'
+import { Button, Badge, Dialog, ListView, FormControl, LoadingText, ErrorMessage, Switch, TabButtons } from 'frappe-ui'
+import FilePickerField from '../components/FilePickerField.vue'
 
 const router = useRouter()
 const sites = ref([])
@@ -194,25 +195,22 @@ onMounted(() => { load(); loadRegistry() })
 
     <Dialog v-model="showCreate" :options="{ title: 'Create Site' }">
       <template #body-content>
-        <div @pointerdown.stop class="flex flex-col gap-3">
+        <div @pointerdown.stop class="flex flex-col gap-4">
           <FormControl label="Site Name" type="text" v-model="siteName" placeholder="mysite.localhost" @keyup.enter="createSite" />
           <FormControl label="Admin Password" type="password" v-model="adminPassword" placeholder="admin" description="Leave blank to use 'admin'" />
-          <div class="border-t pt-3">
-            <label class="flex cursor-pointer select-none items-center gap-2">
-              <input type="checkbox" v-model="restoreFromBackup" class="h-3.5 w-3.5 rounded" />
-              <span class="text-sm font-medium text-ink-gray-7">Restore from backup</span>
-            </label>
-            <div v-if="restoreFromBackup" class="mt-3 flex flex-col gap-3">
-              <div class="flex gap-4 text-sm">
-                <label class="flex cursor-pointer select-none items-center gap-1.5">
-                  <input type="radio" v-model="restoreMode" value="existing" class="h-3.5 w-3.5" />
-                  <span class="text-ink-gray-7">From this bench</span>
-                </label>
-                <label class="flex cursor-pointer select-none items-center gap-1.5">
-                  <input type="radio" v-model="restoreMode" value="upload" class="h-3.5 w-3.5" />
-                  <span class="text-ink-gray-7">Upload files</span>
-                </label>
-              </div>
+
+          <div class="border-t pt-4">
+            <Switch v-model="restoreFromBackup" label="Restore from backup" />
+
+            <div v-if="restoreFromBackup" class="mt-4 flex flex-col gap-4">
+              <TabButtons
+                v-model="restoreMode"
+                :buttons="[
+                  { label: 'From this bench', value: 'existing' },
+                  { label: 'Upload files', value: 'upload' },
+                ]"
+              />
+
               <template v-if="restoreMode === 'existing'">
                 <FormControl
                   label="Source Site"
@@ -231,24 +229,33 @@ onMounted(() => { load(); loadRegistry() })
                   />
                 </div>
               </template>
+
               <template v-else>
-                <div>
-                  <p class="mb-1 text-xs text-ink-gray-6">Database backup (.sql.gz) *</p>
-                  <input type="file" accept=".gz" @change="uploadDb = $event.target.files[0]" class="w-full text-sm text-ink-gray-8" />
-                </div>
-                <div>
-                  <p class="mb-1 text-xs text-ink-gray-6">Public files (.tar.gz)</p>
-                  <input type="file" accept=".gz" @change="uploadPublic = $event.target.files[0]" class="w-full text-sm text-ink-gray-8" />
-                </div>
-                <div>
-                  <p class="mb-1 text-xs text-ink-gray-6">Private files (.tar.gz)</p>
-                  <input type="file" accept=".gz" @change="uploadPrivate = $event.target.files[0]" class="w-full text-sm text-ink-gray-8" />
-                </div>
+                <FilePickerField
+                  label="Database backup (.sql.gz)"
+                  required
+                  accept=".gz"
+                  :file="uploadDb"
+                  @change="uploadDb = $event"
+                />
+                <FilePickerField
+                  label="Public files (.tar.gz)"
+                  accept=".gz"
+                  :file="uploadPublic"
+                  @change="uploadPublic = $event"
+                />
+                <FilePickerField
+                  label="Private files (.tar.gz)"
+                  accept=".gz"
+                  :file="uploadPrivate"
+                  @change="uploadPrivate = $event"
+                />
               </template>
             </div>
           </div>
+
           <ErrorMessage v-if="createError" :message="createError" />
-          <div class="mt-1 flex justify-end gap-2">
+          <div class="flex justify-end gap-2">
             <Button variant="ghost" @click="showCreate = false">Cancel</Button>
             <Button variant="solid" :loading="creating" @click="createSite">Create Site</Button>
           </div>

--- a/bench_cli/commands/new.py
+++ b/bench_cli/commands/new.py
@@ -30,6 +30,11 @@ default = 2
 short = 1
 long = 1
 
+[[workers.custom]]
+queue = "backup"
+count = 2
+timeout = 3600
+
 [admin]
 port = 8002
 enabled = false

--- a/bench_cli/commands/new.py
+++ b/bench_cli/commands/new.py
@@ -30,10 +30,10 @@ default = 2
 short = 1
 long = 1
 
-[[workers.custom]]
-queue = "backup"
-count = 2
-timeout = 3600
+# [[workers.custom]]
+# queue = "backup"
+# count = 2
+# timeout = 3600
 
 [admin]
 port = 8002

--- a/bench_cli/commands/restore_site_from_backup.py
+++ b/bench_cli/commands/restore_site_from_backup.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+from bench_cli.commands.new_site import NewSiteCommand
+from bench_cli.config.site_config import SiteConfig
+from bench_cli.core.site import Site
+
+if TYPE_CHECKING:
+    from bench_cli.core.bench import Bench
+
+
+class NewSiteFromBackupCommand:
+    def __init__(
+        self,
+        bench: "Bench",
+        name: str,
+        db_file: str,
+        admin_password: str = "admin",
+        public_files: str | None = None,
+        private_files: str | None = None,
+    ) -> None:
+        self.bench = bench
+        self.name = name
+        self.db_file = db_file
+        self.admin_password = admin_password
+        self.public_files = public_files
+        self.private_files = private_files
+
+    def run(self) -> None:
+        NewSiteCommand(self.bench, self.name, [], self.admin_password).run()
+        print(f"Restoring backup: {self.db_file}")
+        sys.stdout.flush()
+        site = Site(SiteConfig(name=self.name, apps=[]), self.bench)
+        site.restore(self.db_file, self.public_files, self.private_files)

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -10,7 +10,7 @@ from bench_cli.config.letsencrypt_config import LetsEncryptConfig
 from bench_cli.config.mariadb_config import MariaDBConfig
 from bench_cli.config.nginx_config import NginxConfig
 from bench_cli.config.redis_config import RedisConfig
-from bench_cli.config.worker_config import WorkerConfig
+from bench_cli.config.worker_config import CustomWorkerEntry, WorkerConfig
 from bench_cli.exceptions import ConfigError
 
 _BENCH_NAME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]*$")
@@ -93,10 +93,19 @@ class BenchConfig:
 
     @staticmethod
     def _parse_workers(data: dict) -> WorkerConfig:
+        custom = [
+            CustomWorkerEntry(
+                queue=entry["queue"],
+                count=entry.get("count", 1),
+                timeout=entry.get("timeout", 300),
+            )
+            for entry in data.get("custom", [])
+        ]
         return WorkerConfig(
             default_count=data.get("default", 2),
             short_count=data.get("short", 1),
             long_count=data.get("long", 1),
+            custom=custom,
         )
 
     @staticmethod
@@ -186,6 +195,9 @@ class BenchConfig:
         for name, count in counts.items():
             if not isinstance(count, int) or count < 1:
                 raise ConfigError(f"{name} must be a positive integer, got '{count}'.")
+        for entry in self.workers.custom:
+            if not isinstance(entry.count, int) or entry.count < 1:
+                raise ConfigError(f"workers.custom '{entry.queue}' count must be a positive integer, got '{entry.count}'.")
 
     def _validate_letsencrypt_email(self) -> None:
         if self.letsencrypt.email and not _EMAIL_PATTERN.match(self.letsencrypt.email):

--- a/bench_cli/config/worker_config.py
+++ b/bench_cli/config/worker_config.py
@@ -1,4 +1,11 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CustomWorkerEntry:
+    queue: str
+    count: int
+    timeout: int = 300
 
 
 @dataclass
@@ -6,3 +13,4 @@ class WorkerConfig:
     default_count: int = 2
     short_count: int = 1
     long_count: int = 1
+    custom: list[CustomWorkerEntry] = field(default_factory=list)

--- a/bench_cli/core/bench.py
+++ b/bench_cli/core/bench.py
@@ -122,6 +122,13 @@ class Bench:
             "socketio_port": self.config.socketio_port,
             "webserver_port": self.config.http_port,
         }
+        # Add custom worker timeouts to config (if any exist)
+        custom_workers = {
+            entry.queue: {"timeout": entry.timeout}
+            for entry in self.config.workers.custom
+        }
+        if custom_workers:
+            config["workers"] = custom_workers
         # Use first site found as default (if any exist)
         first_site = next(
             (d.name for d in sorted(self.sites_path.iterdir())

--- a/bench_cli/core/site.py
+++ b/bench_cli/core/site.py
@@ -51,6 +51,17 @@ class Site:
 
         run_command(cmd, cwd=self.bench.sites_path, stream_output=True)
 
+    def restore(self, db_file: str, public_files: str | None = None, private_files: str | None = None) -> None:
+        cmd = [self._bench_binary(), "frappe", "--site", self.config.name, "restore", db_file]
+        if public_files:
+            cmd += ["--with-public-files", public_files]
+        if private_files:
+            cmd += ["--with-private-files", private_files]
+
+        cmd += ["--db-root-username", self.bench.config.mariadb.admin_user, "--db-root-password", self.bench.config.mariadb.root_password]
+
+        run_command(cmd, cwd=self.bench.sites_path, stream_output=True)
+
     def install_app(self, app_name: str) -> None:
         run_command([
             self._bench_binary(), "frappe",

--- a/bench_cli/managers/process_manager.py
+++ b/bench_cli/managers/process_manager.py
@@ -56,7 +56,6 @@ class ProcessManager:
     # ── Lifecycle ───────────────────────────────────────────────────────────
 
     def start(self) -> None:
-        self.generate_config()
         self.pid_file.write_text(str(os.getpid()))
         try:
             self._run_procfile()

--- a/bench_cli/managers/process_manager.py
+++ b/bench_cli/managers/process_manager.py
@@ -56,6 +56,7 @@ class ProcessManager:
     # ── Lifecycle ───────────────────────────────────────────────────────────
 
     def start(self) -> None:
+        self.generate_config()
         self.pid_file.write_text(str(os.getpid()))
         try:
             self._run_procfile()
@@ -87,7 +88,7 @@ class ProcessManager:
         original_sigterm = signal.getsignal(signal.SIGTERM)
         original_sigint = signal.getsignal(signal.SIGINT)
 
-        def _stop(signum, frame):
+        def _stop(_signum, _frame):
             self._stopping = True
             self._stop_all()
 
@@ -166,6 +167,11 @@ class ProcessManager:
             *self._worker_definitions("default", self.bench.config.workers.default_count),
             *self._worker_definitions("short", self.bench.config.workers.short_count),
             *self._worker_definitions("long", self.bench.config.workers.long_count),
+            *[
+                pd
+                for entry in self.bench.config.workers.custom
+                for pd in self._worker_definitions(entry.queue, entry.count)
+            ],
         ]
         if self.bench.config.redis.is_single_instance:
             definitions.append(self._redis_definition("redis", "redis.conf"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,12 @@ test = ["pytest>=8.0"]
 [tool.setuptools.packages.find]
 where = ["."]
 
+[tool.ruff]
+line-length = 200
+
+[tool.ruff.format]
+line-ending = "auto"
+
 [tool.setuptools.package-data]
 "admin.backend" = [
   "static/dist/**/*",


### PR DESCRIPTION
## Custom Worker Management
Best to enable custom workers from the start in bench-cli

Driven from the `bench.toml` file custom workers can be added and will be managed by frameworks `common_site_config.json`

<img width="2380" height="1108" alt="image" src="https://github.com/user-attachments/assets/9d2dc2cf-3d7c-4ccd-b9b6-1c8098913be8" />

Adding to `bench.toml`

```
[[workers.custom]]
queue = "backup"
count = 2
timeout = 3600
```


<img width="2354" height="1188" alt="image" src="https://github.com/user-attachments/assets/7a2a652d-7644-4414-893d-219b7e673616" />


## Site Backup Management
Cron based site backup scheduling

<img width="2422" height="1036" alt="image" src="https://github.com/user-attachments/assets/cda3cd78-e7c5-46c1-a070-66e3f613a643" />

Allow backup deletion with a new task runner command to avoid blocking requests for large sites