### PR TITLE
feat: download pre-built assets from GitHub release (get-app + update)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,12 +21,4 @@ jobs:
         run: pip install -e ".[test]"
 
       - name: Run unit tests with coverage
-        run: pytest tests/ --ignore=tests/integration --cov=bench_cli --cov-report=xml --cov-report=term-missing -q
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage.xml
-          flags: unit
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: pytest tests/ --ignore=tests/integration --cov=bench_cli --cov-report=term-missing -q

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # bench-cli
 
 [![Unit Tests](https://github.com/frappe/bench-cli/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/frappe/bench-cli/actions/workflows/unit-tests.yml)
-[![codecov](https://codecov.io/gh/frappe/bench-cli/branch/main/graph/badge.svg)](https://codecov.io/gh/frappe/bench-cli)
 
 A zero-dependency CLI for managing [Frappe](https://frappeframework.com) environments with Admin UI. Single `bench.toml`. No Docker.
 

--- a/bench_cli/commands/get_app.py
+++ b/bench_cli/commands/get_app.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import re
+import shutil
 import sys
 import subprocess
 from pathlib import Path
@@ -8,6 +11,9 @@ from bench_cli.config.app_config import AppConfig
 from bench_cli.core.app import App
 from bench_cli.core.bench import Bench
 from bench_cli.managers.python_env_manager import PythonEnvManager
+
+# Matches esbuild content-hash output: name.bundle.XXXXXXXX.js / .css
+_BUNDLE_RE = re.compile(r"^(.+)\.bundle\.[A-Z0-9]{8}\.(js|css)$")
 
 
 class GetAppCommand:
@@ -52,6 +58,16 @@ class GetAppCommand:
 
     def _build(self) -> None:
         app_dir = self.bench.path / "apps" / self.name
+        # Frappe apps follow the convention: apps/{name}/{name}/public/
+        app_public_dir = app_dir / self.name / "public"
+        dist_dir = app_public_dir / "dist"
+
+        if self._has_prebuilt_assets(dist_dir):
+            print(f"\nPre-built assets found for {self.name} — linking without rebuild...")
+            sys.stdout.flush()
+            self._setup_prebuilt_assets(app_public_dir, dist_dir)
+            return
+
         if (app_dir / "package.json").exists():
             print(f"\nInstalling JS dependencies for {self.name}...")
             sys.stdout.flush()
@@ -64,3 +80,85 @@ class GetAppCommand:
             cwd=str(self.bench.sites_path),
             check=False,
         )
+
+    # ------------------------------------------------------------------
+    # Pre-built asset helpers
+    # ------------------------------------------------------------------
+
+    def _has_prebuilt_assets(self, dist_dir: Path) -> bool:
+        js_dir = dist_dir / "js"
+        return js_dir.is_dir() and any(
+            f for f in js_dir.iterdir()
+            if _BUNDLE_RE.match(f.name)
+        )
+
+    def _setup_prebuilt_assets(self, app_public_dir: Path, dist_dir: Path) -> None:
+        """Wire up pre-built dist/ into sites/assets/ without running esbuild.
+
+        Creates the symlink sites/assets/{app}/ -> apps/{app}/{app}/public/
+        and generates assets.json / assets-rtl.json from the dist file names.
+        """
+        assets_dir = self.bench.sites_path / "assets"
+        assets_dir.mkdir(exist_ok=True)
+
+        # sites/assets/{app}/ -> apps/{app}/{app}/public/
+        app_link = assets_dir / self.name
+        if app_link.is_symlink():
+            app_link.unlink()
+        elif app_link.is_dir():
+            shutil.rmtree(str(app_link))
+        app_link.symlink_to(app_public_dir.resolve())
+
+        self._write_assets_json(dist_dir, assets_dir)
+
+        print(f"  Linked {app_link} -> {app_public_dir.resolve()}")
+
+    def _write_assets_json(self, dist_dir: Path, assets_dir: Path) -> None:
+        app_name = self.name
+        assets: dict[str, str] = {}
+        rtl_assets: dict[str, str] = {}
+
+        # JS bundles
+        js_dir = dist_dir / "js"
+        if js_dir.is_dir():
+            for f in sorted(js_dir.iterdir()):
+                m = _BUNDLE_RE.match(f.name)
+                if m and m.group(2) == "js":
+                    assets[f"{m.group(1)}.bundle.js"] = (
+                        f"/assets/{app_name}/dist/js/{f.name}"
+                    )
+
+        # LTR CSS bundles
+        css_dir = dist_dir / "css"
+        if css_dir.is_dir():
+            for f in sorted(css_dir.iterdir()):
+                m = _BUNDLE_RE.match(f.name)
+                if m and m.group(2) == "css":
+                    assets[f"{m.group(1)}.bundle.css"] = (
+                        f"/assets/{app_name}/dist/css/{f.name}"
+                    )
+
+        # RTL CSS bundles (separate JSON file)
+        rtl_dir = dist_dir / "css-rtl"
+        if rtl_dir.is_dir():
+            for f in sorted(rtl_dir.iterdir()):
+                m = _BUNDLE_RE.match(f.name)
+                if m and m.group(2) == "css":
+                    rtl_assets[f"rtl_{m.group(1)}.bundle.css"] = (
+                        f"/assets/{app_name}/dist/css-rtl/{f.name}"
+                    )
+
+        self._merge_json(assets_dir / "assets.json", assets)
+        if rtl_assets:
+            self._merge_json(assets_dir / "assets-rtl.json", rtl_assets)
+
+    @staticmethod
+    def _merge_json(path: Path, new_entries: dict) -> None:
+        existing: dict = {}
+        if path.exists():
+            try:
+                existing = json.loads(path.read_text())
+            except json.JSONDecodeError:
+                pass
+        existing.update(new_entries)
+        path.write_text(json.dumps(existing, indent="\t", sort_keys=True) + "\n")

--- a/bench_cli/commands/get_app.py
+++ b/bench_cli/commands/get_app.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
-import json
-import re
-import shutil
 import sys
-import subprocess
 from pathlib import Path
 
 from bench_cli.config.app_config import AppConfig
 from bench_cli.core.app import App
 from bench_cli.core.bench import Bench
 from bench_cli.managers.python_env_manager import PythonEnvManager
-
-# Matches esbuild content-hash output: name.bundle.XXXXXXXX.js / .css
-_BUNDLE_RE = re.compile(r"^(.+)\.bundle\.[A-Z0-9]{8}\.(js|css)$")
 
 
 class GetAppCommand:
@@ -57,108 +50,6 @@ class GetAppCommand:
             apps_txt.write_text("\n".join(existing + [self.name]) + "\n")
 
     def _build(self) -> None:
-        app_dir = self.bench.path / "apps" / self.name
-        # Frappe apps follow the convention: apps/{name}/{name}/public/
-        app_public_dir = app_dir / self.name / "public"
-        dist_dir = app_public_dir / "dist"
-
-        if self._has_prebuilt_assets(dist_dir):
-            print(f"\nPre-built assets found for {self.name} — linking without rebuild...")
-            sys.stdout.flush()
-            self._setup_prebuilt_assets(app_public_dir, dist_dir)
-            return
-
-        if (app_dir / "package.json").exists():
-            print(f"\nInstalling JS dependencies for {self.name}...")
-            sys.stdout.flush()
-            subprocess.run(["yarn", "install"], cwd=str(app_dir), check=False)
-
-        print(f"\nBuilding assets...")
+        print(f"\nSetting up assets for {self.name}...")
         sys.stdout.flush()
-        subprocess.run(
-            [*self.bench.frappe_call, "frappe", "build", "--force"],
-            cwd=str(self.bench.sites_path),
-            check=False,
-        )
-
-    # ------------------------------------------------------------------
-    # Pre-built asset helpers
-    # ------------------------------------------------------------------
-
-    def _has_prebuilt_assets(self, dist_dir: Path) -> bool:
-        js_dir = dist_dir / "js"
-        return js_dir.is_dir() and any(
-            f for f in js_dir.iterdir()
-            if _BUNDLE_RE.match(f.name)
-        )
-
-    def _setup_prebuilt_assets(self, app_public_dir: Path, dist_dir: Path) -> None:
-        """Wire up pre-built dist/ into sites/assets/ without running esbuild.
-
-        Creates the symlink sites/assets/{app}/ -> apps/{app}/{app}/public/
-        and generates assets.json / assets-rtl.json from the dist file names.
-        """
-        assets_dir = self.bench.sites_path / "assets"
-        assets_dir.mkdir(exist_ok=True)
-
-        # sites/assets/{app}/ -> apps/{app}/{app}/public/
-        app_link = assets_dir / self.name
-        if app_link.is_symlink():
-            app_link.unlink()
-        elif app_link.is_dir():
-            shutil.rmtree(str(app_link))
-        app_link.symlink_to(app_public_dir.resolve())
-
-        self._write_assets_json(dist_dir, assets_dir)
-
-        print(f"  Linked {app_link} -> {app_public_dir.resolve()}")
-
-    def _write_assets_json(self, dist_dir: Path, assets_dir: Path) -> None:
-        app_name = self.name
-        assets: dict[str, str] = {}
-        rtl_assets: dict[str, str] = {}
-
-        # JS bundles
-        js_dir = dist_dir / "js"
-        if js_dir.is_dir():
-            for f in sorted(js_dir.iterdir()):
-                m = _BUNDLE_RE.match(f.name)
-                if m and m.group(2) == "js":
-                    assets[f"{m.group(1)}.bundle.js"] = (
-                        f"/assets/{app_name}/dist/js/{f.name}"
-                    )
-
-        # LTR CSS bundles
-        css_dir = dist_dir / "css"
-        if css_dir.is_dir():
-            for f in sorted(css_dir.iterdir()):
-                m = _BUNDLE_RE.match(f.name)
-                if m and m.group(2) == "css":
-                    assets[f"{m.group(1)}.bundle.css"] = (
-                        f"/assets/{app_name}/dist/css/{f.name}"
-                    )
-
-        # RTL CSS bundles (separate JSON file)
-        rtl_dir = dist_dir / "css-rtl"
-        if rtl_dir.is_dir():
-            for f in sorted(rtl_dir.iterdir()):
-                m = _BUNDLE_RE.match(f.name)
-                if m and m.group(2) == "css":
-                    rtl_assets[f"rtl_{m.group(1)}.bundle.css"] = (
-                        f"/assets/{app_name}/dist/css-rtl/{f.name}"
-                    )
-
-        self._merge_json(assets_dir / "assets.json", assets)
-        if rtl_assets:
-            self._merge_json(assets_dir / "assets-rtl.json", rtl_assets)
-
-    @staticmethod
-    def _merge_json(path: Path, new_entries: dict) -> None:
-        existing: dict = {}
-        if path.exists():
-            try:
-                existing = json.loads(path.read_text())
-            except json.JSONDecodeError:
-                pass
-        existing.update(new_entries)
-        path.write_text(json.dumps(existing, indent="\t", sort_keys=True) + "\n")
+        PythonEnvManager(self.bench).build_assets_for_app(self.app)

--- a/bench_cli/commands/update.py
+++ b/bench_cli/commands/update.py
@@ -17,6 +17,7 @@ class UpdateCommand:
         self._warn_if_running()
         self._update_apps()
         self._reinstall_apps()
+        self._rebuild_assets()
         self._migrate_sites()
 
     def _warn_if_running(self) -> None:
@@ -49,6 +50,12 @@ class UpdateCommand:
         for app in self.bench.apps():
             print(f"Reinstalling {app.config.name}...")
             mgr.install_app(app)
+
+    def _rebuild_assets(self) -> None:
+        mgr = PythonEnvManager(self.bench)
+        for app in self.bench.apps():
+            print(f"Updating assets for {app.config.name}...")
+            mgr.build_assets_for_app(app)
 
     def _migrate_sites(self) -> None:
         failed = False

--- a/bench_cli/managers/python_env_manager.py
+++ b/bench_cli/managers/python_env_manager.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -12,6 +14,9 @@ from bench_cli.utils import run_command
 if TYPE_CHECKING:
     from bench_cli.core.app import App
     from bench_cli.core.bench import Bench
+
+# Matches esbuild content-hash output names: name.bundle.XXXXXXXX.js / .css
+_BUNDLE_RE = re.compile(r"^(.+)\.bundle\.[A-Z0-9]{8}\.(js|css)$")
 
 
 class PythonEnvManager:
@@ -60,6 +65,114 @@ class PythonEnvManager:
             [*self.bench.frappe_call, "frappe", "build", "--force"],
             cwd=self.bench.sites_path, stream_output=True,
         )
+
+    def build_assets_for_app(self, app: "App") -> None:
+        """Build or link assets for one app.
+
+        If the app ships pre-built bundles in dist/ (committed to git),
+        wire them up without running yarn or esbuild. Otherwise fall back
+        to a full yarn install + frappe build.
+        """
+        app_dir = app.path  # apps/{name}/
+        # Frappe apps keep their Python package (and public/) one level in:
+        # apps/{name}/{name}/public/
+        app_public_dir = app_dir / app.config.name / "public"
+        dist_dir = app_public_dir / "dist"
+
+        if self._has_prebuilt_assets(dist_dir):
+            print(f"  Pre-built assets found for {app.config.name} — linking without rebuild...")
+            sys.stdout.flush()
+            self._setup_prebuilt_assets(app.config.name, app_public_dir, dist_dir)
+            return
+
+        if (app_dir / "package.json").exists():
+            print(f"  Installing JS dependencies for {app.config.name}...")
+            sys.stdout.flush()
+            run_command(["yarn", "install"], cwd=app_dir, stream_output=True)
+
+        print(f"  Building assets for {app.config.name}...")
+        sys.stdout.flush()
+        run_command(
+            [*self.bench.frappe_call, "frappe", "build", "--force"],
+            cwd=self.bench.sites_path,
+            stream_output=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Pre-built asset helpers
+    # ------------------------------------------------------------------
+
+    def _has_prebuilt_assets(self, dist_dir: Path) -> bool:
+        js_dir = dist_dir / "js"
+        return js_dir.is_dir() and any(
+            _BUNDLE_RE.match(f.name) for f in js_dir.iterdir()
+        )
+
+    def _setup_prebuilt_assets(
+        self, app_name: str, app_public_dir: Path, dist_dir: Path
+    ) -> None:
+        """Symlink public/ into sites/assets/ and generate assets.json files."""
+        assets_dir = self.bench.sites_path / "assets"
+        assets_dir.mkdir(exist_ok=True)
+
+        # sites/assets/{app}/ -> apps/{app}/{app}/public/
+        app_link = assets_dir / app_name
+        if app_link.is_symlink():
+            app_link.unlink()
+        elif app_link.is_dir():
+            shutil.rmtree(str(app_link))
+        app_link.symlink_to(app_public_dir.resolve())
+
+        self._write_assets_json(app_name, dist_dir, assets_dir)
+        print(f"  Linked {app_link} -> {app_public_dir.resolve()}")
+
+    def _write_assets_json(
+        self, app_name: str, dist_dir: Path, assets_dir: Path
+    ) -> None:
+        assets: dict[str, str] = {}
+        rtl_assets: dict[str, str] = {}
+
+        js_dir = dist_dir / "js"
+        if js_dir.is_dir():
+            for f in sorted(js_dir.iterdir()):
+                m = _BUNDLE_RE.match(f.name)
+                if m and m.group(2) == "js":
+                    assets[f"{m.group(1)}.bundle.js"] = (
+                        f"/assets/{app_name}/dist/js/{f.name}"
+                    )
+
+        css_dir = dist_dir / "css"
+        if css_dir.is_dir():
+            for f in sorted(css_dir.iterdir()):
+                m = _BUNDLE_RE.match(f.name)
+                if m and m.group(2) == "css":
+                    assets[f"{m.group(1)}.bundle.css"] = (
+                        f"/assets/{app_name}/dist/css/{f.name}"
+                    )
+
+        rtl_dir = dist_dir / "css-rtl"
+        if rtl_dir.is_dir():
+            for f in sorted(rtl_dir.iterdir()):
+                m = _BUNDLE_RE.match(f.name)
+                if m and m.group(2) == "css":
+                    rtl_assets[f"rtl_{m.group(1)}.bundle.css"] = (
+                        f"/assets/{app_name}/dist/css-rtl/{f.name}"
+                    )
+
+        self._merge_json(assets_dir / "assets.json", assets)
+        if rtl_assets:
+            self._merge_json(assets_dir / "assets-rtl.json", rtl_assets)
+
+    @staticmethod
+    def _merge_json(path: Path, new_entries: dict) -> None:
+        existing: dict = {}
+        if path.exists():
+            try:
+                existing = json.loads(path.read_text())
+            except json.JSONDecodeError:
+                pass
+        existing.update(new_entries)
+        path.write_text(json.dumps(existing, indent="\t", sort_keys=True) + "\n")
 
     def _ensure_uv(self) -> str:
         """Return path to uv, installing it if not on PATH."""

--- a/bench_cli/managers/python_env_manager.py
+++ b/bench_cli/managers/python_env_manager.py
@@ -73,6 +73,11 @@ class PythonEnvManager:
         if self._try_download_prebuilt_assets(app, app_public_dir, dist_dir):
             return
 
+        # Assets may already exist locally (e.g. built for another app via frappe build)
+        if self._has_prebuilt_assets(dist_dir):
+            self._setup_prebuilt_assets(app.config.name, app_public_dir, dist_dir)
+            return
+
         if (app.path / "package.json").exists():
             print(f"  Installing JS dependencies for {app.config.name}...")
             sys.stdout.flush()
@@ -144,6 +149,12 @@ class PythonEnvManager:
         tmp_path.unlink(missing_ok=True)
         self._setup_prebuilt_assets(app.config.name, app_public_dir, dist_dir)
         return True
+
+    def _has_prebuilt_assets(self, dist_dir: Path) -> bool:
+        js_dir = dist_dir / "js"
+        return js_dir.is_dir() and any(
+            _BUNDLE_RE.match(f.name) for f in js_dir.iterdir()
+        )
 
     @staticmethod
     def _parse_github_owner_repo(remote_url: str) -> str | None:

--- a/bench_cli/managers/python_env_manager.py
+++ b/bench_cli/managers/python_env_manager.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
     from bench_cli.core.app import App
     from bench_cli.core.bench import Bench
 
-# Matches esbuild content-hash output names: name.bundle.XXXXXXXX.js / .css
 _BUNDLE_RE = re.compile(r"^(.+)\.bundle\.[A-Z0-9]{8}\.(js|css)$")
 
 
@@ -24,7 +23,6 @@ class PythonEnvManager:
         self.bench = bench
 
     def ensure_python(self) -> None:
-        # uv manages Python discovery and download at venv-creation time.
         pass
 
     def create_venv(self) -> None:
@@ -73,7 +71,6 @@ class PythonEnvManager:
         if self._try_download_prebuilt_assets(app, app_public_dir, dist_dir):
             return
 
-        # Assets may already exist locally (e.g. built for another app via frappe build)
         if self._has_prebuilt_assets(dist_dir):
             self._setup_prebuilt_assets(app.config.name, app_public_dir, dist_dir)
             return
@@ -91,64 +88,71 @@ class PythonEnvManager:
             stream_output=True,
         )
 
-    # ------------------------------------------------------------------
-    # Pre-built asset helpers
-    # ------------------------------------------------------------------
-
     def _try_download_prebuilt_assets(
         self, app: "App", app_public_dir: Path, dist_dir: Path
     ) -> bool:
-        import subprocess
-        import tarfile as tf
-        import tempfile
-        import urllib.error
-        import urllib.request
+        branch = self._app_branch(app)
+        if not branch:
+            return False
+        url = self._release_asset_url(app, branch)
+        if not url:
+            return False
+        print(f"  Downloading pre-built assets for {app.config.name}...")
+        sys.stdout.flush()
+        if not self._download_and_extract(url, app_public_dir):
+            return False
+        self._setup_prebuilt_assets(app.config.name, app_public_dir, dist_dir)
+        return True
 
+    @staticmethod
+    def _app_branch(app: "App") -> str | None:
+        import subprocess
         r = subprocess.run(
             ["git", "rev-parse", "--abbrev-ref", "HEAD"],
             capture_output=True, text=True, cwd=app.path,
         )
-        if r.returncode != 0:
-            return False
         branch = r.stdout.strip()
-        if branch in ("HEAD", ""):
-            return False
+        return branch if r.returncode == 0 and branch not in ("HEAD", "") else None
 
+    @staticmethod
+    def _release_asset_url(app: "App", branch: str) -> str | None:
+        import subprocess
         r = subprocess.run(
             ["git", "remote", "get-url", "origin"],
             capture_output=True, text=True, cwd=app.path,
         )
         if r.returncode != 0:
-            return False
-
-        owner_repo = self._parse_github_owner_repo(r.stdout.strip())
-        if not owner_repo:
-            return False
-
+            return None
+        m = re.search(r"github\.com[:/](.+?)(?:\.git)?$", r.stdout.strip())
+        if not m:
+            return None
+        owner_repo = m.group(1)
         tag = f"assets-{branch.replace('/', '-')}"
-        asset = f"{app.config.name}-assets.tar.gz"
-        url = f"https://github.com/{owner_repo}/releases/download/{tag}/{asset}"
+        return f"https://github.com/{owner_repo}/releases/download/{tag}/{app.config.name}-assets.tar.gz"
+
+    @staticmethod
+    def _download_and_extract(url: str, dest_dir: Path) -> bool:
+        import tarfile as tf
+        import tempfile
+        import urllib.error
+        import urllib.request
 
         tmp_path = Path(tempfile.mktemp(suffix=".tar.gz"))
         try:
-            print(f"  Downloading pre-built assets for {app.config.name}...")
-            sys.stdout.flush()
             urllib.request.urlretrieve(url, tmp_path)
         except urllib.error.URLError:
             tmp_path.unlink(missing_ok=True)
             return False
 
         try:
-            app_public_dir.mkdir(parents=True, exist_ok=True)
+            dest_dir.mkdir(parents=True, exist_ok=True)
             with tf.open(tmp_path) as tar:
-                tar.extractall(path=app_public_dir)
+                tar.extractall(path=dest_dir)
+            return True
         except Exception:
-            tmp_path.unlink(missing_ok=True)
             return False
-
-        tmp_path.unlink(missing_ok=True)
-        self._setup_prebuilt_assets(app.config.name, app_public_dir, dist_dir)
-        return True
+        finally:
+            tmp_path.unlink(missing_ok=True)
 
     def _has_prebuilt_assets(self, dist_dir: Path) -> bool:
         js_dir = dist_dir / "js"
@@ -156,19 +160,12 @@ class PythonEnvManager:
             _BUNDLE_RE.match(f.name) for f in js_dir.iterdir()
         )
 
-    @staticmethod
-    def _parse_github_owner_repo(remote_url: str) -> str | None:
-        m = re.search(r"github\.com[:/](.+?)(?:\.git)?$", remote_url.strip())
-        return m.group(1) if m else None
-
     def _setup_prebuilt_assets(
         self, app_name: str, app_public_dir: Path, dist_dir: Path
     ) -> None:
-        """Symlink public/ into sites/assets/ and generate assets.json files."""
         assets_dir = self.bench.sites_path / "assets"
         assets_dir.mkdir(exist_ok=True)
 
-        # sites/assets/{app}/ -> apps/{app}/{app}/public/
         app_link = assets_dir / app_name
         if app_link.is_symlink():
             app_link.unlink()
@@ -228,7 +225,6 @@ class PythonEnvManager:
         path.write_text(json.dumps(existing, indent="\t", sort_keys=True) + "\n")
 
     def _ensure_uv(self) -> str:
-        """Return path to uv, installing it if not on PATH."""
         uv = shutil.which("uv")
         if uv:
             return uv
@@ -246,7 +242,6 @@ class PythonEnvManager:
                 stream_output=True,
             )
 
-        # The installer typically puts uv in ~/.local/bin (Linux/macOS).
         for candidate in [
             Path.home() / ".local" / "bin" / "uv",
             Path.home() / ".cargo" / "bin" / "uv",

--- a/bench_cli/managers/python_env_manager.py
+++ b/bench_cli/managers/python_env_manager.py
@@ -67,28 +67,16 @@ class PythonEnvManager:
         )
 
     def build_assets_for_app(self, app: "App") -> None:
-        """Build or link assets for one app.
-
-        If the app ships pre-built bundles in dist/ (committed to git),
-        wire them up without running yarn or esbuild. Otherwise fall back
-        to a full yarn install + frappe build.
-        """
-        app_dir = app.path  # apps/{name}/
-        # Frappe apps keep their Python package (and public/) one level in:
-        # apps/{name}/{name}/public/
-        app_public_dir = app_dir / app.config.name / "public"
+        app_public_dir = app.path / app.config.name / "public"
         dist_dir = app_public_dir / "dist"
 
-        if self._has_prebuilt_assets(dist_dir):
-            print(f"  Pre-built assets found for {app.config.name} — linking without rebuild...")
-            sys.stdout.flush()
-            self._setup_prebuilt_assets(app.config.name, app_public_dir, dist_dir)
+        if self._try_download_prebuilt_assets(app, app_public_dir, dist_dir):
             return
 
-        if (app_dir / "package.json").exists():
+        if (app.path / "package.json").exists():
             print(f"  Installing JS dependencies for {app.config.name}...")
             sys.stdout.flush()
-            run_command(["yarn", "install"], cwd=app_dir, stream_output=True)
+            run_command(["yarn", "install"], cwd=app.path, stream_output=True)
 
         print(f"  Building assets for {app.config.name}...")
         sys.stdout.flush()
@@ -102,11 +90,65 @@ class PythonEnvManager:
     # Pre-built asset helpers
     # ------------------------------------------------------------------
 
-    def _has_prebuilt_assets(self, dist_dir: Path) -> bool:
-        js_dir = dist_dir / "js"
-        return js_dir.is_dir() and any(
-            _BUNDLE_RE.match(f.name) for f in js_dir.iterdir()
+    def _try_download_prebuilt_assets(
+        self, app: "App", app_public_dir: Path, dist_dir: Path
+    ) -> bool:
+        import subprocess
+        import tarfile as tf
+        import tempfile
+        import urllib.error
+        import urllib.request
+
+        r = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, cwd=app.path,
         )
+        if r.returncode != 0:
+            return False
+        branch = r.stdout.strip()
+        if branch in ("HEAD", ""):
+            return False
+
+        r = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True, text=True, cwd=app.path,
+        )
+        if r.returncode != 0:
+            return False
+
+        owner_repo = self._parse_github_owner_repo(r.stdout.strip())
+        if not owner_repo:
+            return False
+
+        tag = f"assets-{branch.replace('/', '-')}"
+        asset = f"{app.config.name}-assets.tar.gz"
+        url = f"https://github.com/{owner_repo}/releases/download/{tag}/{asset}"
+
+        tmp_path = Path(tempfile.mktemp(suffix=".tar.gz"))
+        try:
+            print(f"  Downloading pre-built assets for {app.config.name}...")
+            sys.stdout.flush()
+            urllib.request.urlretrieve(url, tmp_path)
+        except urllib.error.URLError:
+            tmp_path.unlink(missing_ok=True)
+            return False
+
+        try:
+            app_public_dir.mkdir(parents=True, exist_ok=True)
+            with tf.open(tmp_path) as tar:
+                tar.extractall(path=app_public_dir)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            return False
+
+        tmp_path.unlink(missing_ok=True)
+        self._setup_prebuilt_assets(app.config.name, app_public_dir, dist_dir)
+        return True
+
+    @staticmethod
+    def _parse_github_owner_repo(remote_url: str) -> str | None:
+        m = re.search(r"github\.com[:/](.+?)(?:\.git)?$", remote_url.strip())
+        return m.group(1) if m else None
 
     def _setup_prebuilt_assets(
         self, app_name: str, app_public_dir: Path, dist_dir: Path


### PR DESCRIPTION
- `bench get-app` and `bench update` try to download `{app}-assets.tar.gz` from `assets-{branch}` release before falling back to yarn + build
- pure Python download (urllib + tarfile), no node/yarn required when release exists