### PR TITLE
feat(admin): Support bench.toml configuration from bench start

### DIFF
--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -68,21 +68,22 @@ def create_app(bench_root: Path) -> Flask:
 
     @app.route("/api/status")
     def api_status():
-        if not (bench_root / "env" / "bin" / "python").exists():
-            return jsonify(_wizard_status(bench_root))
+        initialized = (bench_root / "env" / "bin" / "python").exists()
         try:
             config = BenchConfig.from_file(bench_root / "bench.toml")
-            if not config.admin.password:
-                return jsonify({"enabled": False, "error": "No admin password configured in bench.toml"}), 503
-            return jsonify(
-                {
-                    "enabled": config.admin.enabled,
-                    "name": config.name,
-                    "authenticated": bool(session.get("authenticated")),
-                }
-            )
         except Exception as exc:
             return jsonify({"enabled": False, "error": str(exc)}), 503
+        # Show wizard when bench was never initialized, or when init was
+        # interrupted before an admin password was saved.
+        if not initialized or not config.admin.password:
+            return jsonify(_wizard_status(bench_root))
+        return jsonify(
+            {
+                "enabled": config.admin.enabled,
+                "name": config.name,
+                "authenticated": bool(session.get("authenticated")),
+            }
+        )
 
     @app.route("/api/login", methods=["POST"])
     def api_login():

--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -11,6 +11,7 @@ from .views.stats import stats_bp
 from .views.database import database_bp
 from .views.logs import logs_bp
 from .views.processes import processes_bp
+from .views.setup import setup_bp
 from .views.sites import sites_bp
 from .views.tasks import tasks_bp
 from .views.volume import volume_bp
@@ -19,6 +20,17 @@ from bench_cli.exceptions import ConfigError
 
 _STATIC_DIR = Path(__file__).parent / "static"
 _OPEN_PATHS = {"/api/status", "/api/login", "/api/logout"}
+
+
+def _wizard_status(bench_root: Path) -> dict:
+    import tomllib
+    name = bench_root.name
+    try:
+        with open(bench_root / "bench.toml", "rb") as f:
+            name = tomllib.load(f).get("bench", {}).get("name", name)
+    except Exception:
+        pass
+    return {"wizard": True, "name": name, "enabled": True, "authenticated": True}
 
 
 def create_app(bench_root: Path) -> Flask:
@@ -46,6 +58,8 @@ def create_app(bench_root: Path) -> Flask:
     def _guard():
         if not request.path.startswith("/api") or request.path in _OPEN_PATHS:
             return None
+        if request.path.startswith("/api/setup/"):
+            return None
         try:
             config = _load_config()
             return _check_enabled(config) or _check_password(config)
@@ -54,6 +68,8 @@ def create_app(bench_root: Path) -> Flask:
 
     @app.route("/api/status")
     def api_status():
+        if not (bench_root / "env" / "bin" / "python").exists():
+            return jsonify(_wizard_status(bench_root))
         try:
             config = BenchConfig.from_file(bench_root / "bench.toml")
             if not config.admin.password:
@@ -87,6 +103,7 @@ def create_app(bench_root: Path) -> Flask:
         session.clear()
         return jsonify({"ok": True})
 
+    app.register_blueprint(setup_bp, url_prefix="/api/setup")
     app.register_blueprint(dashboard_bp, url_prefix="/api")
     app.register_blueprint(apps_bp, url_prefix="/api/apps")
     app.register_blueprint(sites_bp, url_prefix="/api/sites")

--- a/admin/backend/tasks/jobs/init_task.py
+++ b/admin/backend/tasks/jobs/init_task.py
@@ -11,12 +11,13 @@ from bench_cli.core.bench import Bench
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run bench init as a task")
     parser.add_argument("bench_root")
+    parser.add_argument("--sudo-password", default="")
     args = parser.parse_args()
 
     bench_root = Path(args.bench_root)
     config = BenchConfig.from_file(bench_root / "bench.toml")
     bench = Bench(config, bench_root)
-    InitCommand(bench).run()
+    InitCommand(bench, sudo_password=args.sudo_password).run()
 
 
 if __name__ == "__main__":

--- a/admin/backend/tasks/jobs/init_task.py
+++ b/admin/backend/tasks/jobs/init_task.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from bench_cli.commands.init import InitCommand
+from bench_cli.config.bench_config import BenchConfig
+from bench_cli.core.bench import Bench
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run bench init as a task")
+    parser.add_argument("bench_root")
+    args = parser.parse_args()
+
+    bench_root = Path(args.bench_root)
+    config = BenchConfig.from_file(bench_root / "bench.toml")
+    bench = Bench(config, bench_root)
+    InitCommand(bench).run()
+
+
+if __name__ == "__main__":
+    main()

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -159,7 +159,10 @@ class TaskRunner:
         if command == "setup-letsencrypt":
             return [sys.executable, "-m", "admin.backend.tasks.jobs.setup_letsencrypt_task", str(self._bench_root)]
         if command == "bench-init":
-            return [sys.executable, "-m", "admin.backend.tasks.jobs.init_task", str(self._bench_root)]
+            argv = [sys.executable, "-m", "admin.backend.tasks.jobs.init_task", str(self._bench_root)]
+            if args.get("sudo_password"):
+                argv += ["--sudo-password", args["sudo_password"]]
+            return argv
         if command == "new-site-from-backup":
             argv = [sys.executable, "-m", "admin.backend.tasks.jobs.new_site_from_backup_task", str(self._bench_root), args["name"], args["db_file"]]
             if args.get("admin_password"):

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -33,6 +33,7 @@ _WHITELIST: dict[str, list[str]] = {
     "setup-production": [],
     "setup-letsencrypt": [],
     "new-site-from-backup": ["name", "db_file"],
+    "bench-init": [],
 }
 
 
@@ -157,6 +158,8 @@ class TaskRunner:
             return [sys.executable, "-m", "admin.backend.tasks.jobs.setup_production_task", str(self._bench_root)]
         if command == "setup-letsencrypt":
             return [sys.executable, "-m", "admin.backend.tasks.jobs.setup_letsencrypt_task", str(self._bench_root)]
+        if command == "bench-init":
+            return [sys.executable, "-m", "admin.backend.tasks.jobs.init_task", str(self._bench_root)]
         if command == "new-site-from-backup":
             argv = [sys.executable, "-m", "admin.backend.tasks.jobs.new_site_from_backup_task", str(self._bench_root), args["name"], args["db_file"]]
             if args.get("admin_password"):

--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -47,8 +47,12 @@ def _validate(data: dict) -> str | None:
 @setup_bp.route("/init", methods=["POST"])
 def start_init():
     bench_root = Path(current_app.config["BENCH_ROOT"])
+    data = request.get_json(silent=True) or {}
+    args = {}
+    if data.get("sudo_password"):
+        args["sudo_password"] = data["sudo_password"]
     try:
-        task_id = TaskRunner(bench_root).run("bench-init", {})
+        task_id = TaskRunner(bench_root).run("bench-init", args)
         return jsonify({"ok": True, "task_id": task_id})
     except Exception as exc:
         return jsonify({"ok": False, "error": str(exc)}), 500

--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -90,7 +90,10 @@ def stream_task(task_id: str):
 
 
 def _read_defaults(bench_root: Path) -> dict:
-    result = {"bench_name": bench_root.name, **BenchTomlBuilder.DEFAULTS}
+    from bench_cli.platform import is_linux
+    from admin.backend.tasks.manager.task_reader import TaskReader
+
+    result = {"bench_name": bench_root.name, "is_linux": is_linux(), **BenchTomlBuilder.DEFAULTS}
     toml_path = bench_root / "bench.toml"
     if toml_path.exists():
         try:
@@ -99,6 +102,14 @@ def _read_defaults(bench_root: Path) -> dict:
                 result["bench_name"] = bench_root.name
         except Exception:
             pass
+
+    try:
+        tasks = TaskReader(bench_root).list_tasks()
+        running = next((t for t in tasks if t.command == "bench-init" and t.status == "running"), None)
+        result["running_init_task_id"] = running.task_id if running else None
+    except Exception:
+        result["running_init_task_id"] = None
+
     return result
 
 

