### PR TITLE
perf(production): cap malloc arenas to cut bench memory ~20%

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ use_companion_manager = false      # run scheduler/workers/socketio inside gunic
 workers = 4
 threads = 4                          # threads per worker (used by gthread)
 timeout = 120
+malloc_arena_max = 2                 # cap glibc malloc arenas to reduce RSS; 0 = unset
 
 [volume]
 pool = "bench-pool"
@@ -158,6 +159,7 @@ enabled = true
 workers = 4
 threads = 4
 timeout = 120
+malloc_arena_max = 2
 
 [letsencrypt]
 email = "ops@example.com"

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -154,6 +154,7 @@ class BenchConfig:
             threads=data.get("threads", 4),
             timeout=data.get("timeout", 120),
             worker_class=data.get("worker_class", "sync"),
+            malloc_arena_max=data.get("malloc_arena_max", 0),
         )
 
     @staticmethod
@@ -298,6 +299,10 @@ class BenchConfig:
             raise ConfigError(f"gunicorn.timeout must be a positive integer, got '{self.gunicorn.timeout}'.")
         if not self.gunicorn.worker_class:
             raise ConfigError("gunicorn.worker_class must not be empty.")
+        if not isinstance(self.gunicorn.malloc_arena_max, int) or self.gunicorn.malloc_arena_max < 0:
+            raise ConfigError(
+                f"gunicorn.malloc_arena_max must be a non-negative integer, got '{self.gunicorn.malloc_arena_max}'."
+            )
 
     def _validate_mariadb_version(self) -> None:
         if self.mariadb.version and not _VERSION_PATTERN.match(self.mariadb.version):

--- a/bench_cli/config/gunicorn_config.py
+++ b/bench_cli/config/gunicorn_config.py
@@ -7,3 +7,4 @@ class GunicornConfig:
     threads: int = 4
     timeout: int = 120
     worker_class: str = "sync"
+    malloc_arena_max: int = 2  # MALLOC_ARENA_MAX for Python procs; 0/absent = unset

--- a/bench_cli/config/toml_writer.py
+++ b/bench_cli/config/toml_writer.py
@@ -74,6 +74,7 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append(f"threads = {g.threads}")
     parts.append(f"timeout = {g.timeout}")
     parts.append(f'worker_class = "{g.worker_class}"')
+    parts.append(f"malloc_arena_max = {g.malloc_arena_max or 2}")
     parts.append("")
 
     le = config.letsencrypt

--- a/bench_cli/managers/process_manager.py
+++ b/bench_cli/managers/process_manager.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, List
 
@@ -33,6 +33,8 @@ class ProcessDefinition:
     name: str
     command: str
     log_file: Path
+    # Extra environment variables for this process (and anything it forks).
+    env: dict = field(default_factory=dict)
 
 
 class ProcessManager:
@@ -115,6 +117,7 @@ class ProcessManager:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 preexec_fn=os.setsid,
+                env={**os.environ, **pd.env} if pd.env else None,
             )
             color = _COLORS[i % len(_COLORS)]
             self._procs[pd.name] = proc
@@ -204,6 +207,14 @@ class ProcessManager:
             return self._web_definition(dev=True)
         return pd
 
+    def _py_memory_env(self) -> dict:
+        """Caps glibc malloc arenas for the Python procs to keep RSS down.
+        Companions inherit it by forking the gunicorn master."""
+        arenas = self.bench.config.gunicorn.malloc_arena_max
+        if arenas and arenas > 0:
+            return {"MALLOC_ARENA_MAX": str(arenas)}
+        return {}
+
     def _web_definition(self, dev: bool = False) -> ProcessDefinition:
         sites = self.bench.sites_path
         python = self.bench.env_path / "bin" / "python"
@@ -219,18 +230,22 @@ class ProcessManager:
             name="web",
             command=f"cd {sites} && {gunicorn} -c ../config/gunicorn.conf.py frappe.app:application",
             log_file=self.bench.logs_path / "web.log",
