### PR TITLE
feat: Select socketio backend (python/node) and drop dedicated socketio redis

### DIFF
--- a/admin/backend/views/settings.py
+++ b/admin/backend/views/settings.py
@@ -7,6 +7,7 @@ from flask import Blueprint, current_app, jsonify, request
 
 from bench_cli.config.bench_config import BenchConfig
 from bench_cli.config.toml_writer import bench_config_to_toml
+from bench_cli.managers.redis_manager import RedisManager
 from bench_cli.managers.volume_manager import VolumeManager
 from bench_cli.platform import is_linux
 
@@ -224,7 +225,7 @@ def _build_settings_response(config: BenchConfig) -> dict:
             "socket_path": config.mariadb.socket_path,
             "version": config.mariadb.version or "",
         },
-        "redis": {"cache_port": config.redis.cache_port, "queue_port": config.redis.queue_port, "version": config.redis.version or ""},
+        "redis": {"cache_port": config.redis.cache_port, "queue_port": config.redis.queue_port, "version": RedisManager.installed_version() or config.redis.version or ""},
         "workers": {"default": config.workers.default_count, "short": config.workers.short_count, "long": config.workers.long_count},
         "nginx": {
             "http_port": config.nginx.http_port,

--- a/admin/backend/views/settings.py
+++ b/admin/backend/views/settings.py
@@ -22,7 +22,6 @@ _RESTART_KEYS = {
     ("mariadb", "socket_path"),
     ("redis", "cache_port"),
     ("redis", "queue_port"),
-    ("redis", "socketio_port"),
     ("workers", "default"),
     ("workers", "short"),
     ("workers", "long"),
@@ -38,7 +37,7 @@ def _restart_trigger_values(config: BenchConfig) -> dict:
     return {
         "bench": {"python": config.python_version, "http_port": config.http_port, "socketio_port": config.socketio_port},
         "mariadb": {"host": config.mariadb.host, "port": config.mariadb.port, "admin_user": config.mariadb.admin_user, "socket_path": config.mariadb.socket_path},
-        "redis": {"cache_port": config.redis.cache_port, "queue_port": config.redis.queue_port, "socketio_port": config.redis.socketio_port},
+        "redis": {"cache_port": config.redis.cache_port, "queue_port": config.redis.queue_port},
         "workers": {"default": config.workers.default_count, "short": config.workers.short_count, "long": config.workers.long_count},
         "production": {"process_manager": config.production.process_manager},
     }
@@ -94,7 +93,6 @@ class ConfigPatcher:
         redis_config = self.config.redis
         redis_config.cache_port = int(redis.get("cache_port", redis_config.cache_port))
         redis_config.queue_port = int(redis.get("queue_port", redis_config.queue_port))
-        redis_config.socketio_port = int(redis.get("socketio_port", redis_config.socketio_port))
 
     def _apply_workers(self) -> None:
         workers = self.data.get("workers") or {}
@@ -226,7 +224,7 @@ def _build_settings_response(config: BenchConfig) -> dict:
             "socket_path": config.mariadb.socket_path,
             "version": config.mariadb.version or "",
         },
-        "redis": {"cache_port": config.redis.cache_port, "queue_port": config.redis.queue_port, "socketio_port": config.redis.socketio_port, "version": config.redis.version or ""},
+        "redis": {"cache_port": config.redis.cache_port, "queue_port": config.redis.queue_port, "version": config.redis.version or ""},
         "workers": {"default": config.workers.default_count, "short": config.workers.short_count, "long": config.workers.long_count},
         "nginx": {
             "http_port": config.nginx.http_port,

--- a/admin/frontend/src/components/SettingsModal.vue
+++ b/admin/frontend/src/components/SettingsModal.vue
@@ -275,7 +275,7 @@ watch(() => props.modelValue, (val) => {
                 <div class="grid grid-cols-2 gap-4">
                   <FormControl type="number" label="Cache Port" v-model="form.redis.cache_port" />
                   <FormControl type="number" label="Queue Port" v-model="form.redis.queue_port" />
-                  <FormControl label="Version" v-model="form.redis.version" placeholder="e.g. 7" />
+                  <FormControl label="Version" v-model="form.redis.version" disabled placeholder="not installed" />
                 </div>
               </div>
 

--- a/admin/frontend/src/components/SettingsModal.vue
+++ b/admin/frontend/src/components/SettingsModal.vue
@@ -82,7 +82,6 @@ function validateSettings() {
     [form.value.bench.socketio_port, 'SocketIO Port'],
     [form.value.redis.cache_port, 'Redis Cache Port'],
     [form.value.redis.queue_port, 'Redis Queue Port'],
-    [form.value.redis.socketio_port, 'Redis SocketIO Port'],
   ]
   for (const [port, name] of ports) {
     const n = Number(port)
@@ -276,7 +275,6 @@ watch(() => props.modelValue, (val) => {
                 <div class="grid grid-cols-2 gap-4">
                   <FormControl type="number" label="Cache Port" v-model="form.redis.cache_port" />
                   <FormControl type="number" label="Queue Port" v-model="form.redis.queue_port" />
-                  <FormControl type="number" label="SocketIO Port" v-model="form.redis.socketio_port" />
                   <FormControl label="Version" v-model="form.redis.version" placeholder="e.g. 7" />
                 </div>
               </div>

--- a/admin/frontend/src/pages/Settings.vue
+++ b/admin/frontend/src/pages/Settings.vue
@@ -25,7 +25,7 @@ const saveSuccess = ref('')
 const form = ref({
   bench: { name: '', python: '', http_port: 8000, socketio_port: 9000, default_branch: '' },
   mariadb: { host: 'localhost', port: 3306, admin_user: 'root', socket_path: '', version: '' },
-  redis: { cache_port: 13000, queue_port: 11000, socketio_port: 12000, version: '' },
+  redis: { cache_port: 13000, queue_port: 11000, version: '' },
   workers: { default: 2, short: 1, long: 1 },
   nginx: { http_port: 80, https_port: 443, config_dir: '/etc/nginx/conf.d', worker_processes: 'auto', client_max_body_size: '50m' },
   letsencrypt: { email: '', webroot_path: '/var/www/letsencrypt' },
@@ -53,7 +53,6 @@ function validateSettings() {
     [form.value.mariadb.port, 'MariaDB Port'],
     [form.value.redis.cache_port, 'Redis Cache Port'],
     [form.value.redis.queue_port, 'Redis Queue Port'],
-    [form.value.redis.socketio_port, 'Redis SocketIO Port'],
     [form.value.nginx.http_port, 'Nginx HTTP Port'],
     [form.value.nginx.https_port, 'Nginx HTTPS Port'],
   ]
@@ -192,7 +191,6 @@ onMounted(load)
         <div class="grid grid-cols-2 gap-4">
           <FormControl type="number" label="Cache Port" v-model="form.redis.cache_port" />
           <FormControl type="number" label="Queue Port" v-model="form.redis.queue_port" />
-          <FormControl type="number" label="SocketIO Port" v-model="form.redis.socketio_port" />
           <FormControl label="Version" v-model="form.redis.version" placeholder="e.g. 7" />
         </div>
       </div>

--- a/admin/frontend/src/pages/Settings.vue
+++ b/admin/frontend/src/pages/Settings.vue
@@ -191,7 +191,7 @@ onMounted(load)
         <div class="grid grid-cols-2 gap-4">
           <FormControl type="number" label="Cache Port" v-model="form.redis.cache_port" />
           <FormControl type="number" label="Queue Port" v-model="form.redis.queue_port" />
-          <FormControl label="Version" v-model="form.redis.version" placeholder="e.g. 7" />
+          <FormControl label="Version" v-model="form.redis.version" disabled placeholder="not installed" />
         </div>
       </div>
 

--- a/bench_cli/commands/status.py
+++ b/bench_cli/commands/status.py
@@ -60,7 +60,6 @@ class StatusCommand:
         else:
             self._row("Cache port", str(redis.cache_port))
             self._row("Queue port", str(redis.queue_port))
-            self._row("SocketIO port", str(redis.socketio_port))
 
         if cfg.admin.enabled:
             self._section("Admin")

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -96,13 +96,11 @@ class BenchConfig:
             return RedisConfig(
                 cache_port=port,
                 queue_port=port,
-                socketio_port=port,
                 version=data.get("version"),
             )
         return RedisConfig(
             cache_port=data.get("cache_port", 13000),
             queue_port=data.get("queue_port", 11000),
-            socketio_port=data.get("socketio_port", 12000),
             version=data.get("version"),
         )
 
@@ -249,8 +247,8 @@ class BenchConfig:
             raise ConfigError(f"bench.socketio_backend '{self.socketio_backend}' is invalid. Must be 'python' or 'node'.")
 
     def _validate_redis_ports(self) -> None:
-        ports = [self.redis.cache_port, self.redis.queue_port, self.redis.socketio_port]
-        port_names = ["redis.cache_port", "redis.queue_port", "redis.socketio_port"]
+        ports = [self.redis.cache_port, self.redis.queue_port]
+        port_names = ["redis.cache_port", "redis.queue_port"]
         for name, port in zip(port_names, ports):
             if not (_REDIS_PORT_MIN <= port <= _REDIS_PORT_MAX):
                 raise ConfigError(f"{name} {port} is out of range. Must be between {_REDIS_PORT_MIN} and {_REDIS_PORT_MAX}.")

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -35,6 +35,7 @@ class BenchConfig:
     apps: List[AppConfig] = field(default_factory=list)
     http_port: int = 8000
     socketio_port: int = 9000
+    socketio_backend: str = "python"
     default_branch: str = ""
     production: ProductionConfig = field(default_factory=ProductionConfig)
     nginx: NginxConfig = field(default_factory=NginxConfig)
@@ -75,6 +76,7 @@ class BenchConfig:
             python_version=bench_data.get("python", ""),
             http_port=bench_data.get("http_port", 8000),
             socketio_port=bench_data.get("socketio_port", 9000),
+            socketio_backend=bench_data.get("socketio_backend", "python"),
             default_branch=bench_data.get("default_branch", ""),
             apps=apps,
             mariadb=mariadb,
@@ -198,6 +200,7 @@ class BenchConfig:
         self._validate_bench_name()
         self._validate_app_names_unique()
         self._validate_ports()
+        self._validate_socketio_backend()
         self._validate_redis_ports()
         self._validate_worker_counts()
         self._validate_letsencrypt_email()
@@ -240,6 +243,10 @@ class BenchConfig:
         for name, port in ports.items():
             if not (_PORT_MIN <= port <= _PORT_MAX):
                 raise ConfigError(f"{name} {port} is out of range. Must be between {_PORT_MIN} and {_PORT_MAX}.")
+
+    def _validate_socketio_backend(self) -> None:
+        if self.socketio_backend not in ("python", "node"):
+            raise ConfigError(f"bench.socketio_backend '{self.socketio_backend}' is invalid. Must be 'python' or 'node'.")
 
     def _validate_redis_ports(self) -> None:
         ports = [self.redis.cache_port, self.redis.queue_port, self.redis.socketio_port]

--- a/bench_cli/config/bench_toml_builder.py
+++ b/bench_cli/config/bench_toml_builder.py
@@ -82,7 +82,7 @@ def _apply_setting(config: BenchConfig, key: str, value) -> None:
         config.apps[0].branch = str(value)
     elif key == "redis_port":
         redis = config.redis
-        redis.cache_port = redis.queue_port = redis.socketio_port = int(value)
+        redis.cache_port = redis.queue_port = int(value)
     # unknown keys (wizard extras like is_linux) are ignored
 
 

--- a/bench_cli/config/bench_toml_builder.py
+++ b/bench_cli/config/bench_toml_builder.py
@@ -16,6 +16,7 @@ FLAT_KEYS = {
     "python": "python_version",
     "http_port": "http_port",
     "socketio_port": "socketio_port",
+    "socketio_backend": "socketio_backend",
     "mariadb_password": "mariadb.root_password",
     "admin_enabled": "admin.enabled",
     "admin_port": "admin.port",

--- a/bench_cli/config/redis_config.py
+++ b/bench_cli/config/redis_config.py
@@ -6,9 +6,8 @@ from typing import Optional
 class RedisConfig:
     cache_port: int = 13000
     queue_port: int = 11000
-    socketio_port: int = 12000
     version: Optional[str] = None
 
     @property
     def is_single_instance(self) -> bool:
-        return self.cache_port == self.queue_port == self.socketio_port
+        return self.cache_port == self.queue_port

--- a/bench_cli/config/toml_writer.py
+++ b/bench_cli/config/toml_writer.py
@@ -41,7 +41,6 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append("[redis]")
     parts.append(f"cache_port = {r.cache_port}")
     parts.append(f"queue_port = {r.queue_port}")
-    parts.append(f"socketio_port = {r.socketio_port}")
     if r.version:
         parts.append(f'version = "{r.version}"')
     parts.append("")

--- a/bench_cli/config/toml_writer.py
+++ b/bench_cli/config/toml_writer.py
@@ -11,6 +11,7 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append(f'python = "{config.python_version}"')
     parts.append(f"http_port = {config.http_port}")
     parts.append(f"socketio_port = {config.socketio_port}")
+    parts.append(f'socketio_backend = "{config.socketio_backend}"')
     if config.default_branch:
         parts.append(f'default_branch = "{config.default_branch}"')
     parts.append("")

--- a/bench_cli/core/bench.py
+++ b/bench_cli/core/bench.py
@@ -121,11 +121,10 @@ class Bench:
         if r.is_single_instance:
             redis_cache = f"redis://localhost:{r.cache_port}/0"
             redis_queue = f"redis://localhost:{r.cache_port}/1"
-            redis_socketio = f"redis://localhost:{r.cache_port}/2"
         else:
             redis_cache = f"redis://localhost:{r.cache_port}"
             redis_queue = f"redis://localhost:{r.queue_port}"
-            redis_socketio = f"redis://localhost:{r.socketio_port}"
+        redis_socketio = redis_cache
         config = {
             "redis_cache": redis_cache,
             "redis_queue": redis_queue,

--- a/bench_cli/core/bench.py
+++ b/bench_cli/core/bench.py
@@ -132,6 +132,7 @@ class Bench:
             "redis_socketio": redis_socketio,
             "socketio_port": self.config.socketio_port,
             "webserver_port": self.config.http_port,
+            "socketio_backend": self.config.socketio_backend,
         }
         # Add custom worker timeouts to config (if any exist)
         custom_workers = {

--- a/bench_cli/managers/nginx_manager.py
+++ b/bench_cli/managers/nginx_manager.py
@@ -47,17 +47,16 @@ class NginxManager:
     def _generate_site_config(self, site: "SiteConfig", ssl_ready: bool) -> str:
         bench_name = self.bench.config.name
         nginx_config = self.bench.config.nginx
-        redis_config = self.bench.config.redis
         bench_root = self.bench.path
 
         if not site.ssl or not ssl_ready:
             return self._render_http_only_block(
-                site, bench_name, nginx_config, redis_config, bench_root
+                site, bench_name, nginx_config, bench_root
             )
 
         return (
             self._render_http_redirect_block(site, nginx_config)
-            + self._render_https_block(site, bench_name, nginx_config, redis_config, bench_root)
+            + self._render_https_block(site, bench_name, nginx_config, bench_root)
         )
 
     def _render_upstream_block(self, bench_name: str) -> str:
@@ -73,13 +72,12 @@ class NginxManager:
         site: "SiteConfig",
         bench_name: str,
         nginx_config: object,
-        redis_config: object,
         bench_root: Path,
     ) -> str:
         server_name = " ".join(site.all_domains)
         max_body = nginx_config.client_max_body_size
         http_port = nginx_config.http_port
-        socketio_port = redis_config.socketio_port
+        socketio_port = self.bench.config.socketio_port
         webroot = self.bench.config.letsencrypt.webroot_path
 
         return (
@@ -123,13 +121,12 @@ class NginxManager:
         site: "SiteConfig",
         bench_name: str,
         nginx_config: object,
-        redis_config: object,
         bench_root: Path,
     ) -> str:
         server_name = " ".join(site.all_domains)
         https_port = nginx_config.https_port
         max_body = nginx_config.client_max_body_size
-        socketio_port = redis_config.socketio_port
+        socketio_port = self.bench.config.socketio_port
         cert = self.cert_path(site)
         key = Path("/etc/letsencrypt/live") / site.name / "privkey.pem"
 

--- a/bench_cli/managers/process_manager.py
+++ b/bench_cli/managers/process_manager.py
@@ -179,7 +179,6 @@ class ProcessManager:
         else:
             defs.append(self._redis_definition("redis_cache", "redis_cache.conf"))
             defs.append(self._redis_definition("redis_queue", "redis_queue.conf"))
-            defs.append(self._redis_definition("redis_socketio", "redis_socketio.conf"))
         return defs
 
     def _process_definitions(self) -> List[ProcessDefinition]:

--- a/bench_cli/managers/process_manager.py
+++ b/bench_cli/managers/process_manager.py
@@ -207,10 +207,14 @@ class ProcessManager:
         )
 
     def _socketio_definition(self) -> ProcessDefinition:
-        sites = self.bench.sites_path
+        if self.bench.config.socketio_backend == "python":
+            python = self.bench.env_path / "bin" / "python"
+            command = f"cd {self.bench.path} && {python} -m frappe.realtime.server"
+        else:
+            command = f"cd {self.bench.sites_path} && node {self.bench.apps_path}/frappe/socketio.js"
         return ProcessDefinition(
             name="socketio",
-            command=f"cd {sites} && node {self.bench.apps_path}/frappe/socketio.js",
+            command=command,
             log_file=self.bench.logs_path / "socketio.log",
         )
 

--- a/bench_cli/managers/redis_manager.py
+++ b/bench_cli/managers/redis_manager.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import re
 import shutil
+import subprocess
 from typing import TYPE_CHECKING
 
 from bench_cli.config.redis_config import RedisConfig
@@ -17,6 +19,24 @@ class RedisManager:
 
     def is_installed(self) -> bool:
         return shutil.which("redis-server") is not None
+
+    @staticmethod
+    def installed_version() -> str:
+        """Return the installed redis-server version (e.g. '7.0.11'), or '' if unavailable."""
+        if shutil.which("redis-server") is None:
+            return ""
+        try:
+            result = subprocess.run(
+                ["redis-server", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        # Output: "Redis server v=7.0.11 sha=... malloc=... bits=64 build=..."
+        match = re.search(r"v=(\S+)", result.stdout)
+        return match.group(1) if match else ""
 
     def install(self) -> None:
         if self.is_installed():

--- a/bench_cli/managers/redis_manager.py
+++ b/bench_cli/managers/redis_manager.py
@@ -36,7 +36,6 @@ class RedisManager:
         else:
             self._write_cache_config()
             self._write_queue_config()
-            self._write_socketio_config()
 
     def _write_single_config(self) -> None:
         content = (
@@ -61,10 +60,3 @@ class RedisManager:
             'save ""\n'
         )
         (self.bench.config_path / "redis_queue.conf").write_text(content)
-
-    def _write_socketio_config(self) -> None:
-        content = (
-            f"port {self.config.socketio_port}\n"
-            "bind 127.0.0.1\n"
-        )
-        (self.bench.config_path / "redis_socketio.conf").write_text(content)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -157,13 +157,16 @@ port 13000
 bind 127.0.0.1
 ```
 
-**Multi-instance mode** (`cache_port`/`queue_port`/`socketio_port`):
+**Multi-instance mode** (`cache_port`/`queue_port`):
 
-**`redis_cache.conf`** / **`redis_queue.conf`** / **`redis_socketio.conf`**
+**`redis_cache.conf`** / **`redis_queue.conf`**
 ```
 port <N>
 bind 127.0.0.1
 ```
+
+There is no dedicated socketio Redis — socketio shares the cache instance, so
+`common_site_config.json` sets `redis_socketio` equal to `redis_cache`.
 
 Existing files are overwritten.
 
@@ -188,7 +191,6 @@ Multi-instance Redis:
 ...
 redis_cache: redis-server config/redis_cache.conf
 redis_queue: redis-server config/redis_queue.conf
-redis_socketio: redis-server config/redis_socketio.conf
 ```
 
 On completion, prints:

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -174,7 +174,7 @@ Writes `config/Procfile` with one line per process: web server, socketio, admin 
 Single-instance Redis:
 ```
 web: cd sites && env/bin/bench frappe serve --port 8000 --noreload
-socketio: cd sites && node apps/frappe/socketio.js
+socketio: env/bin/python -m frappe.realtime.server  # python backend (default); runs from bench root
 admin: PYTHONPATH=<cli_root> .admin-venv/bin/python -m admin.backend.server --bench-root <bench> --port 8002
 worker_default_1: cd sites && env/bin/bench frappe worker --queue default
 worker_default_2: cd sites && env/bin/bench frappe worker --queue default

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -21,7 +21,7 @@ def make_bench(tmp_path: Path) -> Bench:
         python_version="3.14",
         apps=[AppConfig(name="frappe", repo="https://github.com/frappe/frappe", branch="version-16")],
         mariadb=MariaDBConfig(root_password="root"),
-        redis=RedisConfig(cache_port=13000, queue_port=11000, socketio_port=12000),
+        redis=RedisConfig(cache_port=13000, queue_port=11000),
         workers=WorkerConfig(default_count=2, short_count=1, long_count=1),
     )
     return Bench(config, tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -23,7 +23,7 @@ MINIMAL_VALID_DATA: dict = {
         {"name": "frappe", "repo": "https://github.com/frappe/frappe", "branch": "version-16"}
     ],
     "mariadb": {"root_password": "root"},
-    "redis": {"cache_port": 13000, "queue_port": 11000, "socketio_port": 12000},
+    "redis": {"cache_port": 13000, "queue_port": 11000},
 }
 
 
@@ -44,7 +44,6 @@ def test_load_minimal_config() -> None:
 
     assert config.redis.cache_port == 13000
     assert config.redis.queue_port == 11000
-    assert config.redis.socketio_port == 12000
 
 
 def test_framework_app_is_first() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,7 +25,7 @@ def make_bench(tmp_path: Path) -> Bench:
             AppConfig(name="frappe", repo="https://github.com/frappe/frappe", branch="version-16"),
         ],
         mariadb=MariaDBConfig(root_password="root"),
-        redis=RedisConfig(cache_port=13000, queue_port=11000, socketio_port=12000),
+        redis=RedisConfig(cache_port=13000, queue_port=11000),
         workers=WorkerConfig(default_count=2, short_count=1, long_count=1),
     )
     return Bench(config, tmp_path)
@@ -165,12 +165,12 @@ def test_bench_init_apps_comes_from_config(tmp_path: Path) -> None:
 def test_process_definitions_returns_correct_count(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
     # workers: default=2, short=1, long=1 => 4 worker processes
-    # plus web, socketio, redis_cache, redis_queue, redis_socketio = 5
+    # plus web, socketio, redis_cache, redis_queue = 4
     # plus admin, admin-ui = 2
-    # total = 11
+    # total = 10
     process_manager = ProcessManager(bench)
     definitions = process_manager._process_definitions()
-    assert len(definitions) == 11
+    assert len(definitions) == 10
 
 
 def test_process_definitions_worker_names_are_numbered(tmp_path: Path) -> None:
@@ -191,7 +191,7 @@ def test_process_definitions_includes_redis_processes(tmp_path: Path) -> None:
     names = [pd.name for pd in definitions]
     assert "redis_cache" in names
     assert "redis_queue" in names
-    assert "redis_socketio" in names
+    assert "redis_socketio" not in names
 
 
 def test_process_definitions_order_starts_with_web(tmp_path: Path) -> None:

--- a/tests/test_managers_extra.py
+++ b/tests/test_managers_extra.py
@@ -19,7 +19,7 @@ def make_bench(tmp_path: Path) -> Bench:
         python_version="3.14",
         apps=[AppConfig(name="frappe", repo="https://github.com/frappe/frappe", branch="version-16")],
         mariadb=MariaDBConfig(root_password="root"),
-        redis=RedisConfig(cache_port=13000, queue_port=11000, socketio_port=12000),
+        redis=RedisConfig(cache_port=13000, queue_port=11000),
         workers=WorkerConfig(default_count=1, short_count=1, long_count=1),
     )
     bench = Bench(config, tmp_path)
@@ -33,7 +33,7 @@ def make_bench(tmp_path: Path) -> Bench:
 
 def test_redis_manager_single_instance_writes_one_config(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
-    redis_cfg = RedisConfig(cache_port=13000, queue_port=13000, socketio_port=13000)
+    redis_cfg = RedisConfig(cache_port=13000, queue_port=13000)
     assert redis_cfg.is_single_instance
 
     manager = RedisManager(redis_cfg, bench)
@@ -45,7 +45,7 @@ def test_redis_manager_single_instance_writes_one_config(tmp_path: Path) -> None
 
 def test_redis_manager_multi_instance_writes_three_configs(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
-    redis_cfg = RedisConfig(cache_port=13000, queue_port=11000, socketio_port=12000)
+    redis_cfg = RedisConfig(cache_port=13000, queue_port=11000)
     assert not redis_cfg.is_single_instance
 
     manager = RedisManager(redis_cfg, bench)
@@ -59,7 +59,7 @@ def test_redis_manager_multi_instance_writes_three_configs(tmp_path: Path) -> No
 
 def test_redis_manager_single_config_content(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
-    redis_cfg = RedisConfig(cache_port=13000, queue_port=13000, socketio_port=13000)
+    redis_cfg = RedisConfig(cache_port=13000, queue_port=13000)
     RedisManager(redis_cfg, bench).generate_configs()
 
     content = (bench.config_path / "redis.conf").read_text()
@@ -69,7 +69,7 @@ def test_redis_manager_single_config_content(tmp_path: Path) -> None:
 
 def test_redis_manager_multi_config_ports(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
-    redis_cfg = RedisConfig(cache_port=13000, queue_port=11000, socketio_port=12000)
+    redis_cfg = RedisConfig(cache_port=13000, queue_port=11000)
     RedisManager(redis_cfg, bench).generate_configs()
 
     assert "port 13000" in (bench.config_path / "redis_cache.conf").read_text()
@@ -79,7 +79,7 @@ def test_redis_manager_multi_config_ports(tmp_path: Path) -> None:
 
 def test_redis_manager_cache_config_has_no_save(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
-    redis_cfg = RedisConfig(cache_port=13000, queue_port=11000, socketio_port=12000)
+    redis_cfg = RedisConfig(cache_port=13000, queue_port=11000)
     RedisManager(redis_cfg, bench).generate_configs()
 
     cache = (bench.config_path / "redis_cache.conf").read_text()

--- a/tests/test_nginx_config.py
+++ b/tests/test_nginx_config.py
@@ -16,7 +16,7 @@ _BASE_DATA: dict = {
         {"name": "frappe", "repo": "https://github.com/frappe/frappe", "branch": "version-16"}
     ],
     "mariadb": {"root_password": "root"},
-    "redis": {"cache_port": 13000, "queue_port": 11000, "socketio_port": 12000},
+    "redis": {"cache_port": 13000, "queue_port": 11000},
 }
 
 _SSL_DATA: dict = {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,7 +61,7 @@ def test_write_toml_preserves_new_app(tmp_path: Path) -> None:
         "apps": [{"name": "frappe", "repo": "https://github.com/frappe/frappe", "branch": "v16"}],
         "sites": [{"name": "site1.localhost", "apps": ["frappe"]}],
         "mariadb": {"root_password": "root"},
-        "redis": {"cache_port": 13000, "queue_port": 11000, "socketio_port": 12000},
+        "redis": {"cache_port": 13000, "queue_port": 11000},
     }
     original["apps"].append(
         {"name": "payments", "repo": "https://github.com/frappe/payments", "branch": "v16"}
@@ -78,7 +78,7 @@ def test_write_toml_file_is_valid_toml(tmp_path: Path) -> None:
         "apps": [{"name": "frappe", "repo": "https://r.co/frappe", "branch": "main"}],
         "sites": [{"name": "s.localhost", "apps": ["frappe"]}],
         "mariadb": {"root_password": "r"},
-        "redis": {"cache_port": 13000, "queue_port": 11000, "socketio_port": 12000},
+        "redis": {"cache_port": 13000, "queue_port": 11000},
     }
     path = tmp_path / "bench.toml"
     write_toml(path, data)


### PR DESCRIPTION
- Add bench.socketio_backend to bench.toml (default python, switchable to node); handled across all process managers.
- Fix python backend reading wrong Redis port (launch from bench root, not sites/).
- Drop the dedicated socketio Redis, Socketio need a redis for pubsub only.
- Sync socketio_backend into common_site_config.json.
- Fix nginx /socket.io proxying to the socketio server port instead of a Redis port.
- Admin settings: show installed Redis version as read-only.
- Update tests and docs.