### PR TITLE
feat(admin): Password and size breakdown

### DIFF
--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import secrets
 from pathlib import Path
 
-from flask import Flask, jsonify, request, send_file
+from flask import Flask, jsonify, request, send_file, session
 
 from .views.apps import apps_bp
 from .views.dashboard import dashboard_bp
@@ -17,23 +18,35 @@ from bench_cli.config.bench_config import BenchConfig
 from bench_cli.exceptions import ConfigError
 
 _STATIC_DIR = Path(__file__).parent / "static"
+_OPEN_PATHS = {"/api/status", "/api/login", "/api/logout"}
 
 
 def create_app(bench_root: Path) -> Flask:
     app = Flask(__name__, static_folder=str(_STATIC_DIR), static_url_path="/static")
     app.config["BENCH_ROOT"] = bench_root
     app.config["TEMPLATES_AUTO_RELOAD"] = False
+    app.secret_key = secrets.token_hex(32)
+
+    def _load_config():
+        return BenchConfig.from_file(bench_root / "bench.toml")
+
+    def _check_enabled(config: BenchConfig):
+        if not config.admin.enabled:
+            return jsonify({"error": "Admin is disabled", "enabled": False}), 503
+        return None
+
+    def _check_password(config: BenchConfig):
+        if config.admin.password and not session.get("authenticated"):
+            return jsonify({"error": "Authentication required"}), 401
+        return None
 
     @app.before_request
-    def _check_admin_enabled():
-        if not request.path.startswith("/api"):
-            return None
-        if request.path == "/api/status":
+    def _guard():
+        if not request.path.startswith("/api") or request.path in _OPEN_PATHS:
             return None
         try:
-            config = BenchConfig.from_file(bench_root / "bench.toml")
-            if not config.admin.enabled:
-                return jsonify({"error": "Admin is disabled", "enabled": False}), 503
+            config = _load_config()
+            return _check_enabled(config) or _check_password(config)
         except Exception as exc:
             return jsonify({"error": str(exc), "enabled": False}), 503
 
@@ -41,9 +54,35 @@ def create_app(bench_root: Path) -> Flask:
     def api_status():
         try:
             config = BenchConfig.from_file(bench_root / "bench.toml")
-            return jsonify({"enabled": config.admin.enabled, "name": config.name})
+            password_required = bool(config.admin.password)
+            authenticated = not password_required or bool(session.get("authenticated"))
+            return jsonify(
+                {
+                    "enabled": config.admin.enabled,
+                    "name": config.name,
+                    "password_required": password_required,
+                    "authenticated": authenticated,
+                }
+            )
         except Exception as exc:
             return jsonify({"enabled": False, "error": str(exc)}), 503
+
+    @app.route("/api/login", methods=["POST"])
+    def api_login():
+        try:
+            config = BenchConfig.from_file(bench_root / "bench.toml")
+        except Exception as exc:
+            return jsonify({"ok": False, "error": str(exc)}), 503
+        data = request.get_json(silent=True) or {}
+        if data.get("password") == config.admin.password:
+            session["authenticated"] = True
+            return jsonify({"ok": True})
+        return jsonify({"ok": False, "error": "Incorrect password"}), 401
+
+    @app.route("/api/logout", methods=["POST"])
+    def api_logout():
+        session.clear()
+        return jsonify({"ok": True})
 
     app.register_blueprint(dashboard_bp, url_prefix="/api")
     app.register_blueprint(apps_bp, url_prefix="/api/apps")

--- a/admin/backend/views/stats.py
+++ b/admin/backend/views/stats.py
@@ -1,21 +1,45 @@
 from __future__ import annotations
 
+import subprocess
 from dataclasses import asdict
+from functools import lru_cache
+from pathlib import Path
 
 import psutil
 from flask import Blueprint, current_app, jsonify
 
+from bench_cli.config.bench_config import BenchConfig
 from ..readers.volume_reader import VolumeReader
 
 stats_bp = Blueprint("stats", __name__)
 
 
+@lru_cache(maxsize=16)
+def _directory_size(path: str) -> int:
+    try:
+        result = subprocess.run(["du", "-sb", path], capture_output=True, timeout=10)
+        return int(result.stdout.split()[0]) if result.returncode == 0 else 0
+    except Exception:
+        return 0
+
+
+def _path_sizes(bench_root: Path, config: BenchConfig) -> list[dict]:
+    benches_dir = str(bench_root)
+    mariadb_dir = config.volume.mariadb.data_dir
+    return [
+        {"label": "Benches", "path": benches_dir, "used_bytes": _directory_size(benches_dir)},
+        {"label": "MariaDB", "path": mariadb_dir, "used_bytes": _directory_size(mariadb_dir)},
+    ]
+
+
 @stats_bp.route("/stats")
 def stats():
     bench_root = current_app.config["BENCH_ROOT"]
