### PR TITLE
feat(socketio): Select realtime backend at runtime via `bench socketio`

### DIFF
--- a/bench_cli/cli.py
+++ b/bench_cli/cli.py
@@ -15,6 +15,7 @@ _OWN_COMMANDS = frozenset(
         "start",
         "stop",
         "restart",
+        "socketio",
         "get-app",
         "new-site",
         "frappe",
@@ -146,6 +147,7 @@ def _make_parser() -> argparse.ArgumentParser:
     sub.add_parser("start", help="Start all bench processes.")
     sub.add_parser("stop", help="Stop the running bench.")
     sub.add_parser("restart", help="Restart supervisor processes (production mode only).")
+    sub.add_parser("socketio", help="Run the realtime server (backend chosen at runtime from socketio_backend).")
     p_build = sub.add_parser("build", help="Build assets (downloads pre-built if available).")
     p_build.add_argument("--force", action="store_true", help="Force a full rebuild, skipping pre-built asset download.")
     sub.add_parser("update", help="Pull latest code and migrate sites.")
@@ -302,6 +304,11 @@ def _dispatch(args: argparse.Namespace) -> None:
         from bench_cli.commands.restart import RestartCommand
 
         RestartCommand(_load_bench()).run()
+
+    elif cmd == "socketio":
+        from bench_cli.commands.socketio import SocketIOCommand
+
+        SocketIOCommand(_load_bench()).run()
 
     elif cmd == "get-app":
         _cmd_get_app(args)

--- a/bench_cli/commands/socketio.py
+++ b/bench_cli/commands/socketio.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+from bench_cli.core.bench import Bench
+from bench_cli.exceptions import BenchError
+
+
+class SocketIOCommand:
+    """Launch the realtime (socketio) server, picking the backend at runtime.
+
+    Backend is read from ``socketio_backend`` in bench.toml ("node" default, or
+    "python"). The process replaces itself via ``os.execv`` so the process
+    manager (foreground runner / systemd / supervisor) keeps tracking the real
+    server pid. If the python backend is requested but the frappe env does not
+    ship ``frappe.realtime.server``, it falls back to the node backend.
+    """
+
+    def __init__(self, bench: Bench) -> None:
+        self.bench = bench
+
+    def run(self) -> None:
+        backend = getattr(self.bench.config, "socketio_backend", "node")
+        if backend not in ("node", "python"):
+            print(f"Unknown socketio_backend {backend!r}; falling back to 'node'.")
+            backend = "node"
+
+        # process commands run from the sites dir (see _web_definition etc.)
+        os.chdir(self.bench.sites_path)
+
+        if backend == "python":
+            python = str(self.bench.env_path / "bin" / "python")
+            if self._python_backend_supported(python):
+                os.execv(python, [python, "-m", "frappe.realtime.server"])
+            print(
+                "socketio_backend is 'python' but this frappe env has no "
+                "'frappe.realtime.server'; falling back to the node backend."
+            )
+
+        node = shutil.which("node") or shutil.which("nodejs")
+        if not node:
+            raise BenchError(
+                "Cannot start socketio: node not found and the python backend is "
+                "unavailable. Install node or a frappe version with "
+                "frappe.realtime.server."
+            )
+        socketio_js = str(self.bench.apps_path / "frappe" / "socketio.js")
+        os.execv(node, [node, socketio_js])
+
+    @staticmethod
+    def _python_backend_supported(python: str) -> bool:
+        """Check the frappe env ships the python realtime server.
+
+        Probes with the frappe env interpreter and find_spec so the module's
+        heavy import side-effects (gevent monkey-patching) don't run.
+        """
+        if not os.path.exists(python):
+            return False
+        try:
+            return (
+                subprocess.run(
+                    [
+                        python,
+                        "-c",
+                        "import importlib.util, sys;"
+                        "sys.exit(0 if importlib.util.find_spec('frappe.realtime.server') else 1)",
+                    ],
+                    timeout=30,
+                ).returncode
+                == 0
+            )
+        except (subprocess.SubprocessError, OSError):
+            return False

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -35,6 +35,7 @@ class BenchConfig:
     apps: List[AppConfig] = field(default_factory=list)
     http_port: int = 8000
     socketio_port: int = 9000
+    socketio_backend: str = "node"
     default_branch: str = ""
     production: ProductionConfig = field(default_factory=ProductionConfig)
     nginx: NginxConfig = field(default_factory=NginxConfig)
@@ -75,6 +76,7 @@ class BenchConfig:
             python_version=bench_data.get("python", ""),
             http_port=bench_data.get("http_port", 8000),
             socketio_port=bench_data.get("socketio_port", 9000),
+            socketio_backend=bench_data.get("socketio_backend", "node"),
             default_branch=bench_data.get("default_branch", ""),
             apps=apps,
             mariadb=mariadb,

--- a/bench_cli/config/toml_writer.py
+++ b/bench_cli/config/toml_writer.py
@@ -11,6 +11,7 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append(f'python = "{config.python_version}"')
     parts.append(f"http_port = {config.http_port}")
     parts.append(f"socketio_port = {config.socketio_port}")
+    parts.append(f'socketio_backend = "{config.socketio_backend}"')
     if config.default_branch:
         parts.append(f'default_branch = "{config.default_branch}"')
     parts.append("")

--- a/bench_cli/managers/process_manager.py
+++ b/bench_cli/managers/process_manager.py
@@ -198,10 +198,10 @@ class ProcessManager:
         )
 
     def _socketio_definition(self) -> ProcessDefinition:
-        sites = self.bench.sites_path
+        bench_entry = _cli_root() / "bench"
         return ProcessDefinition(
             name="socketio",
-            command=f"cd {sites} && node {self.bench.apps_path}/frappe/socketio.js",
+            command=f"{bench_entry} -b {self.bench.config.name} socketio",
             log_file=self.bench.logs_path / "socketio.log",
         )
 


### PR DESCRIPTION
Related : https://github.com/frappe/frappe/pull/39879

Socketio process command is now a stable launcher (`bench socketio`) instead of hardcoded node. It reads `socketio_backend` from bench.toml ("node"/"python") and execs the chosen backend, so switching no longer regenerates Procfile/systemd/supervisor config — edit bench.toml and restart.