### PR TITLE
feat(admin): show log line counts

### DIFF
--- a/admin/backend/readers/log_reader.py
+++ b/admin/backend/readers/log_reader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 import time
 from collections.abc import Generator
 from dataclasses import dataclass
@@ -16,6 +17,7 @@ class LogFileInfo:
     size_bytes: int
     last_modified: datetime
     process_name: str
+    line_count: int
 
 
 _MAX_STREAM_LINES = 5000
@@ -29,17 +31,26 @@ class LogReader:
         logs_dir = self._bench_root / "logs"
         if not logs_dir.exists():
             return []
+        return [self._build_info(p) for p in sorted(logs_dir.glob("*.log"))]
 
-        result = []
-        for log_path in sorted(logs_dir.glob("*.log")):
-            stat = log_path.stat()
-            result.append(LogFileInfo(
-                filename=log_path.name,
-                size_bytes=stat.st_size,
-                last_modified=datetime.fromtimestamp(stat.st_mtime),
-                process_name=log_path.stem,
-            ))
-        return result
+    @staticmethod
+    def _build_info(path: Path) -> LogFileInfo:
+        stat = path.stat()
+        return LogFileInfo(
+            filename=path.name,
+            size_bytes=stat.st_size,
+            last_modified=datetime.fromtimestamp(stat.st_mtime),
+            process_name=path.stem,
+            line_count=LogReader._count_lines(path),
+        )
+
+    @staticmethod
+    def _count_lines(path: Path) -> int:
+        try:
+            output = subprocess.check_output(["wc", "-l", str(path)])
+            return int(output.split()[0])
+        except (subprocess.CalledProcessError, FileNotFoundError, ValueError):
+            return 0
 
     def read_tail(self, filename: str, lines: int = 200) -> list[str]:
         log_path = self._validated_path(filename)

--- a/admin/backend/views/logs.py
+++ b/admin/backend/views/logs.py
@@ -23,6 +23,7 @@ def index():
             "size_bytes": lf.size_bytes,
             "last_modified": lf.last_modified.isoformat(),
             "process_name": lf.process_name,
+            "line_count": lf.line_count,
         }
         for lf in log_files
     ])

--- a/admin/frontend/src/pages/LogList.vue
+++ b/admin/frontend/src/pages/LogList.vue
@@ -16,10 +16,15 @@ function fmtDate(iso) {
   return new Date(iso).toLocaleString(undefined, { dateStyle: 'short', timeStyle: 'short' })
 }
 
+function fmtLines(lines) {
+  return Number(lines ?? 0).toLocaleString()
+}
+
 const columns = [
   { label: 'File', key: 'filename', width: '200px' },
   { label: 'Process', key: 'process_name', width: '150px' },
   { label: 'Size', key: '_size', width: '80px' },
+  { label: 'Lines', key: '_lines', width: '100px' },
   { label: 'Last Modified', key: '_modified' },
 ]
 
@@ -27,6 +32,7 @@ const rows = computed(() =>
   logs.value.map(l => ({
     ...l,
     _size: fmtSize(l.size_bytes),
+    _lines: fmtLines(l.line_count),
     _modified: fmtDate(l.last_modified),
   }))
 )


### PR DESCRIPTION
## Task

- Task: 7.4 Line count in list

## Summary

This PR adds log line counts to the admin logs list view.

It includes line count metadata in the logs API response and displays it in the admin UI to help users better estimate log volume.

## Changes

- Added `line_count` to the log metadata returned by `LogReader`
- Counted lines for `.log` files using `wc -l`
- Exposed `line_count` in the `/api/logs/` response
- Added a `Lines` column to the admin logs table
- Formatted line counts with locale separators
- Added a fallback to display `0` when line count is unavailable