### PR TITLE
feat(tasks): download task output log from detail page

### DIFF
--- a/admin/backend/views/tasks.py
+++ b/admin/backend/views/tasks.py
@@ -124,3 +124,24 @@ def rerun_task(task_id: str):
         return jsonify({"ok": False, "error": str(error)}), 500
 
     return jsonify({"ok": True, "task_id": new_task_id})
+
+
+@tasks_bp.route("/<task_id>/output/download")
+def download_task_output(task_id: str):
+    bench_root = current_app.config["BENCH_ROOT"]
+    try:
+        task = TaskReader(bench_root).read_task(task_id)
+    except TaskNotFoundError as error:
+        return jsonify({"error": str(error)}), 404
+    except Exception as error:
+        return jsonify({"error": str(error)}), 500
+
+    output_path = task.output_path
+    if not output_path.exists():
+        return jsonify({"error": "No output file found"}), 404
+
+    return Response(
+        output_path.read_bytes(),
+        mimetype="text/plain",
+        headers={"Content-Disposition": f'attachment; filename="{task_id}_output.log"'},
+    )

--- a/admin/frontend/src/pages/TaskDetail.vue
+++ b/admin/frontend/src/pages/TaskDetail.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { Button, Badge, Dialog, LoadingText, ErrorMessage } from 'frappe-ui'
 import TerminalOutput from '../components/TerminalOutput.vue'
 import { processLine } from '../utils/ansi.js'
+import LucideDownload from '~icons/lucide/download'
 
 const route = useRoute()
 const router = useRouter()
@@ -131,6 +132,9 @@ onUnmounted(() => { if (es) { es.close(); es = null } })
           {{ fmtDuration(task.duration_seconds) }}
         </span>
         <div class="ml-auto flex gap-2">
+          <a :href="`/api/tasks/${taskId}/output/download`" class="ml-auto">
+            <Button variant="ghost" :prefix-icon="LucideDownload">Download</Button>
+          </a>
           <Button
             v-if="task.status === 'running'"
             variant="outline"


### PR DESCRIPTION
## Task

Todo 8.3 - Download output

## Summary

This PR adds the ability to download a task's raw output log directly from the task detail page.

A new backend endpoint serves the task's `output.log` file, while the frontend adds a Download action to the task header for quick access to the complete log output.

## Changes

- Added a new endpoint: `GET /api/tasks/<task_id>/output/download`
- Validates task existence using `TaskReader`
- Returns a `404` response when the task or output file is not found
- Serves `output.log` as a downloadable `text/plain` attachment
- Names downloaded files as `<task_id>_output.log`
- Added a **Download** button to the task detail page header
- Uses the browser's native download behavior without additional frontend requests
- Places the Download action alongside the existing **Kill** and **Re-run** actions

## Notes

The task detail page displays only the most recent 200 log lines, while the downloaded file contains the complete task output.