+            env=self._py_memory_env(),
         )
 
     def _socketio_definition(self) -> ProcessDefinition:
         if self.bench.config.socketio_backend == "python":
             python = self.bench.env_path / "bin" / "python"
             command = f"cd {self.bench.path} && {python} -m frappe.realtime.server"
+            backend_env = self._py_memory_env()
         else:
             command = f"cd {self.bench.sites_path} && node {self.bench.apps_path}/frappe/socketio.js"
+            backend_env = {}
         return ProcessDefinition(
             name="socketio",
             command=command,
             log_file=self.bench.logs_path / "socketio.log",
+            env=backend_env,
         )
 
     def _worker_pool_definition(self, queues: str, num_workers: int) -> ProcessDefinition:
@@ -239,6 +254,7 @@ class ProcessManager:
             name="worker_pool",
             command=f"cd {sites} && {self.bench.env_path}/bin/python -m frappe.utils.bench_helper frappe worker-pool --num-workers {num_workers} --queue {queues}",
             log_file=self.bench.logs_path / "worker_pool.log",
+            env=self._py_memory_env(),
         )
 
     def _worker_definitions(self, queue: str, count: int) -> List[ProcessDefinition]:
@@ -248,6 +264,7 @@ class ProcessManager:
                 name=f"worker_{queue}_{i}",
                 command=f"cd {sites} && {self.bench.env_path}/bin/python -m frappe.utils.bench_helper frappe worker --queue {queue}",
                 log_file=self.bench.logs_path / f"worker_{queue}_{i}.log",
+                env=self._py_memory_env(),
             )
             for i in range(1, count + 1)
         ]

--- a/bench_cli/managers/supervisor_process_manager.py
+++ b/bench_cli/managers/supervisor_process_manager.py
@@ -137,6 +137,8 @@ class SupervisorProcessManager(ProcessManager):
                 break
             env_vars.append(f'{m.group(1)}="{m.group(2)}"')
             cmd = cmd[m.end():]
+        for key, value in pd.env.items():
+            env_vars.append(f'{key}="{value}"')
 
         directory = ""
         m2 = re.match(r"^cd\s+(\S+)\s*&&\s*", cmd)

--- a/bench_cli/managers/systemd_process_manager.py
+++ b/bench_cli/managers/systemd_process_manager.py
@@ -151,6 +151,8 @@ class SystemdProcessManager(ProcessManager):
         while m := re.match(r"^([A-Z_][A-Z0-9_]*)=(\S+)\s+", cmd):
             env_lines.append(f"Environment={m.group(1)}={m.group(2)}")
             cmd = cmd[m.end() :]
+        for key, value in pd.env.items():
+            env_lines.append(f"Environment={key}={value}")
 
         working_dir = ""
         if m2 := re.match(r"^cd\s+(\S+)\s*&&\s*", cmd):

--- a/docs/config.md
+++ b/docs/config.md
@@ -57,6 +57,7 @@ workers = 4             # number of Gunicorn worker processes
 threads = 4             # threads per worker (used by gthread worker class)
 timeout = 120
 worker_class = "sync"
+malloc_arena_max = 2    # cap glibc malloc arenas to reduce RSS; 0 = leave unset
 
 # ── Let's Encrypt (production only) ──────────────────────────────────────────
 [letsencrypt]
@@ -191,6 +192,7 @@ Omit this section entirely for development benches. The section is only read by 
 | `threads` | int | no | `4` | Threads per worker. Used by the `gthread` worker class. |
 | `timeout` | int | no | `120` | Request timeout in seconds. |
 | `worker_class` | string | no | `sync` | Gunicorn worker class. |
