### PR TITLE
ui: replace ZFS terminology with plain storage language

### DIFF
--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -77,9 +77,9 @@ def _validate(data: dict) -> str | None:
             return "volume_pool is required"
         backing = data.get("volume_backing", "auto")
         if backing == "device" and not data.get("volume_device"):
-            return "volume_device is required when volume backing is a block device"
+            return "A disk must be selected for dedicated disk storage"
         if backing == "image" and not data.get("volume_image_size"):
-            return "volume_image_size is required when volume backing is a disk image"
+            return "A storage file size is required for file-based storage"
     return None
 
 

--- a/admin/frontend/src/components/SettingsModal.vue
+++ b/admin/frontend/src/components/SettingsModal.vue
@@ -37,7 +37,7 @@ const BASE_TABS = [
 const isLinux = ref(false)
 const TABS = computed(() => {
   let tabs = isLinux.value
-    ? [...BASE_TABS, { key: 'volume', label: 'ZFS Volume' }]
+    ? [...BASE_TABS, { key: 'volume', label: 'Volume' }]
     : BASE_TABS
 
     return tabs
@@ -351,17 +351,17 @@ watch(() => props.modelValue, (val) => {
                 </div>
               </div>
 
-              <!-- ZFS Volume -->
+              <!-- Volume -->
               <div v-else-if="activeTab === 'volume'" class="flex flex-col gap-4">
                 <div class="grid grid-cols-2 gap-4">
-                  <FormControl label="Pool Name" :modelValue="form.volume.pool" disabled />
+                  <FormControl label="Volume Name" :modelValue="form.volume.pool" disabled />
                   <FormControl
                     v-if="form.volume.backing === 'image'"
-                    label="Disk Image"
+                    label="Storage File"
                     :modelValue="`${form.volume.image_path} (${form.volume.image_size})`"
                     disabled
                   />
-                  <FormControl v-else label="Block Device" :modelValue="form.volume.device" disabled />
+                  <FormControl v-else label="Disk" :modelValue="form.volume.device" disabled />
                 </div>
                 <div class="grid grid-cols-2 gap-4">
                   <FormControl label="Bench Reservation" v-model="form.volume.benches_reservation" />

--- a/admin/frontend/src/pages/Monitor.vue
+++ b/admin/frontend/src/pages/Monitor.vue
@@ -166,7 +166,7 @@ onUnmounted(() => {
 
           <div v-if="stats.volume?.enabled">
             <div class="mb-2 flex items-baseline justify-between">
-              <span class="text-sm font-medium text-ink-gray-7">ZFS Pool</span>
+              <span class="text-sm font-medium text-ink-gray-7">Volume</span>
               <Badge :label="stats.volume.pool_health" :theme="poolHealthTheme(stats.volume.pool_health)" />
             </div>
             <p class="font-mono text-xs text-ink-gray-4">{{ stats.volume.pool }}</p>

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -169,7 +169,7 @@ const modalWidthClass = computed(() => {
 const titles = {
   passwords: 'Set up passwords',
   customize: 'Customize your bench',
-  volume: 'Storage setup',
+  volume: 'Storage setup (ZFS)',
   running: 'Initializing bench…',
   done: 'Setup complete',
 }

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -110,7 +110,7 @@ const imageSliderModel = computed({
 const deviceOptions = computed(() => [
   ...availableDevices.value.map((d) => ({
     label: `${d.path} (${Math.floor(d.size_bytes / 1024 ** 3)}G${
-      d.pool ? `, pool: ${d.pool}` : d.has_signature ? ', stale data' : ''
+      d.pool ? `, existing volume: ${d.pool}` : d.has_signature ? ', stale data' : ''
     })`,
     value: d.path,
   })),
@@ -169,12 +169,12 @@ const modalWidthClass = computed(() => {
 const titles = {
   passwords: 'Set up passwords',
   customize: 'Customize your bench',
-  volume: 'ZFS volume management',
+  volume: 'Storage setup',
   running: 'Initializing bench…',
   done: 'Setup complete',
 }
 const subtitles = {
-  volume: 'Choose where the ZFS pool lives — a spare disk or a disk image on the root filesystem',
+  volume: 'Choose where your data is stored — a dedicated disk gives better isolation, or you can use space from your current disk',
 }
 const title = computed(() => titles[step.value] || benchName.value)
 const subtitle = computed(() => subtitles[step.value] || null)
@@ -283,14 +283,14 @@ function parseSize(value) {
 
 function validateVolume() {
   if (!isLinux.value || !form.value.volume_enabled) return null
-  if (!form.value.volume_pool) return 'Pool name is required.'
+  if (!form.value.volume_pool) return 'Volume name is required.'
   const sizeHint = 'must be a positive integer with a K/M/G/T suffix (e.g. 10G)'
   let imageSize = null
   if (form.value.volume_backing === 'image') {
     imageSize = parseSize(form.value.volume_image_size)
     if (imageSize === null) return `Image size "${form.value.volume_image_size}" ${sizeHint}.`
   } else if (!form.value.volume_device) {
-    return 'Block device is required.'
+    return 'Disk is required.'
   }
   const datasets = [
     ['Bench', form.value.volume_benches_reservation, form.value.volume_benches_quota],
@@ -451,24 +451,24 @@ function backToConfig() {
         <div v-else-if="step === 'volume'" class="flex flex-col gap-4">
           <FormControl
             type="select"
-            label="Storage backing"
+            label="Storage type"
             v-model="form.volume_backing"
             :options="[
-              { label: 'Dedicated block device', value: 'device' },
-              { label: 'Disk image on root filesystem (no spare disk needed)', value: 'image' },
+              { label: 'Dedicated disk', value: 'device' },
+              { label: 'File on existing disk (no spare disk needed)', value: 'image' },
             ]"
           />
-          <FormControl label="Pool name" v-model="form.volume_pool" placeholder="bench-pool" />
+          <FormControl label="Volume name" v-model="form.volume_pool" placeholder="bench-pool" />
           <FormControl
             v-if="form.volume_backing === 'device' && showDeviceDropdown"
             type="select"
-            label="Block device"
+            label="Disk"
             v-model="form.volume_device"
             :options="deviceOptions"
           />
           <FormControl
             v-else-if="form.volume_backing === 'device'"
-            label="Block device"
+            label="Disk"
             v-model="form.volume_device"
             placeholder="/dev/sdb"
           />
@@ -490,8 +490,8 @@ function backToConfig() {
             <Slider v-model="imageSliderModel" :min="imageSizeMinGiB" :max="imageSizeMaxGiB" :step="1" />
           </div>
           <p v-if="form.volume_backing === 'image'" class="text-xs text-ink-gray-4">
-            A preallocated {{ form.volume_image_size }} file will be created at
-            /var/lib/bench-zfs/{{ form.volume_pool || 'pool' }}.img and used as the ZFS pool.
+            A {{ form.volume_image_size }} storage file will be created at
+            /var/lib/bench-zfs/{{ form.volume_pool || 'bench' }}.img and used as the storage volume.
           </p>
           <div class="grid grid-cols-2 gap-2">
             <FormControl label="Bench reservation" v-model="form.volume_benches_reservation" @input="sizesTouched = true" />

--- a/admin/frontend/src/pages/Snapshots.vue
+++ b/admin/frontend/src/pages/Snapshots.vue
@@ -204,10 +204,9 @@ onMounted(loadSnapshots)
           class="rounded border border-outline-amber-1 bg-surface-amber-1 p-3 text-ink-amber-3"
         >
           <p class="font-medium">MariaDB will be stopped and restarted</p>
-          <p class="mt-1 text-ink-amber-2">The following commands will run in order:</p>
-          <pre class="mt-2 rounded bg-surface-white px-3 py-2 font-mono text-xs text-ink-gray-9">sudo systemctl stop mariadb
-sudo zfs rollback -r {{ rollbackRow?.tag }}
-sudo systemctl start mariadb</pre>
+          <p class="mt-1 text-ink-amber-2">
+            MariaDB will be stopped, the snapshot will be restored, then MariaDB will restart automatically.
+          </p>
           <p class="mt-2 text-ink-amber-2">
             Ensure no critical database operations are in progress before proceeding.
           </p>


### PR DESCRIPTION
- Setup wizard: "ZFS volume management" → "Storage setup", backing options renamed to plain English, pool → volume name, block device → disk
- Settings modal: tab "ZFS Volume" → "Volume", field labels updated
- Monitor: "ZFS Pool" → "Volume"
- Snapshots rollback dialog: removed raw `sudo zfs rollback` command, replaced with plain description
- Backend error messages: removed "block device" / "disk image" jargon

Prompts:
> most users will be confused by seeing ZFS. for them it should just be defining some volume and then snapshot management in the admin panel. in the admin panel and setup, remove references to ZFS. just call it volume and snapshot management where necessary. plan this change.
> accept and make a PR for this