--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from flask import Blueprint, Response, current_app, jsonify, request, stream_with_context
+
+from admin.backend.tasks.manager.task_reader import TaskReader
+from admin.backend.tasks.manager.task_runner import TaskRunner
+from bench_cli.config.bench_toml_builder import BenchTomlBuilder
+
+setup_bp = Blueprint("setup", __name__)
+
+
+@setup_bp.route("/config")
+def get_config():
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    return jsonify(_read_defaults(bench_root))
+
+
+@setup_bp.route("/save", methods=["POST"])
+def save_config():
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    data = request.get_json(silent=True) or {}
+
+    error = _validate(data)
+    if error:
+        return jsonify({"ok": False, "error": error}), 400
+
+    settings = {**data, "admin_enabled": True}
+    content = BenchTomlBuilder(_current_name(bench_root), settings).render()
+    (bench_root / "bench.toml").write_text(content)
+    return jsonify({"ok": True})
+
+
+def _validate(data: dict) -> str | None:
+    for field in ("mariadb_password", "admin_password"):
+        if not data.get(field):
+            return f"{field} is required"
+    if data.get("volume_enabled"):
+        for field in ("volume_pool", "volume_device"):
+            if not data.get(field):
+                return f"{field} is required when volume management is enabled"
+    return None
+
+
+@setup_bp.route("/init", methods=["POST"])
+def start_init():
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    try:
+        task_id = TaskRunner(bench_root).run("bench-init", {})
+        return jsonify({"ok": True, "task_id": task_id})
+    except Exception as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 500
+
+
+@setup_bp.route("/new-site", methods=["POST"])
+def start_new_site():
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    data = request.get_json(silent=True) or {}
+    if not data.get("name"):
+        return jsonify({"ok": False, "error": "Site name is required"}), 400
+
+    args = {"name": data["name"]}
+    if data.get("admin_password"):
+        args["admin_password"] = data["admin_password"]
+    try:
+        task_id = TaskRunner(bench_root).run("new-site", args)
+        return jsonify({"ok": True, "task_id": task_id})
+    except Exception as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 500
+
+
+@setup_bp.route("/stream/<task_id>")
+def stream_task(task_id: str):
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    reader = TaskReader(bench_root)
+
+    def generate():
+        for line in reader.stream_output(task_id):
+            if line.startswith("__DONE__:"):
+                yield f"event: done\ndata: {line[9:]}\n\n"
+            else:
+                yield f"data: {line}\n\n"
+
+    return Response(stream_with_context(generate()), mimetype="text/event-stream")
+
+
+def _default_config(bench_root: Path) -> dict:
+    return {
+        "bench_name": bench_root.name,
+        "python": "3.14",
+        "mariadb_password": "root",
+        "admin_password": "",
+        "app_repo": "https://github.com/frappe/frappe",
+        "app_branch": "version-16",
+        "http_port": 8000,
+        "socketio_port": 9000,
+        "redis_port": 13000,
+        "workers_default": 2,
+        "workers_short": 1,
+        "workers_long": 1,
+        "volume_enabled": False,
+        "volume_pool": "",
+        "volume_device": "",
+        "volume_benches_reservation": "10G",
+        "volume_benches_quota": "50G",
+        "volume_mariadb_reservation": "5G",
+        "volume_mariadb_quota": "20G",
+        "volume_mariadb_data_dir": "/var/lib/mysql",
+        "volume_snapshots_enabled": False,
+    }
+
+
+def _read_defaults(bench_root: Path) -> dict:
+    defaults = _default_config(bench_root)
+    toml_path = bench_root / "bench.toml"
+    if not toml_path.exists():
+        return defaults
+    try:
+        with open(toml_path, "rb") as f:
+            data = tomllib.load(f)
+        defaults.update(_read_general(data, defaults))
+        defaults.update(_read_volume(data.get("volume", {}), defaults))
+    except Exception:
+        pass
+    return defaults
+
+
+def _read_general(data: dict, defaults: dict) -> dict:
+    bench = data.get("bench", {})
+    app = (data.get("apps") or [{}])[0]
+    return {
+        "bench_name": bench.get("name", defaults["bench_name"]),
+        "python": bench.get("python", defaults["python"]),
+        "http_port": bench.get("http_port", defaults["http_port"]),
+        "socketio_port": bench.get("socketio_port", defaults["socketio_port"]),
+        "mariadb_password": data.get("mariadb", {}).get("root_password", defaults["mariadb_password"]),
+        "admin_password": data.get("admin", {}).get("password", defaults["admin_password"]),
+        "app_repo": app.get("repo", defaults["app_repo"]),
+        "app_branch": app.get("branch", defaults["app_branch"]),
+        "redis_port": data.get("redis", {}).get("port", defaults["redis_port"]),
+        "workers_default": data.get("workers", {}).get("default", defaults["workers_default"]),
+        "workers_short": data.get("workers", {}).get("short", defaults["workers_short"]),
+        "workers_long": data.get("workers", {}).get("long", defaults["workers_long"]),
+    }
+
+
+def _read_volume(volume: dict, defaults: dict) -> dict:
+    benches = volume.get("benches", {})
+    mariadb = volume.get("mariadb", {})
+    snapshots = volume.get("snapshots", {})
+    return {
+        "volume_enabled": volume.get("enabled", defaults["volume_enabled"]),
+        "volume_pool": volume.get("pool", defaults["volume_pool"]),
+        "volume_device": volume.get("device", defaults["volume_device"]),
+        "volume_benches_reservation": benches.get("reservation", defaults["volume_benches_reservation"]),
+        "volume_benches_quota": benches.get("quota", defaults["volume_benches_quota"]),
+        "volume_mariadb_reservation": mariadb.get("reservation", defaults["volume_mariadb_reservation"]),
+        "volume_mariadb_quota": mariadb.get("quota", defaults["volume_mariadb_quota"]),
+        "volume_mariadb_data_dir": mariadb.get("data_dir", defaults["volume_mariadb_data_dir"]),
+        "volume_snapshots_enabled": snapshots.get("enabled", defaults["volume_snapshots_enabled"]),
+    }
+
+
+def _current_name(bench_root: Path) -> str:
+    toml_path = bench_root / "bench.toml"
+    if not toml_path.exists():
+        return bench_root.name
+    try:
+        with open(toml_path, "rb") as f:
+            return tomllib.load(f).get("bench", {}).get("name", bench_root.name)
+    except Exception:
+        return bench_root.name

--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
 
 from flask import Blueprint, Response, current_app, jsonify, request, stream_with_context
@@ -90,81 +89,17 @@ def stream_task(task_id: str):
     return Response(stream_with_context(generate()), mimetype="text/event-stream")
 
 
-def _default_config(bench_root: Path) -> dict:
-    return {
-        "bench_name": bench_root.name,
-        "python": "3.14",
-        "mariadb_password": "root",
-        "admin_password": "",
-        "app_repo": "https://github.com/frappe/frappe",
-        "app_branch": "version-16",
-        "http_port": 8000,
-        "socketio_port": 9000,
-        "redis_port": 13000,
-        "workers_default": 2,
-        "workers_short": 1,
-        "workers_long": 1,
-        "volume_enabled": False,
-        "volume_pool": "",
-        "volume_device": "",
-        "volume_benches_reservation": "10G",
-        "volume_benches_quota": "50G",
-        "volume_mariadb_reservation": "5G",
-        "volume_mariadb_quota": "20G",
-        "volume_mariadb_data_dir": "/var/lib/mysql",
-        "volume_snapshots_enabled": False,
-    }
-
-
 def _read_defaults(bench_root: Path) -> dict:
-    defaults = _default_config(bench_root)
+    result = {"bench_name": bench_root.name, **BenchTomlBuilder.DEFAULTS}
     toml_path = bench_root / "bench.toml"
-    if not toml_path.exists():
-        return defaults
-    try:
-        with open(toml_path, "rb") as f:
-            data = tomllib.load(f)
-        defaults.update(_read_general(data, defaults))
-        defaults.update(_read_volume(data.get("volume", {}), defaults))
-    except Exception:
-        pass
-    return defaults
-
-
-def _read_general(data: dict, defaults: dict) -> dict:
-    bench = data.get("bench", {})
-    app = (data.get("apps") or [{}])[0]
-    return {
-        "bench_name": bench.get("name", defaults["bench_name"]),
-        "python": bench.get("python", defaults["python"]),
-        "http_port": bench.get("http_port", defaults["http_port"]),
-        "socketio_port": bench.get("socketio_port", defaults["socketio_port"]),
-        "mariadb_password": data.get("mariadb", {}).get("root_password", defaults["mariadb_password"]),
-        "admin_password": data.get("admin", {}).get("password", defaults["admin_password"]),
-        "app_repo": app.get("repo", defaults["app_repo"]),
-        "app_branch": app.get("branch", defaults["app_branch"]),
-        "redis_port": data.get("redis", {}).get("port", defaults["redis_port"]),
-        "workers_default": data.get("workers", {}).get("default", defaults["workers_default"]),
-        "workers_short": data.get("workers", {}).get("short", defaults["workers_short"]),
-        "workers_long": data.get("workers", {}).get("long", defaults["workers_long"]),
-    }
-
-
-def _read_volume(volume: dict, defaults: dict) -> dict:
-    benches = volume.get("benches", {})
-    mariadb = volume.get("mariadb", {})
-    snapshots = volume.get("snapshots", {})
-    return {
-        "volume_enabled": volume.get("enabled", defaults["volume_enabled"]),
-        "volume_pool": volume.get("pool", defaults["volume_pool"]),
-        "volume_device": volume.get("device", defaults["volume_device"]),
-        "volume_benches_reservation": benches.get("reservation", defaults["volume_benches_reservation"]),
-        "volume_benches_quota": benches.get("quota", defaults["volume_benches_quota"]),
-        "volume_mariadb_reservation": mariadb.get("reservation", defaults["volume_mariadb_reservation"]),
-        "volume_mariadb_quota": mariadb.get("quota", defaults["volume_mariadb_quota"]),
-        "volume_mariadb_data_dir": mariadb.get("data_dir", defaults["volume_mariadb_data_dir"]),
-        "volume_snapshots_enabled": snapshots.get("enabled", defaults["volume_snapshots_enabled"]),
-    }
+    if toml_path.exists():
+        try:
+            result.update(BenchTomlBuilder.read_settings(toml_path))
+            if not result.get("bench_name"):
+                result["bench_name"] = bench_root.name
+        except Exception:
+            pass
+    return result
 
 
 def _current_name(bench_root: Path) -> str:
@@ -172,7 +107,6 @@ def _current_name(bench_root: Path) -> str:
     if not toml_path.exists():
         return bench_root.name
     try:
-        with open(toml_path, "rb") as f:
-            return tomllib.load(f).get("bench", {}).get("name", bench_root.name)
+        return BenchTomlBuilder.read_settings(toml_path).get("bench_name") or bench_root.name
     except Exception:
         return bench_root.name

