### PR TITLE
feat(admin): dark mode with light/dark/auto theme selector

### DIFF
--- a/admin/frontend/src/App.vue
+++ b/admin/frontend/src/App.vue
@@ -2,7 +2,9 @@
 import { ref, onMounted } from 'vue'
 import AppLayout from './components/AppLayout.vue'
 import Login from './pages/Login.vue'
-import { Alert } from 'frappe-ui'
+import { Alert, useTheme } from 'frappe-ui'
+
+const { initializeTheme } = useTheme()
 
 const adminEnabled = ref(true)
 const adminError = ref('')
@@ -21,6 +23,7 @@ async function loadStatus() {
 }
 
 onMounted(async () => {
+  initializeTheme()
   try {
     await loadStatus()
   } catch {

--- a/admin/frontend/src/components/AppSidebar.vue
+++ b/admin/frontend/src/components/AppSidebar.vue
@@ -88,7 +88,7 @@ onUnmounted(() => clearInterval(pollTimer))
       <SidebarItem :label="item.label" :icon="item.icon" :to="item.to" :isActive="isActive(item.to)">
         <template v-if="item.to === '/tasks' && runningCount > 0" #suffix>
           <span
-            class="flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-gray-800 px-1 text-[10px] font-bold text-white">
+            class="flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-ink-gray-8 px-1 text-[10px] font-bold text-surface-white">
             {{ runningCount }}
           </span>
         </template>

--- a/admin/frontend/src/pages/Apps.vue
+++ b/admin/frontend/src/pages/Apps.vue
@@ -372,7 +372,7 @@ onMounted(() => { loadApps(); loadRegistry(); loadUpdateStatus() })
         <div v-if="addMode === 'picker'">
           <TextInput v-model="registrySearch" placeholder="Search apps…" class="mb-3" />
           <div class="max-h-52 overflow-y-auto mb-3">
-            <div v-if="!filteredRegistry.length" class="p-4 text-gray-400">No apps found</div>
+            <div v-if="!filteredRegistry.length" class="p-4 text-ink-gray-4">No apps found</div>
             <button
               v-for="a in filteredRegistry"
               :key="a.name"

--- a/admin/frontend/src/pages/Dashboard.vue
+++ b/admin/frontend/src/pages/Dashboard.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { Badge, Card, LoadingText, ErrorMessage, Progress, AxisChart } from 'frappe-ui'
+import { Badge, LoadingText, ErrorMessage, Progress, AxisChart } from 'frappe-ui'
 const router = useRouter()
 
 const data = ref(null)
@@ -93,27 +93,32 @@ onUnmounted(() => {
 
     <template v-else-if="data">
       <div class="grid grid-cols-2 gap-4 md:grid-cols-4">
-        <button class="text-left" @click="router.push('/apps')">
-          <Card :title="`${data.cloned_count} / ${data.apps.length}`" subtitle="Apps cloned" />
-        </button>
-        <button class="text-left" @click="router.push('/sites')">
-          <Card :title="`${data.online_count} / ${data.sites.length}`" subtitle="Sites online" />
-        </button>
-        <button class="text-left" @click="router.push('/processes')">
-          <Card :title="`${data.running_count} / ${data.processes.length}`" subtitle="Processes running" />
-        </button>
-        <button class="text-left" @click="router.push('/tasks')">
-          <Card :title="String(data.recent_tasks.length)" subtitle="Recent tasks" />
+        <button
+          v-for="{ count, total, label, route } in [
+            { count: data.cloned_count, total: data.apps.length, label: 'Apps cloned', route: '/apps' },
+            { count: data.online_count, total: data.sites.length, label: 'Sites online', route: '/sites' },
+            { count: data.running_count, total: data.processes.length, label: 'Processes running', route: '/processes' },
+            { count: data.recent_tasks.length, total: null, label: 'Recent tasks', route: '/tasks' },
+          ]"
+          :key="label"
+          class="rounded-lg border border-outline-gray-1 bg-surface-white px-6 py-5 text-left shadow-sm transition-colors hover:bg-surface-gray-1"
+          @click="router.push(route)"
+        >
+          <h2 class="text-xl font-semibold text-ink-gray-9">
+            {{ total !== null ? `${count} / ${total}` : String(count) }}
+          </h2>
+          <p class="mt-1.5 text-base text-ink-gray-5">{{ label }}</p>
         </button>
       </div>
 
-      <Card v-if="stats" title="Server Stats">
-        <template #actions>
+      <div v-if="stats" class="rounded-lg border border-outline-gray-1 bg-surface-white px-6 py-5 shadow-sm">
+        <div class="mb-4 flex items-center justify-between">
+          <h2 class="text-xl font-semibold text-ink-gray-9">Server Stats</h2>
           <span class="flex items-center gap-1.5 text-xs text-ink-gray-4">
             <span class="h-2 w-2 animate-pulse rounded-full bg-green-500" />
             Live
           </span>
-        </template>
+        </div>
 
         <div class="flex flex-col gap-6">
           <div class="grid grid-cols-3 gap-6">
@@ -181,7 +186,7 @@ onUnmounted(() => {
 
           <AxisChart v-if="history.length > 1" :config="chartConfig" />
         </div>
-      </Card>
+      </div>
     </template>
   </div>
 </template>

--- a/admin/frontend/src/pages/Settings.vue
+++ b/admin/frontend/src/pages/Settings.vue
@@ -1,9 +1,20 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { Button, FormControl, ErrorMessage, LoadingText, Switch } from 'frappe-ui'
+import { Button, FormControl, ErrorMessage, LoadingText, Switch, Select, useTheme } from 'frappe-ui'
 
 const router = useRouter()
+
+const { currentTheme, setTheme } = useTheme()
+const theme = computed({
+  get: () => currentTheme.value,
+  set: (val) => setTheme(val),
+})
+const THEME_OPTIONS = [
+  { label: 'Light', value: 'light' },
+  { label: 'Dark', value: 'dark' },
+  { label: 'Auto (System)', value: 'system' },
+]
 
 const loading = ref(true)
 const loadError = ref('')
@@ -125,22 +136,30 @@ onMounted(load)
     <ErrorMessage v-else-if="loadError" :message="loadError" />
 
     <template v-else>
+      <!-- Appearance -->
+      <div class="flex flex-col gap-4">
+        <h3 class="text-base font-semibold text-ink-gray-8">Appearance</h3>
+        <Select label="Theme" :options="THEME_OPTIONS" v-model="theme" class="w-40" />
+      </div>
+
+      <div class="border-t border-outline-gray-1" />
+
       <!-- Mode -->
       <div class="flex flex-col gap-4">
-        <h3 class="text-base font-semibold text-gray-800">Mode</h3>
+        <h3 class="text-base font-semibold text-ink-gray-8">Mode</h3>
         <div class="flex flex-col gap-3">
           <Switch v-model="form.production.enabled" label="Production Mode" />
-          <div v-if="form.production.enabled" class="flex flex-col gap-3 pl-4 border-l border-gray-200">
+          <div v-if="form.production.enabled" class="flex flex-col gap-3 pl-4 border-l border-outline-gray-2">
             <Switch v-model="form.production.lightweight" label="Lightweight" />
           </div>
         </div>
       </div>
 
-      <div class="border-t border-gray-100" />
+      <div class="border-t border-outline-gray-1" />
 
       <!-- Bench -->
       <div class="flex flex-col gap-4">
-        <h3 class="text-base font-semibold text-gray-800">Bench</h3>
+        <h3 class="text-base font-semibold text-ink-gray-8">Bench</h3>
         <div class="grid grid-cols-2 gap-4">
           <FormControl label="Name" :modelValue="form.bench.name" disabled />
           <FormControl label="Python Version" :modelValue="form.bench.python" disabled />
@@ -149,11 +168,11 @@ onMounted(load)
         </div>
       </div>
 
-      <div class="border-t border-gray-100" />
+      <div class="border-t border-outline-gray-1" />
 
       <!-- MariaDB -->
       <div class="flex flex-col gap-4">
-        <h3 class="text-base font-semibold text-gray-800">MariaDB</h3>
+        <h3 class="text-base font-semibold text-ink-gray-8">MariaDB</h3>
         <div class="grid grid-cols-2 gap-4">
           <FormControl label="Host" v-model="form.mariadb.host" />
           <FormControl type="number" label="Port" v-model="form.mariadb.port" />
@@ -163,11 +182,11 @@ onMounted(load)
         </div>
       </div>
 
-      <div class="border-t border-gray-100" />
+      <div class="border-t border-outline-gray-1" />
 
       <!-- Redis -->
       <div class="flex flex-col gap-4">
-        <h3 class="text-base font-semibold text-gray-800">Redis</h3>
+        <h3 class="text-base font-semibold text-ink-gray-8">Redis</h3>
         <div class="grid grid-cols-2 gap-4">
           <FormControl type="number" label="Cache Port" v-model="form.redis.cache_port" />
           <FormControl type="number" label="Queue Port" v-model="form.redis.queue_port" />
@@ -176,11 +195,11 @@ onMounted(load)
         </div>
       </div>
 
-      <div class="border-t border-gray-100" />
+      <div class="border-t border-outline-gray-1" />
 
       <!-- Workers -->
       <div class="flex flex-col gap-4">
-        <h3 class="text-base font-semibold text-gray-800">Workers</h3>
+        <h3 class="text-base font-semibold text-ink-gray-8">Workers</h3>
         <div class="grid grid-cols-3 gap-4">
           <FormControl type="number" label="Default Workers" v-model="form.workers.default" />
           <FormControl type="number" label="Short Workers" v-model="form.workers.short" />
@@ -188,11 +207,11 @@ onMounted(load)
         </div>
       </div>
 
-      <div class="border-t border-gray-100" />
+      <div class="border-t border-outline-gray-1" />
 
       <!-- Nginx -->
       <div class="flex flex-col gap-4">
-        <h3 class="text-base font-semibold text-gray-800">Nginx</h3>
+        <h3 class="text-base font-semibold text-ink-gray-8">Nginx</h3>
         <Switch v-model="form.production.nginx" label="Manage Nginx" />
         <div class="grid grid-cols-2 gap-4">
           <FormControl type="number" label="HTTP Port" v-model="form.nginx.http_port" />
@@ -203,22 +222,22 @@ onMounted(load)
         </div>
       </div>
 
-      <div class="border-t border-gray-100" />
+      <div class="border-t border-outline-gray-1" />
 
       <!-- Let's Encrypt -->
       <div class="flex flex-col gap-4">
-        <h3 class="text-base font-semibold text-gray-800">Let's Encrypt</h3>
+        <h3 class="text-base font-semibold text-ink-gray-8">Let's Encrypt</h3>
         <div class="grid grid-cols-2 gap-4">
           <FormControl label="Email" v-model="form.letsencrypt.email" placeholder="you@example.com" />
           <FormControl label="Webroot Path" v-model="form.letsencrypt.webroot_path" />
         </div>
       </div>
 
-      <div class="border-t border-gray-100" />
+      <div class="border-t border-outline-gray-1" />
 
       <!-- Setup -->
       <div class="flex flex-col gap-4">
-        <h3 class="text-base font-semibold text-gray-800">Setup</h3>
+        <h3 class="text-base font-semibold text-ink-gray-8">Setup</h3>
         <ErrorMessage :message="taskError" />
         <div class="flex flex-wrap gap-2">
           <Button variant="outline" :loading="taskLoading === 'setup-nginx'" @click="taskLoading = 'setup-nginx'; runTask('setup-nginx')">Setup Nginx</Button>


### PR DESCRIPTION
- Wire up `useTheme()` from frappe-ui in `App.vue` so the saved preference is applied on every load before first render
- Add **Appearance** section to Settings with a Light / Dark / Auto (System) select — switches instantly, stored in `localStorage`
- Replace hardcoded `gray-*` Tailwind classes with frappe-ui semantic tokens (`ink-gray-*`, `outline-gray-*`) so they respond to the `data-theme` attribute frappe-ui sets on `<html>`

Prompts: "raise a pr to add a dark mode to the admin app using frappe-ui themes. also add a configuration in the settings to let the user select from light, dark, auto"

🤖 Generated with [Claude Code](https://claude.com/claude-code)