+| `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to reduce RSS. `0` leaves the system default unset. |
 
 ### `[letsencrypt]` _(production only)_
 
@@ -251,7 +253,7 @@ bench validates `bench.toml` before executing any command. Violations produce a 
 5. Worker counts must be positive integers.
 6. `letsencrypt.email` must match a basic email pattern (`^[^@]+@[^@]+\.[^@]+$`) when present.
 7. `nginx.http_port` and `nginx.https_port` must be distinct.
-8. `gunicorn.workers`, `gunicorn.threads`, and `gunicorn.timeout` must be positive integers; `gunicorn.worker_class` must be a non-empty string.
+8. `gunicorn.workers`, `gunicorn.threads`, and `gunicorn.timeout` must be positive integers; `gunicorn.worker_class` must be a non-empty string; `gunicorn.malloc_arena_max` must be a non-negative integer.
 9. `mariadb.version` and `redis.version`, when present, must match `^\d+(\.\d+)*$` (e.g. `"10.6"`, `"7"`, `"7.0"`).
 10. When `volume.enabled = true`: `pool` and `device` must be non-empty; `reservation` and `quota` values must match a valid ZFS size pattern (e.g. `"10G"`, `"500M"`, `"1T"`); quota must be greater than reservation for both datasets.
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -130,6 +130,7 @@ workers = 4                          # number of Gunicorn worker processes
 threads = 4                          # threads per worker (used by gthread)
 timeout = 120
 worker_class = "sync"
+malloc_arena_max = 2                 # cap glibc malloc arenas; 0 = unset
 ```
 
 Gunicorn binds automatically to `127.0.0.1:<bench.http_port>` and `preload_app` is always enabled.
@@ -140,6 +141,7 @@ Gunicorn binds automatically to `127.0.0.1:<bench.http_port>` and `preload_app` 
 | `threads` | int | no | `4` | Threads per worker. Used by the `gthread` worker class. |
 | `timeout` | int | no | `120` | Request timeout in seconds. |
 | `worker_class` | string | no | `sync` | Gunicorn worker class. |
+| `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to reduce RSS. `0` leaves the system default unset. |
 
 ### `letsencrypt` section (new)
 
@@ -356,6 +358,7 @@ class GunicornConfig:
     threads: int = 4
     timeout: int = 120
     worker_class: str = 'sync'
+    malloc_arena_max: int = 2
 ```
 
 #### `LetsEncryptConfig`

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -377,3 +377,25 @@ def test_systemd_web_service_has_long_timeout_in_companion_mode(tmp_path: Path) 
     unit = manager._render_unit(web_pd)
 
     assert "TimeoutStopSec=1600" in unit
+
+
+def test_malloc_arena_max_in_units(tmp_path: Path) -> None:
+    from bench_cli.managers.supervisor_process_manager import SupervisorProcessManager
+    from bench_cli.managers.systemd_process_manager import SystemdProcessManager
+
+    bench = make_bench(tmp_path, gunicorn=GunicornConfig())  # default 2
+    systemd = SystemdProcessManager(bench)
+    web = next(pd for pd in systemd._prod_process_definitions() if pd.name == "web")
+    assert "Environment=MALLOC_ARENA_MAX=2" in systemd._render_unit(web)
+    assert 'MALLOC_ARENA_MAX="2"' in SupervisorProcessManager(bench)._render_program(web, "web")
+
+    # 0 disables the cap (no env emitted).
+    bench0 = make_bench(tmp_path, gunicorn=GunicornConfig(malloc_arena_max=0))
+    systemd0 = SystemdProcessManager(bench0)
+    web0 = next(pd for pd in systemd0._prod_process_definitions() if pd.name == "web")
+    assert "MALLOC_ARENA_MAX" not in systemd0._render_unit(web0)
+
+
+def test_malloc_arena_max_validation(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError):
+        make_bench(tmp_path, gunicorn=GunicornConfig(malloc_arena_max=-1)).config.validate()


### PR DESCRIPTION
Add gunicorn.malloc_arena_max (sets MALLOC_ARENA_MAX) on the Python web/companion/worker/socketio processes. glibc otherwise spawns up to 8 arenas per CPU per process, which inflated the web service from ~146MB to ~182MB.

Absent from bench.toml it is treated as 0 (system default, no cap); the toml writer emits 2 so new benches get the cap. Plumbed through ProcessDefinition.env into the procfile runner, systemd units, and supervisor programs. Documented in README, docs/config.md and docs/production.md.