--- a/admin/frontend/components.d.ts
+++ b/admin/frontend/components.d.ts
@@ -8,6 +8,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    AdvancedSetup: typeof import('./src/components/AdvancedSetup.vue')['default']
     AppLayout: typeof import('./src/components/AppLayout.vue')['default']
     AppSidebar: typeof import('./src/components/AppSidebar.vue')['default']
     FilePickerField: typeof import('./src/components/FilePickerField.vue')['default']

--- a/admin/frontend/src/App.vue
+++ b/admin/frontend/src/App.vue
@@ -3,7 +3,6 @@ import { ref, onMounted } from 'vue'
 import AppLayout from './components/AppLayout.vue'
 import Login from './pages/Login.vue'
 import Setup from './pages/Setup.vue'
-import { Alert } from 'frappe-ui'
 import { Alert, useTheme } from 'frappe-ui'
 
 const { initializeTheme } = useTheme()

--- a/admin/frontend/src/App.vue
+++ b/admin/frontend/src/App.vue
@@ -2,20 +2,24 @@
 import { ref, onMounted } from 'vue'
 import AppLayout from './components/AppLayout.vue'
 import Login from './pages/Login.vue'
+import Setup from './pages/Setup.vue'
 import { Alert } from 'frappe-ui'
 
+const loading = ref(true)
 const adminEnabled = ref(true)
 const adminError = ref('')
-const authenticated = ref(true)
+const authenticated = ref(false)
 const benchName = ref('')
+const wizardMode = ref(false)
 
 async function loadStatus() {
   const response = await fetch('/api/status')
   const data = await response.json()
+  wizardMode.value = data.wizard === true
   adminEnabled.value = data.enabled !== false
   authenticated.value = data.authenticated !== false
   benchName.value = data.name ?? ''
-  if (!adminEnabled.value) {
+  if (!wizardMode.value && !adminEnabled.value) {
     adminError.value = data.error || 'Admin is disabled in bench.toml'
   }
 }
@@ -25,12 +29,22 @@ onMounted(async () => {
     await loadStatus()
   } catch {
     adminError.value = 'Could not reach the bench admin server.'
+  } finally {
+    loading.value = false
   }
 })
+
+function onSetupDone() {
+  // Bench is now initialized and admin requires a password.
+  // Reload so the fresh status routes the user through the login page.
+  window.location.reload()
+}
 </script>
 
 <template>
-  <div v-if="adminError" class="flex h-screen items-center justify-center p-8">
+  <div v-if="loading" class="flex h-screen items-center justify-center bg-surface-gray-2" />
+  <Setup v-else-if="wizardMode" @done="onSetupDone" />
+  <div v-else-if="adminError" class="flex h-screen items-center justify-center p-8">
     <Alert theme="red" title="Admin Unavailable" :description="adminError" />
   </div>
   <Login v-else-if="!authenticated" :bench-name="benchName" @authenticated="authenticated = true" />