+    config = BenchConfig.from_file(bench_root / "bench.toml")
     mem = psutil.virtual_memory()
     disk = psutil.disk_usage("/")
     volume = VolumeReader(bench_root).read()
+    paths = _path_sizes(bench_root, config) if not volume.enabled else []
     return jsonify(
         {
             "cpu_percent": psutil.cpu_percent(),
@@ -26,5 +50,6 @@ def stats():
             "disk_used": disk.used,
             "disk_total": disk.total,
             "volume": asdict(volume),
+            "paths": paths,
         }
     )

--- a/admin/frontend/src/App.vue
+++ b/admin/frontend/src/App.vue
@@ -1,20 +1,31 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 import AppLayout from './components/AppLayout.vue'
+import Login from './pages/Login.vue'
 import { Alert } from 'frappe-ui'
 
 const adminEnabled = ref(true)
 const adminError = ref('')
+const authenticated = ref(true)
+const passwordRequired = ref(false)
+const benchName = ref('')
+
+async function loadStatus() {
+  const response = await fetch('/api/status')
+  const data = await response.json()
+  adminEnabled.value = data.enabled !== false
+  authenticated.value = data.authenticated !== false
+  passwordRequired.value = data.password_required === true
+  benchName.value = data.name ?? ''
+  if (!adminEnabled.value) {
+    adminError.value = data.error || 'Admin is disabled in bench.toml'
+  }
+}
 
 onMounted(async () => {
   try {
-    const res = await fetch('/api/status')
-    const data = await res.json()
-    adminEnabled.value = data.enabled !== false
-    if (!adminEnabled.value) {
-      adminError.value = data.error || 'Admin is disabled in bench.toml'
-    }
-  } catch (e) {
+    await loadStatus()
+  } catch {
     adminError.value = 'Could not reach the bench admin server.'
   }
 })