--- a/admin/frontend/src/components/AdvancedSetup.vue
+++ b/admin/frontend/src/components/AdvancedSetup.vue
@@ -1,0 +1,54 @@
+<script setup>
+import { ref } from 'vue'
+import { TextInput, FormControl, FormLabel } from 'frappe-ui'
+import LucideChevronRight from '~icons/lucide/chevron-right'
+
+const form = defineModel({ type: Object, required: true })
+const open = ref(false)
+
+const generalFields = [
+  { key: 'app_repo', label: 'Frappe repository' },
+  { key: 'http_port', label: 'HTTP port', type: 'number' },
+  { key: 'socketio_port', label: 'Socket.IO port', type: 'number' },
+  { key: 'redis_port', label: 'Redis port', type: 'number' },
+]
+
+const workerFields = [
+  { key: 'workers_default', label: 'Default' },
+  { key: 'workers_short', label: 'Short' },
+  { key: 'workers_long', label: 'Long' },
+]
+</script>
+
+<template>
+  <div class="rounded-lg border border-outline-gray-2">
+    <button
+      type="button"
+      class="flex w-full items-center gap-1.5 px-3 py-2 text-sm font-medium text-ink-gray-6"
+      @click="open = !open"
+    >
+      <LucideChevronRight class="h-4 w-4 transition-transform" :class="{ 'rotate-90': open }" />
+      Advanced
+    </button>
+
+    <div v-if="open" class="flex flex-col gap-4 border-t border-outline-gray-2 p-3">
+      <FormControl
+        v-for="field in generalFields"
+        :key="field.key"
+        :label="field.label"
+        :type="field.type || 'text'"
+        v-model="form[field.key]"
+      />
+
+      <div class="space-y-1.5">
+        <FormLabel label="Workers" />
+        <div class="grid grid-cols-3 gap-2">
+          <div v-for="field in workerFields" :key="field.key" class="space-y-1">
+            <FormLabel :label="field.label" />
+            <TextInput v-model="form[field.key]" type="number" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/admin/frontend/src/index.css
+++ b/admin/frontend/src/index.css
@@ -6,3 +6,11 @@ html {
 .dialog-overlay {
   z-index: 50;
 }
+
+/* @tailwindcss/forms sets appearance:none on all inputs, which strips the system font Safari
+   uses to render password masking bullets — they appear as boxes without this override.
+   We are doing to for safari compatibility!
+   */
+input[type='password'] {
+  font-family: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+}

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -1,0 +1,299 @@
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { Button, FormControl, FormLabel, Password, Switch, ErrorMessage } from 'frappe-ui'
+import AdvancedSetup from '../components/AdvancedSetup.vue'
+import TerminalOutput from '../components/TerminalOutput.vue'
+import { processLine } from '../utils/ansi.js'
+
+const emit = defineEmits(['done'])
+
+const step = ref('passwords')
+const error = ref('')
+const loading = ref(false)
+const taskLines = ref([])
+const taskStreaming = ref(false)
+const terminal = ref(null)
+const benchName = ref('')
+
+const form = ref({
+  python: '3.14',
+  sudo_password: '',
+  mariadb_password: '',
+  admin_password: '',
+  app_repo: 'https://github.com/frappe/frappe',
+  app_branch: 'version-16',
+  http_port: 8000,
+  socketio_port: 9000,
+  redis_port: 13000,
+  workers_default: 2,
+  workers_short: 1,
+  workers_long: 1,
+  volume_enabled: false,
+  volume_pool: '',
+  volume_device: '',
+  volume_benches_reservation: '10G',
+  volume_benches_quota: '50G',
+  volume_mariadb_reservation: '5G',
+  volume_mariadb_quota: '20G',
+  volume_mariadb_data_dir: '/var/lib/mysql',
+  volume_snapshots_enabled: false,
+})
+
+const siteForm = ref({ name: 'site1.localhost', admin_password: 'admin' })
+
+const configSteps = ['passwords', 'customize', 'volume']
+const stepNumber = computed(() => configSteps.indexOf(step.value) + 1)
+const isConfiguring = computed(() => stepNumber.value > 0)
+const isTerminal = computed(() => step.value === 'running' || step.value === 'site-running')
+const isWide = computed(() => isTerminal.value)
+
+const titles = {
+  passwords: 'Set up passwords',
+  customize: 'Customize your bench',
+  volume: 'ZFS volume management',
+  running: 'Initializing bench…',
+  'create-site': 'Create your first site',
+  'site-running': 'Creating site…',
+}
+const subtitles = {
+  volume: 'Optional — leave disabled to skip',
+}
+const title = computed(() => titles[step.value] || benchName.value)
+const subtitle = computed(() => subtitles[step.value] || null)
+
+onMounted(loadConfig)
+
+async function loadConfig() {
+  try {
+    const res = await fetch('/api/setup/config')
+    const data = await res.json()
+    benchName.value = data.bench_name || ''
+    for (const key of Object.keys(form.value)) {
+      if (data[key] !== undefined) form.value[key] = data[key]
+    }
+  } catch {}
+}
+
+async function postJson(url, body) {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return res.json()
+}
+
+function streamTask(url, onDone) {
+  taskLines.value = []
+  taskStreaming.value = true
+  const source = new EventSource(url)
+  source.onmessage = (e) => {
+    taskLines.value.push(processLine(e.data))
+    terminal.value?.scrollToBottom()
+  }
+  source.addEventListener('done', (e) => {
+    taskStreaming.value = false
+    source.close()
+    onDone(parseInt(e.data) === 0)
+  })
+  source.onerror = () => {
+    taskStreaming.value = false
+    source.close()
+    error.value = 'Lost connection to task stream.'
+  }
+}
+
+function nextStep() {
+  if (step.value === 'passwords' && (!form.value.mariadb_password || !form.value.admin_password)) {
+    error.value = 'MariaDB and admin passwords are required.'
+    return
+  }
+  error.value = ''
+  step.value = configSteps[configSteps.indexOf(step.value) + 1]
+}
+
+function prevStep() {
+  error.value = ''
+  step.value = configSteps[configSteps.indexOf(step.value) - 1]
+}
+
+async function saveConfig() {
+  const data = await postJson('/api/setup/save', form.value)
+  if (!data.ok) throw new Error(data.error || 'Failed to save configuration.')
+}
+
+async function startInitTask() {
+  const data = await postJson('/api/setup/init', { sudo_password: form.value.sudo_password })
+  if (!data.ok) throw new Error(data.error || 'Failed to start initialization.')
+  return data.task_id
+}
+
+async function startSiteTask() {
+  const data = await postJson('/api/setup/new-site', {
+    name: siteForm.value.name,
+    admin_password: siteForm.value.admin_password,
+  })
+  if (!data.ok) throw new Error(data.error || 'Failed to create site.')
+  return data.task_id
+}
+
+async function initialize() {
+  error.value = ''
+  loading.value = true
+  try {
+    await saveConfig()
+    const taskId = await startInitTask()
+    step.value = 'running'
+    streamTask(`/api/setup/stream/${taskId}`, onInitDone)
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+function onInitDone(success) {
+  if (!success) {
+    error.value = 'Initialization failed. Check the output above and try again.'
+    return
+  }
+  step.value = 'create-site'
+}
+
+async function createSite() {
+  if (!siteForm.value.name) {
+    error.value = 'Site name is required.'
+    return
+  }
+  error.value = ''
+  loading.value = true
+  try {
+    const taskId = await startSiteTask()
+    step.value = 'site-running'
+    streamTask(`/api/setup/stream/${taskId}`, onSiteDone)
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    loading.value = false
+  }
+}
+
+function onSiteDone(success) {
+  if (!success) {
+    error.value = 'Site creation failed. Check the output above.'
+    return
+  }
+  emit('done')
+}
+
+function backToConfig() {
+  error.value = ''
+  step.value = step.value === 'site-running' ? 'create-site' : 'volume'
+}
+</script>
+
+<template>
+  <div class="flex h-screen items-center justify-center bg-surface-gray-2 p-4">
+    <div
+      class="flex w-full flex-col rounded-xl border border-outline-gray-2 bg-surface-white shadow-sm"
+      :class="isWide ? 'max-w-2xl' : 'max-w-sm'"
+      style="max-height: calc(100vh - 2rem)"
+    >
+      <!-- Header -->
+      <div class="border-b border-outline-gray-2 px-5 py-4">
+        <p v-if="isConfiguring" class="mb-1 text-xs text-ink-gray-4">
+          {{ benchName }} · Step {{ stepNumber }} of {{ configSteps.length }}
+        </p>
+        <h1 class="text-base font-medium text-ink-gray-7">{{ title }}</h1>
+        <p v-if="subtitle" class="mt-0.5 text-sm text-ink-gray-4">{{ subtitle }}</p>
+      </div>
+
+      <!-- Body -->
+      <div class="flex-1 overflow-y-auto p-5">
+        <div v-if="step === 'passwords'" class="flex flex-col gap-4">
+          <div class="space-y-1.5">
+            <FormLabel label="Sudo password" />
+            <Password v-model="form.sudo_password" placeholder="Used once to install system packages" />
+          </div>
+          <div class="space-y-1.5">
+            <FormLabel label="MariaDB root password" />
+            <Password v-model="form.mariadb_password" placeholder="root" />
+          </div>
+          <div class="space-y-1.5">
+            <FormLabel label="Admin password" />
+            <Password v-model="form.admin_password" placeholder="Choose a password" @keydown.enter="nextStep" />
+          </div>
+          <ErrorMessage v-if="error" :message="error" />
+        </div>
+
+        <div v-else-if="step === 'customize'" class="flex flex-col gap-4">
+          <FormControl label="Python version" v-model="form.python" placeholder="3.14" />
+          <FormControl label="Frappe branch" v-model="form.app_branch" placeholder="version-16" />
+          <AdvancedSetup v-model="form" />
+          <ErrorMessage v-if="error" :message="error" />
+        </div>
+
+        <div v-else-if="step === 'volume'" class="flex flex-col gap-4">
+          <Switch
+            v-model="form.volume_enabled"
+            label="Enable ZFS volume management"
+            description="Isolates bench and MariaDB data in ZFS datasets with quotas. Pool and device cannot be changed after initialization."
+          />
+          <template v-if="form.volume_enabled">
+            <div class="grid grid-cols-2 gap-2">
+              <FormControl label="Pool name" v-model="form.volume_pool" placeholder="bench-pool" />
+              <FormControl label="Block device" v-model="form.volume_device" placeholder="/dev/sdb" />
+            </div>
+            <div class="grid grid-cols-2 gap-2">
+              <FormControl label="Bench reservation" v-model="form.volume_benches_reservation" />
+              <FormControl label="Bench quota" v-model="form.volume_benches_quota" />
+            </div>
+            <div class="grid grid-cols-2 gap-2">
+              <FormControl label="MariaDB reservation" v-model="form.volume_mariadb_reservation" />
+              <FormControl label="MariaDB quota" v-model="form.volume_mariadb_quota" />
+            </div>
+            <FormControl label="MariaDB data directory" v-model="form.volume_mariadb_data_dir" />
+            <Switch v-model="form.volume_snapshots_enabled" label="Enable snapshots" />
+          </template>
+          <ErrorMessage v-if="error" :message="error" />
+        </div>
+
+        <div v-else-if="isTerminal" class="flex flex-col gap-3">
+          <TerminalOutput ref="terminal" :lines="taskLines" :streaming="taskStreaming" />
+          <ErrorMessage v-if="error" :message="error" />
+        </div>
+
+        <div v-else-if="step === 'create-site'" class="flex flex-col gap-4">
+          <FormControl label="Site name" v-model="siteForm.name" placeholder="site1.localhost" />
+          <div class="space-y-1.5">
+            <FormLabel label="Site admin password" />
+            <Password v-model="siteForm.admin_password" placeholder="admin" @keydown.enter="createSite" />
+          </div>
+          <ErrorMessage v-if="error" :message="error" />
+        </div>
+      </div>
+
+      <!-- Footer -->
+      <div v-if="!isTerminal || error" class="flex gap-2 border-t border-outline-gray-2 px-5 py-4">
+        <Button v-if="step === 'customize' || step === 'volume'" variant="subtle" class="flex-1" @click="prevStep">
+          Back
+        </Button>
+        <Button v-if="isTerminal && error" variant="subtle" class="w-full" @click="backToConfig">
+          Back to configuration
+        </Button>
+        <Button v-else-if="step === 'passwords'" variant="solid" class="w-full" @click="nextStep">
+          Next
+        </Button>
+        <Button v-else-if="step === 'customize'" variant="solid" class="flex-1" @click="nextStep">
+          Next
+        </Button>
+        <Button v-else-if="step === 'volume'" variant="solid" :loading="loading" class="flex-1" @click="initialize">
+          Initialize
+        </Button>
+        <Button v-else-if="step === 'create-site'" variant="solid" :loading="loading" class="w-full" @click="createSite">
+          Create Site
+        </Button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -1,7 +1,6 @@
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { Button, FormControl, FormLabel, Password, Switch, ErrorMessage } from 'frappe-ui'
-import AdvancedSetup from '../components/AdvancedSetup.vue'
+import { Button, FormControl, FormLabel, Password, Switch, ErrorMessage, TextInput } from 'frappe-ui'
 import TerminalOutput from '../components/TerminalOutput.vue'
 import { processLine } from '../utils/ansi.js'
 
@@ -14,6 +13,7 @@ const taskLines = ref([])
 const taskStreaming = ref(false)
 const terminal = ref(null)
 const benchName = ref('')
+const isLinux = ref(true)
 
 const form = ref({
   python: '3.14',
@@ -41,8 +41,10 @@ const form = ref({
 
 const siteForm = ref({ name: 'site1.localhost', admin_password: 'admin' })
 
-const configSteps = ['passwords', 'customize', 'volume']
-const stepNumber = computed(() => configSteps.indexOf(step.value) + 1)
+const configSteps = computed(() =>
+  isLinux.value ? ['passwords', 'customize', 'volume'] : ['passwords', 'customize']
+)
+const stepNumber = computed(() => configSteps.value.indexOf(step.value) + 1)
 const isConfiguring = computed(() => stepNumber.value > 0)
 const isTerminal = computed(() => step.value === 'running' || step.value === 'site-running')
 const isWide = computed(() => isTerminal.value)
@@ -68,8 +70,13 @@ async function loadConfig() {
     const res = await fetch('/api/setup/config')
     const data = await res.json()
     benchName.value = data.bench_name || ''
+    isLinux.value = data.is_linux !== false
     for (const key of Object.keys(form.value)) {
       if (data[key] !== undefined) form.value[key] = data[key]
+    }
+    if (data.running_init_task_id) {
+      step.value = 'running'
+      streamTask(`/api/setup/stream/${data.running_init_task_id}`, onInitDone)
     }
   } catch {}
 }
@@ -109,12 +116,12 @@ function nextStep() {
     return
   }
   error.value = ''
-  step.value = configSteps[configSteps.indexOf(step.value) + 1]
+  step.value = configSteps.value[configSteps.value.indexOf(step.value) + 1]
 }
 
 function prevStep() {
   error.value = ''
-  step.value = configSteps[configSteps.indexOf(step.value) - 1]
+  step.value = configSteps.value[configSteps.value.indexOf(step.value) - 1]
 }
 
 async function saveConfig() {
@@ -188,7 +195,7 @@ function onSiteDone(success) {
 
 function backToConfig() {
   error.value = ''
-  step.value = step.value === 'site-running' ? 'create-site' : 'volume'
+  step.value = step.value === 'site-running' ? 'create-site' : configSteps.value[configSteps.value.length - 1]
 }
 </script>
 
@@ -229,7 +236,29 @@ function backToConfig() {
         <div v-else-if="step === 'customize'" class="flex flex-col gap-4">
           <FormControl label="Python version" v-model="form.python" placeholder="3.14" />
           <FormControl label="Frappe branch" v-model="form.app_branch" placeholder="version-16" />
-          <AdvancedSetup v-model="form" />
+          <FormControl label="Frappe repository" v-model="form.app_repo" />
+          <div class="grid grid-cols-3 gap-2">
+            <FormControl label="HTTP port" v-model="form.http_port" type="number" />
+            <FormControl label="Socket.IO port" v-model="form.socketio_port" type="number" />
+            <FormControl label="Redis port" v-model="form.redis_port" type="number" />
+          </div>
+          <div class="space-y-1.5">
+            <FormLabel label="Workers" />
+            <div class="grid grid-cols-3 gap-2">
+              <div class="space-y-1">
+                <FormLabel label="Default" />
+                <TextInput v-model="form.workers_default" type="number" />
+              </div>
+              <div class="space-y-1">
+                <FormLabel label="Short" />
+                <TextInput v-model="form.workers_short" type="number" />
+              </div>
+              <div class="space-y-1">
+                <FormLabel label="Long" />
+                <TextInput v-model="form.workers_long" type="number" />
+              </div>
+            </div>
+          </div>
           <ErrorMessage v-if="error" :message="error" />
         </div>
 
@@ -275,7 +304,7 @@ function backToConfig() {
 
       <!-- Footer -->
       <div v-if="!isTerminal || error" class="flex gap-2 border-t border-outline-gray-2 px-5 py-4">
-        <Button v-if="step === 'customize' || step === 'volume'" variant="subtle" class="flex-1" @click="prevStep">
+        <Button v-if="stepNumber > 1 && isConfiguring" variant="subtle" class="flex-1" @click="prevStep">
           Back
         </Button>
         <Button v-if="isTerminal && error" variant="subtle" class="w-full" @click="backToConfig">
@@ -284,10 +313,10 @@ function backToConfig() {
         <Button v-else-if="step === 'passwords'" variant="solid" class="w-full" @click="nextStep">
           Next
         </Button>
-        <Button v-else-if="step === 'customize'" variant="solid" class="flex-1" @click="nextStep">
+        <Button v-else-if="step !== configSteps[configSteps.length - 1] && isConfiguring" variant="solid" class="flex-1" @click="nextStep">
           Next
         </Button>
-        <Button v-else-if="step === 'volume'" variant="solid" :loading="loading" class="flex-1" @click="initialize">
+        <Button v-else-if="isConfiguring" variant="solid" :loading="loading" class="flex-1" @click="initialize">
           Initialize
         </Button>
         <template v-else-if="step === 'create-site'">

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -202,7 +202,7 @@ function backToConfig() {
       <!-- Header -->
       <div class="border-b border-outline-gray-2 px-5 py-4">
         <p v-if="isConfiguring" class="mb-1 text-xs text-ink-gray-4">
-          {{ benchName }} · Step {{ stepNumber }} of {{ configSteps.length }}
+          Step {{ stepNumber }} of {{ configSteps.length }}
         </p>
         <h1 class="text-base font-medium text-ink-gray-7">{{ title }}</h1>
         <p v-if="subtitle" class="mt-0.5 text-sm text-ink-gray-4">{{ subtitle }}</p>

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -290,9 +290,14 @@ function backToConfig() {
         <Button v-else-if="step === 'volume'" variant="solid" :loading="loading" class="flex-1" @click="initialize">
           Initialize
         </Button>
-        <Button v-else-if="step === 'create-site'" variant="solid" :loading="loading" class="w-full" @click="createSite">
-          Create Site
-        </Button>
+        <template v-else-if="step === 'create-site'">
+          <Button variant="subtle" class="flex-1" @click="$emit('done')">
+            Go to Dashboard
+          </Button>
+          <Button variant="solid" :loading="loading" class="flex-1" @click="createSite">
+            Create Site
+          </Button>
+        </template>
       </div>
     </div>
   </div>

--- a/bench_cli/cli.py
+++ b/bench_cli/cli.py
@@ -140,7 +140,8 @@ def _make_parser() -> argparse.ArgumentParser:
     p_new = sub.add_parser("new", help="Create a new bench.")
     p_new.add_argument("name", help="Name for the new bench.")
 
-    sub.add_parser("init", help="Initialise the bench.")
+    p_init = sub.add_parser("init", help="Initialise the bench.")
+    p_init.add_argument("--sudo-password", default="", help="Sudo password used once to write /etc/sudoers.d/<user>. Not stored.")
     sub.add_parser("start", help="Start all bench processes.")
     sub.add_parser("stop", help="Stop the running bench.")
     sub.add_parser("restart", help="Restart supervisor processes (production mode only).")
@@ -280,7 +281,7 @@ def _dispatch(args: argparse.Namespace) -> None:
     elif cmd == "init":
         from bench_cli.commands.init import InitCommand
 
-        InitCommand(_load_bench()).run()
+        InitCommand(_load_bench(), sudo_password=args.sudo_password).run()
 
     elif cmd == "start":
         from bench_cli.commands.start import RunCommand

--- a/bench_cli/commands/init.py
+++ b/bench_cli/commands/init.py
@@ -7,15 +7,21 @@ from bench_cli.managers.redis_manager import RedisManager
 
 
 class InitCommand:
-    def __init__(self, bench: Bench) -> None:
+    def __init__(self, bench: Bench, sudo_password: str = "") -> None:
         self.bench = bench
+        self._sudo_password = sudo_password
         self._step_counter = 0
         self._total_steps = 0
 
     def run(self) -> None:
         production = self.bench.config.production.nginx
         volume_enabled = self.bench.config.volume.enabled
-        self._total_steps = 10 + (3 if production else 0) + (1 if volume_enabled else 0)
+        has_sudoers = bool(self._sudo_password)
+        self._total_steps = 10 + (3 if production else 0) + (1 if volume_enabled else 0) + (1 if has_sudoers else 0)
+
+        if has_sudoers:
+            self._step("Configure passwordless sudo")
+            self._setup_sudoers()
 
         self._step("Validate bench.toml")
         self.bench.config.validate()
@@ -77,8 +83,43 @@ class InitCommand:
         self._step_counter += 1
         print(f"[{self._step_counter}/{self._total_steps}] {description}...", flush=True)
 
+    def _setup_sudoers(self) -> None:
+        import getpass
+        import subprocess
+
+        username = getpass.getuser()
+        rules = "\n".join(
+            [
+                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/apt-get",
+                f"{username} ALL=(ALL) NOPASSWD: /usr/sbin/nginx",
+                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/systemctl",
+                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/loginctl",
+                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/ln",
+                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/unlink",
+                f"{username} ALL=(ALL) NOPASSWD: /usr/sbin/zpool",
+                f"{username} ALL=(ALL) NOPASSWD: /usr/sbin/zfs",
+                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/rsync",
+            ]
+        )
+        content = f"# Frappe bench — managed by bench init, do not edit\n{rules}\n"
+        sudoers_path = f"/etc/sudoers.d/{username}"
+        result = subprocess.run(
+            ["sudo", "-S", "tee", sudoers_path],
+            input=f"{self._sudo_password}\n{content}",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            print(f"  Warning: could not write sudoers file — {result.stderr.strip() or 'permission denied'}")
+            print("  Sudo operations may prompt for a password during setup.")
+            return
+        subprocess.run(["sudo", "chmod", "0440", sudoers_path], capture_output=True, check=False)
+        print(f"  Wrote {sudoers_path}")
+
     def _download_admin_frontend(self) -> None:
         from bench_cli.commands.admin import download_admin_frontend, BuildAdminCommand, _cli_root
+
         if not download_admin_frontend(_cli_root()):
             print("  Pre-built download failed — building from source (requires Node.js)...")
             BuildAdminCommand().run()
@@ -123,15 +164,18 @@ class InitCommand:
     def _setup_process_manager(self) -> None:
         if self.bench.config.production.lightweight:
             from bench_cli.managers.systemd_process_manager import SystemdProcessManager
+
             mgr = SystemdProcessManager(self.bench)
         else:
             import subprocess
             from bench_cli.platform import get_package_manager, is_linux
+
             pkg = get_package_manager()
             if is_linux() and not pkg.is_installed("supervisor"):
                 pkg.install("supervisor")
                 subprocess.run(["sudo", "systemctl", "disable", "--now", "supervisor"], check=False)
             from bench_cli.managers.supervisor_process_manager import SupervisorProcessManager
+
             mgr = SupervisorProcessManager(self.bench)
         mgr.install_config()
         mgr.reload()

--- a/bench_cli/commands/init.py
+++ b/bench_cli/commands/init.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+import shutil
+from collections.abc import Callable
+
 from bench_cli.core.bench import Bench
 from bench_cli.managers.process_manager import ProcessManagerFactory
 from bench_cli.managers.python_env_manager import PythonEnvManager
 from bench_cli.managers.redis_manager import RedisManager
+
+_BENCH_DIRS = ("apps", "sites", "logs", "config", "pids", "env", "admin", "tasks")
 
 
 class InitCommand:
@@ -12,8 +17,74 @@ class InitCommand:
         self._sudo_password = sudo_password
         self._step_counter = 0
         self._total_steps = 0
+        self._rollback_actions: list[tuple[str, Callable[[], None]]] = []
 
     def run(self) -> None:
+        try:
+            self._do_run()
+        except Exception as exc:
+            print(f"\nError: {exc}", flush=True)
+            self._rollback()
+            raise
+
+    # ── rollback infrastructure ────────────────────────────────────────────
+
+    def _on_rollback(self, label: str, fn: Callable[[], None]) -> None:
+        self._rollback_actions.append((label, fn))
+
+    def _rollback(self) -> None:
+        if not self._rollback_actions:
+            return
+        print("\nRolling back changes...", flush=True)
+        for label, fn in reversed(self._rollback_actions):
+            print(f"  Removing {label}...", flush=True)
+            try:
+                fn()
+            except Exception as e:
+                print(f"    Warning: rollback step failed — {e}", flush=True)
+        print(
+            "\nRollback complete. bench.toml is preserved — fix the issue and run init again.",
+            flush=True,
+        )
+
+    def _remove_bench_dirs(self) -> None:
+        for name in _BENCH_DIRS:
+            p = self.bench.path / name
+            if p.exists() or p.is_symlink():
+                shutil.rmtree(p, ignore_errors=True)
+
+    def _remove_sudoers(self) -> None:
+        import getpass
+        import subprocess
+
+        path = f"/etc/sudoers.d/{getpass.getuser()}"
+        subprocess.run(["sudo", "rm", "-f", path], capture_output=True, check=False)
+
+    def _remove_nginx_symlink(self) -> None:
+        import subprocess
+
+        symlink = self.bench.config.nginx.config_dir / f"{self.bench.config.name}.conf"
+        if symlink.exists() or symlink.is_symlink():
+            subprocess.run(["sudo", "unlink", str(symlink)], capture_output=True, check=False)
+
+    def _remove_systemd_units(self) -> None:
+        import subprocess
+
+        from bench_cli.managers.systemd_process_manager import SystemdProcessManager
+
+        mgr = SystemdProcessManager(self.bench)
+        for f in mgr.user_unit_dir.glob(f"{self.bench.config.name}*"):
+            f.unlink(missing_ok=True)
+        subprocess.run(
+            ["systemctl", "--user", "daemon-reload"],
+            capture_output=True,
+            check=False,
+            env=mgr._systemctl_env(),
+        )
+
+    # ── init steps ─────────────────────────────────────────────────────────
+
+    def _do_run(self) -> None:
         production = self.bench.config.production.nginx
         volume_enabled = self.bench.config.volume.enabled
         has_sudoers = bool(self._sudo_password)
@@ -36,6 +107,7 @@ class InitCommand:
         self._step("Create bench directory structure")
         self.bench.create_directories()
         self.bench.write_common_site_config()
+        self._on_rollback("bench directories", self._remove_bench_dirs)
 
         self._step("Create Python virtualenv")
         python_env_manager = PythonEnvManager(self.bench)
@@ -88,19 +160,17 @@ class InitCommand:
         import subprocess
 
         username = getpass.getuser()
-        rules = "\n".join(
-            [
-                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/apt-get",
-                f"{username} ALL=(ALL) NOPASSWD: /usr/sbin/nginx",
-                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/systemctl",
-                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/loginctl",
-                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/ln",
-                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/unlink",
-                f"{username} ALL=(ALL) NOPASSWD: /usr/sbin/zpool",
-                f"{username} ALL=(ALL) NOPASSWD: /usr/sbin/zfs",
-                f"{username} ALL=(ALL) NOPASSWD: /usr/bin/rsync",
-            ]
-        )
+        rules = "\n".join([
+            f"{username} ALL=(ALL) NOPASSWD: /usr/bin/apt-get",
+            f"{username} ALL=(ALL) NOPASSWD: /usr/sbin/nginx",
+            f"{username} ALL=(ALL) NOPASSWD: /usr/bin/systemctl",
+            f"{username} ALL=(ALL) NOPASSWD: /usr/bin/loginctl",
+            f"{username} ALL=(ALL) NOPASSWD: /usr/bin/ln",
+            f"{username} ALL=(ALL) NOPASSWD: /usr/bin/unlink",
+            f"{username} ALL=(ALL) NOPASSWD: /usr/sbin/zpool",
+            f"{username} ALL=(ALL) NOPASSWD: /usr/sbin/zfs",
+            f"{username} ALL=(ALL) NOPASSWD: /usr/bin/rsync",
+        ])
         content = f"# Frappe bench — managed by bench init, do not edit\n{rules}\n"
         sudoers_path = f"/etc/sudoers.d/{username}"
         result = subprocess.run(
@@ -116,9 +186,10 @@ class InitCommand:
             return
         subprocess.run(["sudo", "chmod", "0440", sudoers_path], capture_output=True, check=False)
         print(f"  Wrote {sudoers_path}")
+        self._on_rollback(sudoers_path, self._remove_sudoers)
 
     def _download_admin_frontend(self) -> None:
-        from bench_cli.commands.admin import download_admin_frontend, BuildAdminCommand, _cli_root
+        from bench_cli.commands.admin import BuildAdminCommand, _cli_root, download_admin_frontend
 
         if not download_admin_frontend(_cli_root()):
             print("  Pre-built download failed — building from source (requires Node.js)...")
@@ -166,6 +237,9 @@ class InitCommand:
             from bench_cli.managers.systemd_process_manager import SystemdProcessManager
 
             mgr = SystemdProcessManager(self.bench)
+            mgr.install_config()
+            mgr.reload()
+            self._on_rollback("systemd user units", self._remove_systemd_units)
         else:
             import subprocess
             from bench_cli.platform import get_package_manager, is_linux
@@ -177,13 +251,15 @@ class InitCommand:
             from bench_cli.managers.supervisor_process_manager import SupervisorProcessManager
 
             mgr = SupervisorProcessManager(self.bench)
-        mgr.install_config()
-        mgr.reload()
+            mgr.install_config()
+            mgr.reload()
+            # supervisor config lives inside config/ — _remove_bench_dirs handles it
 
     def _setup_nginx(self) -> None:
         from bench_cli.commands.setup.nginx import SetupNginxCommand
 
         SetupNginxCommand(self.bench).run()
+        self._on_rollback("nginx config symlink", self._remove_nginx_symlink)
 
     def _setup_letsencrypt(self) -> None:
         if not self.bench.config.letsencrypt.email:

--- a/bench_cli/commands/new.py
+++ b/bench_cli/commands/new.py
@@ -1,76 +1,8 @@
 import secrets
 from pathlib import Path
 
+from bench_cli.config.bench_toml_builder import BenchTomlBuilder
 from bench_cli.exceptions import BenchError
-
-_BENCH_TOML_TEMPLATE = """\
-[bench]
-name = "{name}"
-python = "3.14"
-
-[[apps]]
-name = "frappe"
-repo = "https://github.com/frappe/frappe"
-branch = "version-16"
-
-[mariadb]
-host = "localhost"
-port = 3306
-root_password = "root"
-# version = "10.6"
-
-[redis]
-port = 13000
-# or use separate ports:
-# cache_port = 13000
-# queue_port = 11000
-# socketio_port = 12000
-
-[workers]
-default = 2
-short = 1
-long = 1
-
-# [[workers.custom]]
-# queue = "backup"
-# count = 2
-# timeout = 3600
-
-[admin]
-port = 8002
-enabled = false
-timeout = 180
-password = "{admin_password}"
-
-# ── Production (optional) ─────────────────────────────────────────────────
-# Uncomment to enable production mode (nginx + process manager).
-# Without this section, 'bench start' uses Procfile-based dev mode.
-#
-# [production]
-# nginx = false          # enable nginx reverse proxy
-# lightweight = true   # true = systemd (lower memory), false = supervisor
-
-# ── Volume (ZFS, optional) ────────────────────────────────────────────────
-# Uncomment and configure to use ZFS-based volume management.
-# Requires Linux and the zfsutils-linux package.
-#
-# [volume]
-# enabled = false
-# pool = "bench-pool"       # ZFS pool name (created on first bench init)
-# device = "/dev/sdb"       # block device to use for the pool
-#
-# [volume.benches]
-# reservation = "10G"       # guaranteed space for bench directories
-# quota = "50G"             # hard cap on bench directory space
-#
-# [volume.mariadb]
-# reservation = "5G"        # guaranteed space for MariaDB data files
-# quota = "20G"             # hard cap on MariaDB data space
-# data_dir = "/var/lib/mysql"
-#
-# [volume.snapshots]
-# enabled = false           # set to true to enable bench volume snapshot
-"""
 
 
 class NewCommand:
@@ -92,16 +24,11 @@ class NewCommand:
         self.target_directory.mkdir(parents=True, exist_ok=True)
 
         print("Writing bench.toml")
-        bench_toml.write_text(_BENCH_TOML_TEMPLATE.format(name=self.name, admin_password=secrets.token_hex(nbytes=5)))
+        settings = {"admin_password": secrets.token_hex(nbytes=5)}
+        bench_toml.write_text(BenchTomlBuilder(self.name, settings).render())
 
         print(f"\nBench '{self.name}' created at {self.target_directory}")
-        print("\nNext steps:")
-        print(f"  1. Edit the config:  {bench_toml}")
-        print("  2. Run:              bench init")
-        print("  3. Create a site:    bench new-site site1.localhost")
-        print()
-        print("ZFS volume management (optional):")
-        print("  If you have a spare block device, uncomment the [volume] section in bench.toml")
-        print("  and choose a ZFS preset (pool, device, quotas) before running bench init.")
-        print("  Volume setup runs as part of bench init and cannot be configured after that.")
-        print("  Skip this entirely if no dedicated storage device is available.")
+        print("\nNext step:")
+        print("  bench start")
+        print("  Open http://localhost:8002 — the setup wizard guides you through the rest,")
+        print("  including ZFS volume management under Advanced settings.")

--- a/bench_cli/commands/restart.py
+++ b/bench_cli/commands/restart.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from bench_cli.core.bench import Bench
-from bench_cli.exceptions import BenchError
+from bench_cli.managers.process_manager import ProcessManagerFactory
 
 
 class RestartCommand:
@@ -9,23 +9,7 @@ class RestartCommand:
         self.bench = bench
 
     def run(self) -> None:
-        manager = self._detect_manager()
+        manager = ProcessManagerFactory.detect_running(self.bench)
         manager.generate_config()
         manager.reload()
         manager.restart()
-
-    def _detect_manager(self):
-        from bench_cli.managers.supervisor_process_manager import SupervisorProcessManager
-        from bench_cli.managers.systemd_process_manager import SystemdProcessManager
-
-        supervisor = SupervisorProcessManager(self.bench)
-        if supervisor.supervisor_conf_path.exists():
-            return supervisor
-
-        systemd = SystemdProcessManager(self.bench)
-        if systemd.is_configured():
-            return systemd
-
-        raise BenchError(
-            "No production process manager found. Run 'bench setup production' first."
-        )

--- a/bench_cli/commands/start.py
+++ b/bench_cli/commands/start.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import tomllib
+
 from bench_cli.core.bench import Bench
 from bench_cli.managers.process_manager import ProcessManagerFactory
 
@@ -9,4 +13,39 @@ class RunCommand:
         self.bench = bench
 
     def run(self) -> None:
-        ProcessManagerFactory.create(self.bench).start()
+        if not (self.bench.path / "env" / "bin" / "python").exists():
+            self._start_wizard()
+        else:
+            ProcessManagerFactory.create(self.bench).start()
+
+    def _start_wizard(self) -> None:
+        from bench_cli.managers.admin_env_manager import AdminEnvManager
+        from bench_cli.commands.admin import download_admin_frontend, _cli_root
+
+        cli_root = _cli_root()
+        admin_mgr = AdminEnvManager(cli_root)
+        admin_mgr.ensure()
+
+        dist = cli_root / "admin" / "backend" / "static" / "dist"
+        if not dist.exists():
+            print("Downloading admin frontend...")
+            download_admin_frontend(cli_root)
+
+        port = self._admin_port()
+        print("\nBench not initialized. Starting setup wizard...")
+        print(f"  Open http://localhost:{port} in your browser\n")
+
+        env = {**os.environ, "PYTHONPATH": str(cli_root)}
+        subprocess.run([
+            str(admin_mgr.python), "-m", "admin.backend.server",
+            "--bench-root", str(self.bench.path),
+            "--port", str(port),
+            "--timeout", "7200",
+        ], env=env)
+
+    def _admin_port(self) -> int:
+        try:
+            with open(self.bench.path / "bench.toml", "rb") as f:
+                return tomllib.load(f).get("admin", {}).get("port", 8002)
+        except Exception:
+            return 8002

--- a/bench_cli/commands/stop.py
+++ b/bench_cli/commands/stop.py
@@ -9,5 +9,5 @@ class StopCommand:
         self.bench = bench
 
     def run(self) -> None:
-        ProcessManagerFactory.create(self.bench).stop()
+        ProcessManagerFactory.detect_running(self.bench).stop()
         print("Bench stopped.")

--- a/bench_cli/config/bench_toml_builder.py
+++ b/bench_cli/config/bench_toml_builder.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+_BASE_TEMPLATE = """\
+[bench]
+name = "{name}"
+python = "{python}"
+http_port = {http_port}
+socketio_port = {socketio_port}
+
+[[apps]]
+name = "frappe"
+repo = "{app_repo}"
+branch = "{app_branch}"
+
+[mariadb]
+host = "localhost"
+port = 3306
+root_password = "{mariadb_password}"
+
+[redis]
+port = {redis_port}
+
+[workers]
+default = {workers_default}
+short = {workers_short}
+long = {workers_long}
+
+[admin]
+port = {admin_port}
+enabled = {admin_enabled}
+timeout = 180
+password = "{admin_password}"
+"""
+
+_VOLUME_TEMPLATE = """
+[volume]
+enabled = true
+pool = "{volume_pool}"
+device = "{volume_device}"
+
+[volume.benches]
+reservation = "{volume_benches_reservation}"
+quota = "{volume_benches_quota}"
+
+[volume.mariadb]
+reservation = "{volume_mariadb_reservation}"
+quota = "{volume_mariadb_quota}"
+data_dir = "{volume_mariadb_data_dir}"
+
+[volume.snapshots]
+enabled = {volume_snapshots_enabled}
+"""
+
+
+def _toml_bool(value: object) -> str:
+    return "true" if value else "false"
+
+
+class BenchTomlBuilder:
+    """Single source of truth for rendering a bench.toml document.
+
+    Used by both `bench new` (starter config) and the setup wizard
+    (config from user-supplied values), so the layout never diverges.
+    """
+
+    def __init__(self, name: str, settings: dict | None = None) -> None:
+        self._name = name
+        self._settings = settings or {}
+
+    def render(self) -> str:
+        content = self._render_base()
+        if self._settings.get("volume_enabled"):
+            content += self._render_volume()
+        return content
+
+    def _render_base(self) -> str:
+        get = self._settings.get
+        return _BASE_TEMPLATE.format(
+            name=self._name,
+            python=get("python", "3.14"),
+            http_port=int(get("http_port", 8000)),
+            socketio_port=int(get("socketio_port", 9000)),
+            app_repo=get("app_repo", "https://github.com/frappe/frappe"),
+            app_branch=get("app_branch", "version-16"),
+            mariadb_password=get("mariadb_password", "root"),
+            redis_port=int(get("redis_port", 13000)),
+            workers_default=int(get("workers_default", 2)),
+            workers_short=int(get("workers_short", 1)),
+            workers_long=int(get("workers_long", 1)),
+            admin_port=int(get("admin_port", 8002)),
+            admin_enabled=_toml_bool(get("admin_enabled", False)),
+            admin_password=get("admin_password", ""),
+        )
+
+    def _render_volume(self) -> str:
+        get = self._settings.get
+        return _VOLUME_TEMPLATE.format(
+            volume_pool=get("volume_pool", ""),
+            volume_device=get("volume_device", ""),
+            volume_benches_reservation=get("volume_benches_reservation", "10G"),
+            volume_benches_quota=get("volume_benches_quota", "50G"),
+            volume_mariadb_reservation=get("volume_mariadb_reservation", "5G"),
+            volume_mariadb_quota=get("volume_mariadb_quota", "20G"),
+            volume_mariadb_data_dir=get("volume_mariadb_data_dir", "/var/lib/mysql"),
+            volume_snapshots_enabled=_toml_bool(get("volume_snapshots_enabled", False)),
+        )

--- a/bench_cli/config/bench_toml_builder.py
+++ b/bench_cli/config/bench_toml_builder.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import tomllib
+from pathlib import Path
+
 _BASE_TEMPLATE = """\
 [bench]
 name = "{name}"
@@ -57,15 +60,40 @@ def _toml_bool(value: object) -> str:
 
 
 class BenchTomlBuilder:
-    """Single source of truth for rendering a bench.toml document.
+    """Single source of truth for bench settings: defaults, rendering, and reading.
 
-    Used by both `bench new` (starter config) and the setup wizard
-    (config from user-supplied values), so the layout never diverges.
+    All three operations share the same key names so adding a field only
+    requires touching this class and the wizard frontend.
     """
+
+    DEFAULTS: dict = {
+        "python": "3.14",
+        "http_port": 8000,
+        "socketio_port": 9000,
+        "app_repo": "https://github.com/frappe/frappe",
+        "app_branch": "version-16",
+        "mariadb_password": "root",
+        "admin_password": "",
+        "admin_port": 8002,
+        "admin_enabled": False,
+        "redis_port": 13000,
+        "workers_default": 2,
+        "workers_short": 1,
+        "workers_long": 1,
+        "volume_enabled": False,
+        "volume_pool": "",
+        "volume_device": "",
+        "volume_benches_reservation": "10G",
+        "volume_benches_quota": "50G",
+        "volume_mariadb_reservation": "5G",
+        "volume_mariadb_quota": "20G",
+        "volume_mariadb_data_dir": "/var/lib/mysql",
+        "volume_snapshots_enabled": False,
+    }
 
     def __init__(self, name: str, settings: dict | None = None) -> None:
         self._name = name
-        self._settings = settings or {}
+        self._settings = {**self.DEFAULTS, **(settings or {})}
 
     def render(self) -> str:
         content = self._render_base()
@@ -74,33 +102,77 @@ class BenchTomlBuilder:
         return content
 
     def _render_base(self) -> str:
-        get = self._settings.get
         return _BASE_TEMPLATE.format(
             name=self._name,
-            python=get("python", "3.14"),
-            http_port=int(get("http_port", 8000)),
-            socketio_port=int(get("socketio_port", 9000)),
-            app_repo=get("app_repo", "https://github.com/frappe/frappe"),
-            app_branch=get("app_branch", "version-16"),
-            mariadb_password=get("mariadb_password", "root"),
-            redis_port=int(get("redis_port", 13000)),
-            workers_default=int(get("workers_default", 2)),
-            workers_short=int(get("workers_short", 1)),
-            workers_long=int(get("workers_long", 1)),
-            admin_port=int(get("admin_port", 8002)),
-            admin_enabled=_toml_bool(get("admin_enabled", False)),
-            admin_password=get("admin_password", ""),
+            python=self._settings["python"],
+            http_port=int(self._settings["http_port"]),
+            socketio_port=int(self._settings["socketio_port"]),
+            app_repo=self._settings["app_repo"],
+            app_branch=self._settings["app_branch"],
+            mariadb_password=self._settings["mariadb_password"],
+            redis_port=int(self._settings["redis_port"]),
+            workers_default=int(self._settings["workers_default"]),
+            workers_short=int(self._settings["workers_short"]),
+            workers_long=int(self._settings["workers_long"]),
+            admin_port=int(self._settings["admin_port"]),
+            admin_enabled=_toml_bool(self._settings["admin_enabled"]),
+            admin_password=self._settings["admin_password"],
         )
 
     def _render_volume(self) -> str:
-        get = self._settings.get
         return _VOLUME_TEMPLATE.format(
-            volume_pool=get("volume_pool", ""),
-            volume_device=get("volume_device", ""),
-            volume_benches_reservation=get("volume_benches_reservation", "10G"),
-            volume_benches_quota=get("volume_benches_quota", "50G"),
-            volume_mariadb_reservation=get("volume_mariadb_reservation", "5G"),
-            volume_mariadb_quota=get("volume_mariadb_quota", "20G"),
-            volume_mariadb_data_dir=get("volume_mariadb_data_dir", "/var/lib/mysql"),
-            volume_snapshots_enabled=_toml_bool(get("volume_snapshots_enabled", False)),
+            volume_pool=self._settings["volume_pool"],
+            volume_device=self._settings["volume_device"],
+            volume_benches_reservation=self._settings["volume_benches_reservation"],
+            volume_benches_quota=self._settings["volume_benches_quota"],
+            volume_mariadb_reservation=self._settings["volume_mariadb_reservation"],
+            volume_mariadb_quota=self._settings["volume_mariadb_quota"],
+            volume_mariadb_data_dir=self._settings["volume_mariadb_data_dir"],
+            volume_snapshots_enabled=_toml_bool(self._settings["volume_snapshots_enabled"]),
         )
+
+    @classmethod
+    def read_settings(cls, toml_path: Path) -> dict:
+        """Read bench.toml into the same flat-dict format as DEFAULTS.
+
+        Missing keys fall back to DEFAULTS. bench_name is included (empty
+        string if bench.name is absent so callers can substitute a path-based
+        fallback).
+        """
+        with open(toml_path, "rb") as f:
+            data = tomllib.load(f)
+
+        d = dict(cls.DEFAULTS)
+        bench = data.get("bench", {})
+        app = (data.get("apps") or [{}])[0]
+        volume = data.get("volume", {})
+        bvol = volume.get("benches", {})
+        mvol = volume.get("mariadb", {})
+        snap = volume.get("snapshots", {})
+
+        d.update(
+            {
+                "bench_name": bench.get("name", ""),
+                "python": bench.get("python", d["python"]),
+                "http_port": bench.get("http_port", d["http_port"]),
+                "socketio_port": bench.get("socketio_port", d["socketio_port"]),
+                "mariadb_password": data.get("mariadb", {}).get("root_password", d["mariadb_password"]),
+                "admin_password": data.get("admin", {}).get("password", d["admin_password"]),
+                "app_repo": app.get("repo", d["app_repo"]),
+                "app_branch": app.get("branch", d["app_branch"]),
+                "redis_port": data.get("redis", {}).get("port", d["redis_port"]),
+                "workers_default": data.get("workers", {}).get("default", d["workers_default"]),
+                "workers_short": data.get("workers", {}).get("short", d["workers_short"]),
+                "workers_long": data.get("workers", {}).get("long", d["workers_long"]),
+                "volume_enabled": volume.get("enabled", d["volume_enabled"]),
+                "volume_pool": volume.get("pool", d["volume_pool"]),
+                "volume_device": volume.get("device", d["volume_device"]),
+                "volume_benches_reservation": bvol.get("reservation", d["volume_benches_reservation"]),
+                "volume_benches_quota": bvol.get("quota", d["volume_benches_quota"]),
+                "volume_mariadb_reservation": mvol.get("reservation", d["volume_mariadb_reservation"]),
+                "volume_mariadb_quota": mvol.get("quota", d["volume_mariadb_quota"]),
+                "volume_mariadb_data_dir": mvol.get("data_dir", d["volume_mariadb_data_dir"]),
+                "volume_snapshots_enabled": snap.get("enabled", d["volume_snapshots_enabled"]),
+            }
+        )
+        return d

--- a/bench_cli/managers/process_manager.py
+++ b/bench_cli/managers/process_manager.py
@@ -286,3 +286,26 @@ class ProcessManagerFactory:
             return SystemdProcessManager(bench)
 
         return SupervisorProcessManager(bench)
+
+    @classmethod
+    def detect_running(cls, bench: "Bench") -> ProcessManager:
+        """Return the process manager that is currently active for this bench.
+
+        Probes actual runtime state — systemd is-active and supervisord
+        pid + supervisorctl status — rather than config file presence.
+        This avoids confusion when config files linger after switching managers.
+        Falls back to create() when nothing is detected as running, so callers
+        still get the appropriate "not running" error for the configured manager.
+        """
+        from bench_cli.managers.systemd_process_manager import SystemdProcessManager
+        from bench_cli.managers.supervisor_process_manager import SupervisorProcessManager
+
+        systemd = SystemdProcessManager(bench)
+        if systemd.is_running():
+            return systemd
+
+        supervisor = SupervisorProcessManager(bench)
+        if supervisor.is_running():
+            return supervisor
+
+        return cls.create(bench)

--- a/bench_cli/managers/supervisor_process_manager.py
+++ b/bench_cli/managers/supervisor_process_manager.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import subprocess
-import time
 from pathlib import Path
 
 from bench_cli.managers.admin_env_manager import AdminEnvManager
@@ -51,7 +50,6 @@ class SupervisorProcessManager(ProcessManager):
             os.kill(pid, 0)
             return True
         except (ValueError, ProcessLookupError, OSError):
-            print("HERE!")
             return False
 
     def reload(self) -> None:

--- a/bench_cli/managers/systemd_process_manager.py
+++ b/bench_cli/managers/systemd_process_manager.py
@@ -49,6 +49,8 @@ class SystemdProcessManager(ProcessManager):
         (self.systemd_conf_dir / self._target_name()).write_text(self._render_target(defs))
 
     def install_config(self) -> None:
+        import getpass
+
         self.user_unit_dir.mkdir(parents=True, exist_ok=True)
         defs = self._prod_process_definitions()
         units = [self._unit_name(pd.name) for pd in defs] + [self._target_name()]
@@ -58,17 +60,16 @@ class SystemdProcessManager(ProcessManager):
             if dst.is_symlink() or dst.exists():
                 dst.unlink()
             dst.symlink_to(src)
+
+        subprocess.run(
+            ["sudo", "loginctl", "enable-linger", getpass.getuser()],
+            capture_output=True,
+            check=False,
+        )
+
         env = self._systemctl_env()
-        try:
-            run_command(self._systemctl("daemon-reload"), env=env)
-            run_command(self._systemctl("enable", self._target_name()), env=env)
-        except Exception:
-            print(
-                f"\nNote: Could not reach the user systemd bus for {os.environ.get('USER', 'this user')}.\n"
-                "If linger is not yet enabled, run once as root:\n"
-                f"  sudo loginctl enable-linger {os.environ.get('USER', '<bench-user>')}\n"
-                "Then re-run: bench setup production"
-            )
+        run_command(self._systemctl("daemon-reload"), env=env)
+        run_command(self._systemctl("enable", self._target_name()), env=env)
 
     def is_configured(self) -> bool:
         result = subprocess.run(

--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,29 @@ fi
 
 export PATH="$BENCH_CLI_DIR:$PATH"
 
+# Set up the admin venv (Flask backend for the setup wizard and admin UI)
+ADMIN_VENV="$BENCH_CLI_DIR/.admin-venv"
+if [ ! -f "$ADMIN_VENV/bin/python" ]; then
+    echo "Setting up admin environment..."
+    uv venv "$ADMIN_VENV" --quiet
+    # Read deps from pyproject.toml if python3 is available, otherwise use known defaults
+    if command -v python3 &>/dev/null; then
+        ADMIN_DEPS=$(python3 -c "
+import tomllib, sys
+with open('$BENCH_CLI_DIR/pyproject.toml', 'rb') as f:
+    d = tomllib.load(f)
+deps = d.get('project', {}).get('optional-dependencies', {}).get('admin', [])
+print(' '.join(deps))
+" 2>/dev/null)
+    fi
+    if [ -z "$ADMIN_DEPS" ]; then
+        ADMIN_DEPS="flask>=3.0 psutil>=5.9 pymysql>=1.1"
+    fi
+    # shellcheck disable=SC2086
+    uv pip install --python "$ADMIN_VENV/bin/python" --quiet $ADMIN_DEPS
+    echo "Admin environment ready."
+fi
+
 echo ""
 echo "bench installed to $BENCH_CLI_DIR"
 echo ""


### PR DESCRIPTION
Add admin configurations on bench start generates `bench.toml`

<img width="1386" height="1156" alt="image" src="https://github.com/user-attachments/assets/8d5e70fc-5e39-46a8-8bff-67ec1e3b1d76" />

<img width="1316" height="1182" alt="image" src="https://github.com/user-attachments/assets/101cc955-0402-455f-81ff-1b17a14eca72" />

<img width="1328" height="1296" alt="image" src="https://github.com/user-attachments/assets/7d29a724-70c3-4fc3-9c3f-82e3bb6abf97" />