@@ -24,5 +35,6 @@ onMounted(async () => {
   <div v-if="adminError" class="flex h-screen items-center justify-center p-8">
     <Alert theme="red" title="Admin Unavailable" :description="adminError" />
   </div>
-  <AppLayout v-else />
+  <Login v-else-if="!authenticated" :bench-name="benchName" @authenticated="authenticated = true" />
+  <AppLayout v-else :password-required="passwordRequired" @logout="authenticated = false" />
 </template>

--- a/admin/frontend/src/components/AppLayout.vue
+++ b/admin/frontend/src/components/AppLayout.vue
@@ -4,6 +4,12 @@ import { RouterView, useRoute } from 'vue-router'
 import { Breadcrumbs } from 'frappe-ui'
 import AppSidebar from './AppSidebar.vue'
 
+const props = defineProps({
+  passwordRequired: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['logout'])
+
 const route = useRoute()
 
 const breadcrumbs = computed(() => {
@@ -39,7 +45,7 @@ const breadcrumbs = computed(() => {
 
 <template>
   <div class="flex h-screen overflow-hidden">
-    <AppSidebar />
+    <AppSidebar :password-required="passwordRequired" @logout="$emit('logout')" />
     <main class="flex-1 overflow-auto bg-surface-white">
       <header class="sticky top-0 z-[10] flex items-center border-b bg-surface-white px-5 py-2.5">
         <Breadcrumbs :items="breadcrumbs" />

--- a/admin/frontend/src/components/AppSidebar.vue
+++ b/admin/frontend/src/components/AppSidebar.vue
@@ -9,7 +9,14 @@ import LucideFileText from '~icons/lucide/file-text'
 import LucideGlobe from '~icons/lucide/globe'
 import LucideLayoutDashboard from '~icons/lucide/layout-dashboard'
 import LucideListTodo from '~icons/lucide/list-todo'
+import LucideLogOut from '~icons/lucide/log-out'
 import LucidePackage2 from '~icons/lucide/package-2'
+
+defineProps({
+  passwordRequired: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['logout'])
 
 const route = useRoute()
 
@@ -29,6 +36,8 @@ const baseNavItems = [
 ]
 
 const snapshotsEnabled = ref(false)
+const runningCount = ref(0)
+let pollTimer = null
 
 const navItems = computed(() => [
   ...baseNavItems,
@@ -42,14 +51,11 @@ function isActive(to) {
   return route.path.startsWith(to)
 }
 
-const runningCount = ref(0)
-let pollTimer = null
-
 async function pollRunning() {
   try {
-    const res = await fetch('/api/tasks/?status=running')
-    if (res.ok) {
-      const tasks = await res.json()
+    const response = await fetch('/api/tasks/?status=running')
+    if (response.ok) {
+      const tasks = await response.json()
       runningCount.value = Array.isArray(tasks) ? tasks.length : 0
     }
   } catch { }
@@ -57,13 +63,17 @@ async function pollRunning() {
 
 async function loadVolumeConfig() {
   try {
-    const res = await fetch('/api/volume/status')
-    if (res.ok) {
-      const data = await res.json()
-      console.log(data)
+    const response = await fetch('/api/volume/status')
+    if (response.ok) {
+      const data = await response.json()
       snapshotsEnabled.value = data.enabled === true
     }
   } catch { }
+}
+
+async function logout() {
+  await fetch('/api/logout', { method: 'POST' })
+  emit('logout')
 }
 
 onMounted(() => {
@@ -85,6 +95,9 @@ onUnmounted(() => clearInterval(pollTimer))
           </span>
         </template>
       </SidebarItem>
+    </template>
+    <template v-if="passwordRequired" #footer-items>
+      <SidebarItem label="Logout" :icon="LucideLogOut" @click="logout" />
     </template>
   </Sidebar>
 </template>

--- a/admin/frontend/src/pages/Dashboard.vue
+++ b/admin/frontend/src/pages/Dashboard.vue
@@ -58,6 +58,10 @@ function poolHealthTheme(health) {
   return POOL_HEALTH_THEME[health] ?? 'red'
 }
 
+function diskPercent(bytes) {
+  return stats.value ? (bytes / stats.value.disk_total) * 100 : 0
+}
+
 const chartConfig = computed(() => ({
   title: 'CPU & Memory',
   data: history.value,
@@ -211,6 +215,16 @@ onUnmounted(() => {
                 <span class="text-sm text-ink-gray-5">{{ formatBytes(stats.disk_used) }} / {{ formatBytes(stats.disk_total) }}</span>
               </div>
               <Progress :value="stats.disk_percent" size="md" />
+            </div>
+          </div>
+
+          <div v-else-if="stats.paths?.length" class="grid grid-cols-3 gap-6">
+            <div v-for="pathInfo in stats.paths" :key="pathInfo.path">
+              <div class="mb-2 flex items-baseline justify-between">
+                <span class="text-sm font-medium text-ink-gray-7">{{ pathInfo.label }}</span>
+                <span class="text-sm text-ink-gray-5">{{ formatBytes(pathInfo.used_bytes) }}</span>
+              </div>
+              <Progress :value="diskPercent(pathInfo.used_bytes)" size="md" />
             </div>
           </div>
 

--- a/admin/frontend/src/pages/Login.vue
+++ b/admin/frontend/src/pages/Login.vue
@@ -38,18 +38,16 @@ async function login() {
 </script>
 
 <template>
-  <div class="flex h-screen items-center justify-center bg-surface-gray-2">
-    <div class="w-full max-w-sm rounded-xl border border-outline-gray-2 bg-surface-white shadow-sm">
+  <div class="flex h-screen flex-col items-center justify-center bg-surface-gray-2">
+    <div class="mb-6 flex flex-col items-center gap-3">
+      <img src="/logos/frappe-icon.png" alt="Frappe" class="h-12 w-12 rounded-xl" />
+      <h1 class="text-xl font-semibold text-ink-gray-9">
+        {{ benchName ? `Login to ${benchName}` : 'Bench Admin' }}
+      </h1>
+    </div>
 
-      <div class="border-b border-outline-gray-2 px-6 py-5">
-        <p class="text-base font-semibold text-ink-gray-9">{{ benchName || 'Bench Admin' }}</p>
-        <p class="mt-1 text-sm text-ink-gray-5">
-          Enter the password configured in
-          <code class="rounded bg-surface-gray-2 px-1 font-mono text-xs">bench.toml</code>
-        </p>
-      </div>
-
-      <div class="flex flex-col gap-3 px-6 py-5">
+    <div class="w-full max-w-sm rounded-xl border border-outline-gray-2 bg-surface-white p-6 shadow-sm">
+      <div class="flex flex-col gap-3">
         <TextInput
           v-model="password"
           type="password"
@@ -57,11 +55,14 @@ async function login() {
           @keydown.enter="login"
         />
         <ErrorMessage v-if="error" :message="error" />
-        <Button variant="solid" theme="blue" :loading="loading" @click="login">
-          Sign in
+        <Button variant="solid" :loading="loading" class="w-full" @click="login">
+          Login
         </Button>
       </div>
-
+      <p class="mt-4 text-center text-xs text-ink-gray-4">
+        Enter the password configured in
+        <code class="rounded bg-surface-gray-2 px-1 font-mono">bench.toml</code>
+      </p>
     </div>
   </div>
 </template>

--- a/admin/frontend/src/pages/Login.vue
+++ b/admin/frontend/src/pages/Login.vue
@@ -1,0 +1,67 @@
+<script setup>
+import { ref } from 'vue'
+import { Button, TextInput, ErrorMessage } from 'frappe-ui'
+
+defineProps({
+  benchName: { type: String, default: '' },
+})
+
+const emit = defineEmits(['authenticated'])
+
+const password = ref('')
+const error = ref('')
+const loading = ref(false)
+
+async function postLogin(value) {
+  const response = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ password: value }),
+  })
+  return response.json()
+}
+
+async function login() {
+  if (!password.value) return
+  loading.value = true
+  error.value = ''
+  try {
+    const result = await postLogin(password.value)
+    if (result.ok) emit('authenticated')
+    else error.value = result.error || 'Login failed'
+  } catch {
+    error.value = 'Could not reach the server'
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="flex h-screen items-center justify-center bg-surface-gray-2">
+    <div class="w-full max-w-sm rounded-xl border border-outline-gray-2 bg-surface-white shadow-sm">
+
+      <div class="border-b border-outline-gray-2 px-6 py-5">
+        <p class="text-base font-semibold text-ink-gray-9">{{ benchName || 'Bench Admin' }}</p>
+        <p class="mt-1 text-sm text-ink-gray-5">
+          Enter the password configured in
+          <code class="rounded bg-surface-gray-2 px-1 font-mono text-xs">bench.toml</code>
+        </p>
+      </div>
+
+      <div class="flex flex-col gap-3 px-6 py-5">
+        <TextInput
+          v-model="password"
+          type="password"
+          placeholder="Password"
+          @keydown.enter="login"
+        />
+        <ErrorMessage v-if="error" :message="error" />
+        <Button variant="solid" theme="blue" :loading="loading" @click="login">
+          Sign in
+        </Button>
+      </div>
+
+    </div>
+  </div>
+</template>

--- a/bench_cli/commands/new.py
+++ b/bench_cli/commands/new.py
@@ -1,3 +1,4 @@
+import secrets
 from pathlib import Path
 
 from bench_cli.exceptions import BenchError
@@ -39,6 +40,7 @@ long = 1
 port = 8002
 enabled = false
 timeout = 180
+password = "{admin_password}"
 
 # ── Volume (ZFS, optional) ────────────────────────────────────────────────
 # Uncomment and configure to use ZFS-based volume management.
@@ -82,7 +84,7 @@ class NewCommand:
         self.target_directory.mkdir(parents=True, exist_ok=True)
 
         print("Writing bench.toml")
-        bench_toml.write_text(_BENCH_TOML_TEMPLATE.format(name=self.name))
+        bench_toml.write_text(_BENCH_TOML_TEMPLATE.format(name=self.name, admin_password=secrets.token_hex(nbytes=5)))
 
         print(f"\nBench '{self.name}' created at {self.target_directory}")
         print("\nNext steps:")

--- a/bench_cli/config/admin_config.py
+++ b/bench_cli/config/admin_config.py
@@ -6,3 +6,4 @@ class AdminConfig:
     port: int = 8002
     timeout: int = 180  # seconds
     enabled: bool = False
+    password: str = ""

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -139,6 +139,7 @@ class BenchConfig:
             port=data.get("port", 8002),
             timeout=data.get("timeout", 180),
             enabled=data.get("enabled", False),
+            password=data.get("password", ""),
         )
 
     @staticmethod


### PR DESCRIPTION
- Auto generate admin password on bench init and pass in bench toml.
- Ensure flask session based admin authentication verifying password via the `bench.toml` admin section
- Login page

<img width="920" height="654" alt="image" src="https://github.com/user-attachments/assets/e49b6550-e9bd-41c3-8600-e75be74b2200" />

