### PR TITLE
feat: Optimize for small sites by default to cap memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ workers = 4
 threads = 4                          # threads per worker (used by gthread)
 timeout = 120
 malloc_arena_max = 2                 # cap glibc malloc arenas to reduce RSS; 0 = unset
-memory_allocator = "pymalloc"        # pymalloc (prod) | jemalloc (demo/overcommit: releases RAM eagerly)
+max_requests = 0                     # recycle the web worker after N requests to release heap; 0 = disabled
+max_requests_jitter = 0              # random +/- spread on max_requests so workers don't all recycle at once
 
 [volume]
 pool = "bench-pool"
@@ -161,7 +162,7 @@ workers = 4
 threads = 4
 timeout = 120
 malloc_arena_max = 2
-memory_allocator = "pymalloc"
+max_requests = 0
 
 [letsencrypt]
 email = "ops@example.com"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ workers = 4
 threads = 4                          # threads per worker (used by gthread)
 timeout = 120
 malloc_arena_max = 2                 # cap glibc malloc arenas to reduce RSS; 0 = unset
-memory_allocator = "auto"            # auto|jemalloc|pymalloc; auto uses jemalloc if installed
+memory_allocator = "pymalloc"        # pymalloc (prod) | jemalloc (demo/overcommit: releases RAM eagerly)
 
 [volume]
 pool = "bench-pool"
@@ -161,7 +161,7 @@ workers = 4
 threads = 4
 timeout = 120
 malloc_arena_max = 2
-memory_allocator = "auto"
+memory_allocator = "pymalloc"
 
 [letsencrypt]
 email = "ops@example.com"

--- a/README.md
+++ b/README.md
@@ -104,8 +104,7 @@ workers = 4
 threads = 4                          # threads per worker (used by gthread)
 timeout = 120
 malloc_arena_max = 2                 # cap glibc malloc arenas to reduce RSS; 0 = unset
-malloc_trim_requests = 100           # trim heap after N requests; 0 = disable
-malloc_trim_interval = 300           # trim heap every N seconds (idle too); 0 = disable
+memory_allocator = "auto"            # auto|jemalloc|pymalloc; auto uses jemalloc if installed
 
 [volume]
 pool = "bench-pool"
@@ -162,8 +161,7 @@ workers = 4
 threads = 4
 timeout = 120
 malloc_arena_max = 2
-malloc_trim_requests = 100
-malloc_trim_interval = 300
+memory_allocator = "auto"
 
 [letsencrypt]
 email = "ops@example.com"

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ workers = 4
 threads = 4                          # threads per worker (used by gthread)
 timeout = 120
 malloc_arena_max = 2                 # cap glibc malloc arenas to reduce RSS; 0 = unset
+malloc_trim_requests = 100           # trim heap after N requests; 0 = disable
+malloc_trim_interval = 300           # trim heap every N seconds (idle too); 0 = disable
 
 [volume]
 pool = "bench-pool"
@@ -160,6 +162,8 @@ workers = 4
 threads = 4
 timeout = 120
 malloc_arena_max = 2
+malloc_trim_requests = 100
+malloc_trim_interval = 300
 
 [letsencrypt]
 email = "ops@example.com"

--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import os
 import secrets
+import signal
+import threading
+import time
 from pathlib import Path
 
 from flask import Flask, jsonify, request, send_file, session
@@ -35,11 +39,50 @@ def _wizard_status(bench_root: Path) -> dict:
     return {"wizard": True, "name": name, "enabled": True, "authenticated": True}
 
 
+def _install_idle_watchdog(app: Flask) -> None:
+    """Stop the admin after a period of inactivity when socket-activated.
+
+    Enabled only when BENCH_ADMIN_IDLE_TIMEOUT is set, which the systemd service
+    unit does. Under gunicorn (workers=1, preload_app=False) this runs in the
+    worker, so os.getppid() is the gunicorn arbiter — SIGTERM to it triggers a
+    graceful shutdown and the service stops. systemd keeps the .socket listening,
+    so the next request re-activates the service.
+    """
+    raw = os.environ.get("BENCH_ADMIN_IDLE_TIMEOUT")
+    if not raw:
+        return
+    timeout = int(raw)
+    if timeout <= 0:
+        return
+
+    last_request = time.monotonic()
+    lock = threading.Lock()
+
+    @app.before_request
+    def _touch() -> None:
+        nonlocal last_request
+        with lock:
+            last_request = time.monotonic()
+
+    def _watchdog() -> None:
+        while True:
+            time.sleep(min(timeout, 30))
+            with lock:
+                idle = time.monotonic() - last_request
+            if idle > timeout:
+                os.kill(os.getppid(), signal.SIGTERM)
+                return
+
+    threading.Thread(target=_watchdog, daemon=True).start()
+
+
 def create_app(bench_root: Path) -> Flask:
     app = Flask(__name__, static_folder=str(_STATIC_DIR), static_url_path="/static")
     app.config["BENCH_ROOT"] = bench_root
     app.config["TEMPLATES_AUTO_RELOAD"] = False
     app.secret_key = secrets.token_hex(32)
+
+    _install_idle_watchdog(app)
 
     def _load_config():
         return BenchConfig.from_file(bench_root / "bench.toml")

--- a/admin/backend/wsgi.py
+++ b/admin/backend/wsgi.py
@@ -1,0 +1,15 @@
+"""WSGI entrypoint for running the admin under gunicorn.
+
+The bench root is passed via the BENCH_ADMIN_ROOT environment variable (set by
+the systemd service unit) since gunicorn imports a module-level callable rather
+than invoking a main() with argv.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from admin.backend.app import create_app
+
+application = create_app(Path(os.environ["BENCH_ADMIN_ROOT"]))

--- a/bench_cli/config/admin_config.py
+++ b/bench_cli/config/admin_config.py
@@ -8,3 +8,10 @@ class AdminConfig:
     enabled: bool = False
     password: str = ""
     domain: str = ""
+
+    @property
+    def internal_port(self) -> int:
+        """Localhost-only port that gunicorn binds (via the systemd socket) when
+        the admin is socket-activated. nginx listens on `port` and forwards here.
+        Derived for now; promote to a bench.toml field if it needs to be tunable."""
+        return self.port + 1

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -155,8 +155,7 @@ class BenchConfig:
             timeout=data.get("timeout", 120),
             worker_class=data.get("worker_class", "sync"),
             malloc_arena_max=data.get("malloc_arena_max", 0),
-            malloc_trim_requests=data.get("malloc_trim_requests", 100),
-            malloc_trim_interval=data.get("malloc_trim_interval", 300),
+            memory_allocator=data.get("memory_allocator", "auto"),
         )
 
     @staticmethod
@@ -305,13 +304,9 @@ class BenchConfig:
             raise ConfigError(
                 f"gunicorn.malloc_arena_max must be a non-negative integer, got '{self.gunicorn.malloc_arena_max}'."
             )
-        if not isinstance(self.gunicorn.malloc_trim_requests, int) or self.gunicorn.malloc_trim_requests < 0:
+        if self.gunicorn.memory_allocator not in ("auto", "jemalloc", "pymalloc"):
             raise ConfigError(
-                f"gunicorn.malloc_trim_requests must be a non-negative integer, got '{self.gunicorn.malloc_trim_requests}'."
-            )
-        if not isinstance(self.gunicorn.malloc_trim_interval, int) or self.gunicorn.malloc_trim_interval < 0:
-            raise ConfigError(
-                f"gunicorn.malloc_trim_interval must be a non-negative integer, got '{self.gunicorn.malloc_trim_interval}'."
+                f"gunicorn.memory_allocator must be one of 'auto', 'jemalloc', 'pymalloc', got '{self.gunicorn.memory_allocator}'."
             )
 
     def _validate_mariadb_version(self) -> None:

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -155,7 +155,8 @@ class BenchConfig:
             timeout=data.get("timeout", 120),
             worker_class=data.get("worker_class", "sync"),
             malloc_arena_max=data.get("malloc_arena_max", 0),
-            memory_allocator=data.get("memory_allocator", "pymalloc"),
+            max_requests=data.get("max_requests", 0),
+            max_requests_jitter=data.get("max_requests_jitter", 0),
         )
 
     @staticmethod
@@ -304,9 +305,13 @@ class BenchConfig:
             raise ConfigError(
                 f"gunicorn.malloc_arena_max must be a non-negative integer, got '{self.gunicorn.malloc_arena_max}'."
             )
-        if self.gunicorn.memory_allocator not in ("jemalloc", "pymalloc"):
+        if not isinstance(self.gunicorn.max_requests, int) or self.gunicorn.max_requests < 0:
             raise ConfigError(
-                f"gunicorn.memory_allocator must be 'jemalloc' or 'pymalloc', got '{self.gunicorn.memory_allocator}'."
+                f"gunicorn.max_requests must be a non-negative integer, got '{self.gunicorn.max_requests}'."
+            )
+        if not isinstance(self.gunicorn.max_requests_jitter, int) or self.gunicorn.max_requests_jitter < 0:
+            raise ConfigError(
+                f"gunicorn.max_requests_jitter must be a non-negative integer, got '{self.gunicorn.max_requests_jitter}'."
             )
 
     def _validate_mariadb_version(self) -> None:

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -155,7 +155,7 @@ class BenchConfig:
             timeout=data.get("timeout", 120),
             worker_class=data.get("worker_class", "sync"),
             malloc_arena_max=data.get("malloc_arena_max", 0),
-            memory_allocator=data.get("memory_allocator", "auto"),
+            memory_allocator=data.get("memory_allocator", "pymalloc"),
         )
 
     @staticmethod
@@ -304,9 +304,9 @@ class BenchConfig:
             raise ConfigError(
                 f"gunicorn.malloc_arena_max must be a non-negative integer, got '{self.gunicorn.malloc_arena_max}'."
             )
-        if self.gunicorn.memory_allocator not in ("auto", "jemalloc", "pymalloc"):
+        if self.gunicorn.memory_allocator not in ("jemalloc", "pymalloc"):
             raise ConfigError(
-                f"gunicorn.memory_allocator must be one of 'auto', 'jemalloc', 'pymalloc', got '{self.gunicorn.memory_allocator}'."
+                f"gunicorn.memory_allocator must be 'jemalloc' or 'pymalloc', got '{self.gunicorn.memory_allocator}'."
             )
 
     def _validate_mariadb_version(self) -> None:

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -155,6 +155,8 @@ class BenchConfig:
             timeout=data.get("timeout", 120),
             worker_class=data.get("worker_class", "sync"),
             malloc_arena_max=data.get("malloc_arena_max", 0),
+            malloc_trim_requests=data.get("malloc_trim_requests", 100),
+            malloc_trim_interval=data.get("malloc_trim_interval", 300),
         )
 
     @staticmethod
@@ -302,6 +304,14 @@ class BenchConfig:
         if not isinstance(self.gunicorn.malloc_arena_max, int) or self.gunicorn.malloc_arena_max < 0:
             raise ConfigError(
                 f"gunicorn.malloc_arena_max must be a non-negative integer, got '{self.gunicorn.malloc_arena_max}'."
+            )
+        if not isinstance(self.gunicorn.malloc_trim_requests, int) or self.gunicorn.malloc_trim_requests < 0:
+            raise ConfigError(
+                f"gunicorn.malloc_trim_requests must be a non-negative integer, got '{self.gunicorn.malloc_trim_requests}'."
+            )
+        if not isinstance(self.gunicorn.malloc_trim_interval, int) or self.gunicorn.malloc_trim_interval < 0:
+            raise ConfigError(
+                f"gunicorn.malloc_trim_interval must be a non-negative integer, got '{self.gunicorn.malloc_trim_interval}'."
             )
 
     def _validate_mariadb_version(self) -> None:

--- a/bench_cli/config/gunicorn_config.py
+++ b/bench_cli/config/gunicorn_config.py
@@ -7,6 +7,7 @@ class GunicornConfig:
     threads: int = 4
     timeout: int = 120
     worker_class: str = "sync"
-    malloc_arena_max: int = 2  # MALLOC_ARENA_MAX for Python procs; 0/absent = unset
-    malloc_trim_requests: int = 100  # malloc_trim(0) after N requests; 0 = disable
-    malloc_trim_interval: int = 300  # malloc_trim(0) after N seconds; 0 = disable
+    malloc_arena_max: int = 2  # MALLOC_ARENA_MAX for Python procs (pymalloc only); 0/absent = unset
+    # Memory allocator for the Python procs: "auto" uses jemalloc when the lib is
+    # present on the host, else pymalloc; "jemalloc"/"pymalloc" force the choice.
+    memory_allocator: str = "auto"

--- a/bench_cli/config/gunicorn_config.py
+++ b/bench_cli/config/gunicorn_config.py
@@ -7,10 +7,6 @@ class GunicornConfig:
     threads: int = 4
     timeout: int = 120
     worker_class: str = "sync"
-    malloc_arena_max: int = 2  # MALLOC_ARENA_MAX for Python procs (pymalloc only); 0/absent = unset
-    # Allocator for the Python procs. "pymalloc" (default) is stock CPython on
-    # glibc — best throughput, for production. "jemalloc" LD_PRELOADs jemalloc
-    # tuned to release freed memory to the OS immediately (MADV_DONTNEED) — for
-    # small/demo benches and memory-overcommitted hosts. Falls back to pymalloc
-    # if libjemalloc is not installed.
-    memory_allocator: str = "pymalloc"
+    malloc_arena_max: int = 2  # cap glibc malloc arenas; 0 = unset
+    max_requests: int = 0  # recycle web worker after N requests to release heap; 0 = disabled
+    max_requests_jitter: int = 0

--- a/bench_cli/config/gunicorn_config.py
+++ b/bench_cli/config/gunicorn_config.py
@@ -8,6 +8,9 @@ class GunicornConfig:
     timeout: int = 120
     worker_class: str = "sync"
     malloc_arena_max: int = 2  # MALLOC_ARENA_MAX for Python procs (pymalloc only); 0/absent = unset
-    # Memory allocator for the Python procs: "auto" uses jemalloc when the lib is
-    # present on the host, else pymalloc; "jemalloc"/"pymalloc" force the choice.
-    memory_allocator: str = "auto"
+    # Allocator for the Python procs. "pymalloc" (default) is stock CPython on
+    # glibc — best throughput, for production. "jemalloc" LD_PRELOADs jemalloc
+    # tuned to release freed memory to the OS immediately (MADV_DONTNEED) — for
+    # small/demo benches and memory-overcommitted hosts. Falls back to pymalloc
+    # if libjemalloc is not installed.
+    memory_allocator: str = "pymalloc"

--- a/bench_cli/config/gunicorn_config.py
+++ b/bench_cli/config/gunicorn_config.py
@@ -8,3 +8,5 @@ class GunicornConfig:
     timeout: int = 120
     worker_class: str = "sync"
     malloc_arena_max: int = 2  # MALLOC_ARENA_MAX for Python procs; 0/absent = unset
+    malloc_trim_requests: int = 100  # malloc_trim(0) after N requests; 0 = disable
+    malloc_trim_interval: int = 300  # malloc_trim(0) after N seconds; 0 = disable

--- a/bench_cli/config/toml_writer.py
+++ b/bench_cli/config/toml_writer.py
@@ -75,8 +75,7 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append(f"timeout = {g.timeout}")
     parts.append(f'worker_class = "{g.worker_class}"')
     parts.append(f"malloc_arena_max = {g.malloc_arena_max or 2}")
-    parts.append(f"malloc_trim_requests = {g.malloc_trim_requests}")
-    parts.append(f"malloc_trim_interval = {g.malloc_trim_interval}")
+    parts.append(f'memory_allocator = "{g.memory_allocator}"')
     parts.append("")
 
     le = config.letsencrypt

--- a/bench_cli/config/toml_writer.py
+++ b/bench_cli/config/toml_writer.py
@@ -75,7 +75,8 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append(f"timeout = {g.timeout}")
     parts.append(f'worker_class = "{g.worker_class}"')
     parts.append(f"malloc_arena_max = {g.malloc_arena_max or 2}")
-    parts.append(f'memory_allocator = "{g.memory_allocator}"')
+    parts.append(f"max_requests = {g.max_requests}")
+    parts.append(f"max_requests_jitter = {g.max_requests_jitter}")
     parts.append("")
 
     le = config.letsencrypt

--- a/bench_cli/config/toml_writer.py
+++ b/bench_cli/config/toml_writer.py
@@ -75,6 +75,8 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append(f"timeout = {g.timeout}")
     parts.append(f'worker_class = "{g.worker_class}"')
     parts.append(f"malloc_arena_max = {g.malloc_arena_max or 2}")
+    parts.append(f"malloc_trim_requests = {g.malloc_trim_requests}")
+    parts.append(f"malloc_trim_interval = {g.malloc_trim_interval}")
     parts.append("")
 
     le = config.letsencrypt

--- a/bench_cli/managers/admin_env_manager.py
+++ b/bench_cli/managers/admin_env_manager.py
@@ -20,6 +20,10 @@ class AdminEnvManager:
         return self.venv_path / "bin" / "python"
 
     @property
+    def gunicorn(self) -> Path:
+        return self.venv_path / "bin" / "gunicorn"
+
+    @property
     def uv(self) -> str:
         uv = shutil.which("uv")
         if not uv:
@@ -64,7 +68,7 @@ class AdminEnvManager:
     def _read_admin_deps(self) -> list[str]:
         pyproject = self.venv_path.parent / "pyproject.toml"
         if not pyproject.exists():
-            return ["flask>=3.0", "psutil>=5.9", "pymysql>=1.1"]
+            return ["flask>=3.0", "psutil>=5.9", "pymysql>=1.1", "gunicorn>=21.2"]
         with open(pyproject, "rb") as f:
             data = tomllib.load(f)
         return data.get("project", {}).get("optional-dependencies", {}).get("admin")

--- a/bench_cli/managers/gunicorn_manager.py
+++ b/bench_cli/managers/gunicorn_manager.py
@@ -73,29 +73,33 @@ class GunicornManager:
         return self._render_companion_config(base)
 
     def _malloc_trim_hook(self) -> str:
-        """A throttled post_request hook that returns freed heap to the OS.
+        """A background timer thread that returns freed heap to the OS.
 
         glibc keeps freed allocations in per-arena free lists, so a transient
         spike (large query/report) pins the web worker's RSS at its high-water
-        mark. Calling malloc_trim(0) periodically gives that memory back. We
-        trim after `malloc_trim_requests` requests OR every `malloc_trim_interval`
-        seconds, whichever comes first; the time check only fires on the next
-        request, which is fine because an idle worker has nothing new to free.
-        Returns "" when both knobs are disabled."""
+        mark. malloc_trim(0) gives that memory back. A daemon thread (started in
+        each worker via post_worker_init) trims every `malloc_trim_interval`
+        seconds regardless of traffic — so an idle worker still reclaims after a
+        spike — and post_request wakes it early once `malloc_trim_requests`
+        requests have accrued. Either knob is disabled with 0; both 0 -> ""."""
         cfg = self.bench.config.gunicorn
         reqs, interval = cfg.malloc_trim_requests, cfg.malloc_trim_interval
         if reqs <= 0 and interval <= 0:
             return ""
-        req_cond = f'st["count"] >= {reqs}' if reqs > 0 else "False"
-        time_cond = f'(now - st["last"]) >= {interval}' if interval > 0 else "False"
+        post_request = "" if reqs <= 0 else f'''
+
+def post_request(worker, req, environ, resp):
+    global _malloc_trim_count
+    with _malloc_trim_lock:
+        _malloc_trim_count += 1
+        if _malloc_trim_count >= {reqs}:
+            _malloc_trim_event.set()
+'''
         return f'''
 
 import ctypes
 import threading
-import time
 
-_malloc_trim_lock = threading.Lock()
-_malloc_trim_state = {{"count": 0, "last": 0.0}}
 try:
     _libc = ctypes.CDLL("libc.so.6", use_errno=True)
     _libc.malloc_trim.argtypes = [ctypes.c_size_t]
@@ -103,24 +107,27 @@ try:
 except (OSError, AttributeError):
     _libc = None
 
+_malloc_trim_event = threading.Event()
+_malloc_trim_lock = threading.Lock()
+_malloc_trim_count = 0
 
-def post_request(worker, req, environ, resp):
-    if _libc is None:
-        return
-    now = time.monotonic()
-    do_trim = False
-    with _malloc_trim_lock:
-        st = _malloc_trim_state
-        if st["last"] == 0.0:
-            st["last"] = now
-        st["count"] += 1
-        if {req_cond} or {time_cond}:
-            st["count"] = 0
-            st["last"] = now
-            do_trim = True
-    if do_trim:
-        _libc.malloc_trim(0)
-'''
+
+def _malloc_trim_loop():
+    global _malloc_trim_count
+    timeout = {interval} or None
+    while True:
+        _malloc_trim_event.wait(timeout)
+        _malloc_trim_event.clear()
+        with _malloc_trim_lock:
+            _malloc_trim_count = 0
+        if _libc is not None:
+            _libc.malloc_trim(0)
+
+
+def post_worker_init(worker):
+    if _libc is not None:
+        threading.Thread(target=_malloc_trim_loop, name="malloc-trim", daemon=True).start()
+{post_request}'''
 
     def _render_companion_config(self, base: str) -> str:
         sites_dir = self.bench.sites_path

--- a/bench_cli/managers/gunicorn_manager.py
+++ b/bench_cli/managers/gunicorn_manager.py
@@ -67,65 +67,8 @@ class GunicornManager:
             f"preload_app = True\n"
         )
         if not self.bench.config.production.use_companion_manager:
-            return base + self._malloc_trim_hook()
+            return base
         return self._render_companion_config(base)
-
-    def _malloc_trim_hook(self) -> str:
-        """A background timer thread that returns freed heap to the OS.
-
-        glibc keeps freed allocations in per-arena free lists, so a transient
-        spike (large query/report) pins the web worker's RSS at its high-water
-        mark. malloc_trim(0) gives that memory back. A daemon thread (started in
-        each worker via post_worker_init) trims every `malloc_trim_interval`
-        seconds regardless of traffic — so an idle worker still reclaims after a
-        spike — and post_request wakes it early once `malloc_trim_requests`
-        requests have accrued. Either knob is disabled with 0; both 0 -> ""."""
-        cfg = self.bench.config.gunicorn
-        reqs, interval = cfg.malloc_trim_requests, cfg.malloc_trim_interval
-        if reqs <= 0 and interval <= 0:
-            return ""
-        post_request = "" if reqs <= 0 else f'''
-
-def post_request(worker, req, environ, resp):
-    global _malloc_trim_count
-    with _malloc_trim_lock:
-        _malloc_trim_count += 1
-        if _malloc_trim_count >= {reqs}:
-            _malloc_trim_event.set()
-'''
-        return f'''
-
-import ctypes
-import threading
-
-try:
-    _libc = ctypes.CDLL("libc.so.6", use_errno=True)
-    _libc.malloc_trim.argtypes = [ctypes.c_size_t]
-    _libc.malloc_trim.restype = ctypes.c_int
-except (OSError, AttributeError):
-    _libc = None
-
-_malloc_trim_event = threading.Event()
-_malloc_trim_lock = threading.Lock()
-_malloc_trim_count = 0
-
-
-def _malloc_trim_loop():
-    global _malloc_trim_count
-    timeout = {interval} or None
-    while True:
-        _malloc_trim_event.wait(timeout)
-        _malloc_trim_event.clear()
-        with _malloc_trim_lock:
-            _malloc_trim_count = 0
-        if _libc is not None:
-            _libc.malloc_trim(0)
-
-
-def post_worker_init(worker):
-    if _libc is not None:
-        threading.Thread(target=_malloc_trim_loop, name="malloc-trim", daemon=True).start()
-{post_request}'''
 
     def _render_companion_config(self, base: str) -> str:
         sites_dir = self.bench.sites_path
@@ -155,7 +98,6 @@ def post_worker_init(worker):
             + "def when_ready(server):\n"
             + "    from frappe._optimizations import freeze_gc\n"
             + "    freeze_gc()\n"
-            + self._malloc_trim_hook()
         )
 
     def _render_companion_workers(self, sites_dir: Path, logs_dir: Path) -> str:

--- a/bench_cli/managers/gunicorn_manager.py
+++ b/bench_cli/managers/gunicorn_manager.py
@@ -66,6 +66,9 @@ class GunicornManager:
             f"timeout = {cfg.timeout}\n"
             f"preload_app = True\n"
         )
+        if cfg.max_requests > 0:
+            base += f"max_requests = {cfg.max_requests}\n"
+            base += f"max_requests_jitter = {cfg.max_requests_jitter}\n"
         if not self.bench.config.production.use_companion_manager:
             return base
         return self._render_companion_config(base)

--- a/bench_cli/managers/gunicorn_manager.py
+++ b/bench_cli/managers/gunicorn_manager.py
@@ -69,8 +69,58 @@ class GunicornManager:
             f"preload_app = True\n"
         )
         if not self.bench.config.production.use_companion_manager:
-            return base
+            return base + self._malloc_trim_hook()
         return self._render_companion_config(base)
+
+    def _malloc_trim_hook(self) -> str:
+        """A throttled post_request hook that returns freed heap to the OS.
+
+        glibc keeps freed allocations in per-arena free lists, so a transient
+        spike (large query/report) pins the web worker's RSS at its high-water
+        mark. Calling malloc_trim(0) periodically gives that memory back. We
+        trim after `malloc_trim_requests` requests OR every `malloc_trim_interval`
+        seconds, whichever comes first; the time check only fires on the next
+        request, which is fine because an idle worker has nothing new to free.
+        Returns "" when both knobs are disabled."""
+        cfg = self.bench.config.gunicorn
+        reqs, interval = cfg.malloc_trim_requests, cfg.malloc_trim_interval
+        if reqs <= 0 and interval <= 0:
+            return ""
+        req_cond = f'st["count"] >= {reqs}' if reqs > 0 else "False"
+        time_cond = f'(now - st["last"]) >= {interval}' if interval > 0 else "False"
+        return f'''
+
+import ctypes
+import threading
+import time
+
+_malloc_trim_lock = threading.Lock()
+_malloc_trim_state = {{"count": 0, "last": 0.0}}
+try:
+    _libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    _libc.malloc_trim.argtypes = [ctypes.c_size_t]
+    _libc.malloc_trim.restype = ctypes.c_int
+except (OSError, AttributeError):
+    _libc = None
+
+
+def post_request(worker, req, environ, resp):
+    if _libc is None:
+        return
+    now = time.monotonic()
+    do_trim = False
+    with _malloc_trim_lock:
+        st = _malloc_trim_state
+        if st["last"] == 0.0:
+            st["last"] = now
+        st["count"] += 1
+        if {req_cond} or {time_cond}:
+            st["count"] = 0
+            st["last"] = now
+            do_trim = True
+    if do_trim:
+        _libc.malloc_trim(0)
+'''
 
     def _render_companion_config(self, base: str) -> str:
         sites_dir = self.bench.sites_path
@@ -100,6 +150,7 @@ class GunicornManager:
             + "def when_ready(server):\n"
             + "    from frappe._optimizations import freeze_gc\n"
             + "    freeze_gc()\n"
+            + self._malloc_trim_hook()
         )
 
     def _render_companion_workers(self, sites_dir: Path, logs_dir: Path) -> str:

--- a/bench_cli/managers/gunicorn_manager.py
+++ b/bench_cli/managers/gunicorn_manager.py
@@ -27,9 +27,32 @@ class GunicornManager:
     def config_path(self) -> Path:
         return self.bench.config_path / "gunicorn.conf.py"
 
+    @property
+    def admin_config_path(self) -> Path:
+        return self.bench.config_path / "admin-gunicorn.conf.py"
+
     def generate_config(self) -> None:
         self.config_path.parent.mkdir(parents=True, exist_ok=True)
         self.config_path.write_text(self._render_config())
+
+    def generate_admin_config(self) -> None:
+        """Gunicorn config for the socket-activated admin.
+
+        Bound to a localhost port as a fallback; under systemd socket activation
+        gunicorn inherits the listening socket via LISTEN_FDS and ignores `bind`.
+        Single worker with threads so the in-app idle watchdog and SSE streams
+        share one process. No preload, so create_app runs in the worker (the
+        watchdog needs the arbiter as its parent)."""
+        cfg = self.bench.config.admin
+        self.admin_config_path.parent.mkdir(parents=True, exist_ok=True)
+        self.admin_config_path.write_text(
+            f'bind = "127.0.0.1:{cfg.internal_port}"\n'
+            f"workers = 1\n"
+            f"threads = 8\n"
+            f'worker_class = "gthread"\n'
+            f"timeout = 120\n"
+            f"preload_app = False\n"
+        )
 
     def _render_config(self) -> str:
         cfg = self.bench.config.gunicorn

--- a/bench_cli/managers/gunicorn_manager.py
+++ b/bench_cli/managers/gunicorn_manager.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from bench_cli.config.worker_config import WorkerGroup
     from bench_cli.core.bench import Bench
 
 
@@ -15,7 +14,6 @@ _COMPANION_QUEUE_STOP_TIMEOUT = {
     "long": 1560,
     "short": 360,
 }
-_COMPANION_SCHEDULER_TIMEOUT = 60
 _COMPANION_SOCKETIO_TIMEOUT = 30
 
 
@@ -185,18 +183,9 @@ def post_worker_init(worker):
         return f'        "{key}": {value}'
 
     def _build_companion_workers(self, sites_dir: Path, logs_dir: Path) -> list[dict]:
-        workers: list[dict] = [
-            self._companion_spec(
-                "scheduler",
-                "frappe.gunicorn_companion:run_scheduler",
-                cwd=sites_dir,
-                stop_timeout=_COMPANION_SCHEDULER_TIMEOUT,
-                logs_dir=logs_dir,
-            )
-        ]
-
-        for group_index, group in enumerate(self.bench.config.workers.groups, start=1):
-            workers.extend(self._worker_group_specs(group_index, group, sites_dir, logs_dir))
+        # A single RQ worker-pool runs all queues; the Frappe scheduler runs as a
+        # thread inside the pool workers, so it needs no companion of its own.
+        workers: list[dict] = [self._worker_pool_spec(sites_dir, logs_dir)]
 
         if self._socketio_companion_enabled():
             workers.append(
@@ -211,30 +200,29 @@ def post_worker_init(worker):
 
         return workers
 
-    def _worker_group_specs(
-        self,
-        group_index: int,
-        group: "WorkerGroup",
-        sites_dir: Path,
-        logs_dir: Path,
-    ) -> list[dict]:
-        queue_names = ",".join(group.queues)
+    def _worker_pool_spec(self, sites_dir: Path, logs_dir: Path) -> dict:
+        groups = self.bench.config.workers.groups
+        queues: list[str] = []
+        for group in groups:
+            for queue in group.queues:
+                if queue not in queues:
+                    queues.append(queue)
+        num_workers = max(1, sum(group.count for group in groups))
         stop_timeout = max(
-            _COMPANION_QUEUE_STOP_TIMEOUT.get(q, _COMPANION_QUEUE_STOP_TIMEOUT["default"])
-            for q in group.queues
+            (_COMPANION_QUEUE_STOP_TIMEOUT.get(q, _COMPANION_QUEUE_STOP_TIMEOUT["default"]) for q in queues),
+            default=_COMPANION_QUEUE_STOP_TIMEOUT["default"],
         )
-        name_slug = "-".join(group.queues)
-        return [
-            self._companion_spec(
-                f"worker-{name_slug}-{i}",
-                "frappe.gunicorn_companion:run_worker",
-                cwd=sites_dir,
-                stop_timeout=stop_timeout,
-                logs_dir=logs_dir,
-                env={"FRAPPE_COMPANION_QUEUE": queue_names},
-            )
-            for i in range(1, group.count + 1)
-        ]
+        return self._companion_spec(
+            "worker-pool",
+            "frappe.gunicorn_companion:run_worker_pool",
+            cwd=sites_dir,
+            stop_timeout=stop_timeout,
+            logs_dir=logs_dir,
+            env={
+                "FRAPPE_COMPANION_QUEUE": ",".join(queues),
+                "FRAPPE_COMPANION_NUM_WORKERS": str(num_workers),
+            },
+        )
 
     def _companion_spec(
         self,

--- a/bench_cli/managers/nginx_manager.py
+++ b/bench_cli/managers/nginx_manager.py
@@ -37,10 +37,24 @@ class NginxManager:
             site_ssl_ready = ssl_ready and self.cert_exists(site.config)
             conf_text = self._generate_site_config(site.config, site_ssl_ready)
             (sites_dir / f"{site.config.name}.conf").write_text(conf_text)
+        # Expose the admin via nginx when it has its own domain, or — under
+        # systemd, where it is socket-activated on an internal port — as a
+        # domainless proxy listening on admin.port.
         if self.bench.config.admin.domain:
             conf_text = self._generate_admin_config(ssl_ready)
             (sites_dir / "_admin.conf").write_text(conf_text)
+        elif self._admin_socket_activated():
+            (sites_dir / "_admin.conf").write_text(self._generate_admin_domainless_config())
         self._write_include_conf(nginx_dir)
+
+    def _admin_socket_activated(self) -> bool:
+        return self.bench.config.production.process_manager == "systemd"
+
+    def _admin_proxy_port(self) -> int:
+        """Where the admin actually listens: the socket-activated gunicorn's
+        internal port under systemd, else the Flask process on admin.port."""
+        admin = self.bench.config.admin
+        return admin.internal_port if self._admin_socket_activated() else admin.port
 
     def _write_include_conf(self, nginx_dir: Path) -> None:
         bench_name = self.bench.config.name
@@ -218,17 +232,7 @@ class NginxManager:
             f"        try_files $uri =404;\n"
             f"    }}\n\n"
         )
-        proxy_block = (
-            f"    location / {{\n"
-            f"        proxy_pass         http://127.0.0.1:{admin.port};\n"
-            f"        proxy_read_timeout 120;\n"
-            f"        proxy_redirect     off;\n"
-            f"        proxy_set_header   Host               $host;\n"
-            f"        proxy_set_header   X-Real-IP          $remote_addr;\n"
-            f"        proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;\n"
-            f"        proxy_set_header   X-Forwarded-Proto  $scheme;\n"
-            f"    }}\n"
-        )
+        proxy_block = self._render_admin_proxy_location()
 
         if not ssl_ready or not self.admin_cert_exists():
             return (
@@ -266,6 +270,30 @@ class NginxManager:
             f"    server_name {domain};\n\n"
             + ssl_directives
             + proxy_block
+            + f"}}\n"
+        )
+
+    def _render_admin_proxy_location(self) -> str:
+        return (
+            f"    location / {{\n"
+            f"        proxy_pass         http://127.0.0.1:{self._admin_proxy_port()};\n"
+            f"        proxy_read_timeout 120;\n"
+            f"        proxy_redirect     off;\n"
+            f"        proxy_set_header   Host               $host;\n"
+            f"        proxy_set_header   X-Real-IP          $remote_addr;\n"
+            f"        proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;\n"
+            f"        proxy_set_header   X-Forwarded-Proto  $scheme;\n"
+            f"    }}\n"
+        )
+
+    def _generate_admin_domainless_config(self) -> str:
+        """Plain HTTP proxy on admin.port → socket-activated admin gunicorn.
+        No domain or SSL: nginx just fronts the on-demand admin on its port."""
+        return (
+            f"server {{\n"
+            f"    listen {self.bench.config.admin.port};\n"
+            f"    server_name _;\n\n"
+            + self._render_admin_proxy_location()
             + f"}}\n"
         )
 

--- a/bench_cli/managers/nginx_manager.py
+++ b/bench_cli/managers/nginx_manager.py
@@ -200,6 +200,8 @@ class NginxManager:
             f"        proxy_http_version 1.1;\n"
             f"        proxy_set_header   Upgrade $http_upgrade;\n"
             f'        proxy_set_header   Connection "upgrade";\n'
+            f"        proxy_set_header   X-Frappe-Site-Name $host;\n"
+            f"        proxy_set_header   Origin $scheme://$http_host;\n"
             f"        proxy_set_header   Host $host;\n"
             f"    }}\n\n"
         )

--- a/bench_cli/managers/process_manager.py
+++ b/bench_cli/managers/process_manager.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import functools
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -16,6 +18,20 @@ from bench_cli.managers.gunicorn_manager import GunicornManager
 
 if TYPE_CHECKING:
     from bench_cli.core.bench import Bench
+
+@functools.lru_cache(maxsize=1)
+def _jemalloc_path() -> str | None:
+    """Full path to libjemalloc on this host, or None if not installed.
+
+    Parses ``ldconfig -p`` (the loader cache); the path is suitable for
+    LD_PRELOAD."""
+    try:
+        out = subprocess.run(["ldconfig", "-p"], capture_output=True, text=True, timeout=5).stdout
+    except (OSError, subprocess.SubprocessError):
+        return None
+    # e.g. "libjemalloc.so.2 (libc6,x86-64) => /lib/x86_64-linux-gnu/libjemalloc.so.2"
+    match = re.search(r"^\s*libjemalloc\.so.*=>\s*(\S+)", out, re.MULTILINE)
+    return match.group(1) if match else None
 
 
 def _cli_root() -> Path:
@@ -208,8 +224,17 @@ class ProcessManager:
         return pd
 
     def _py_memory_env(self) -> dict:
-        """Caps glibc malloc arenas for the Python procs to keep RSS down.
-        Companions inherit it by forking the gunicorn master."""
+        """Allocator/RSS tuning env for the Python procs. The web process passes
+        it to gunicorn, whose companions inherit it by forking the master.
+
+        With jemalloc (the default when the lib is present) we only LD_PRELOAD
+        it — pymalloc still pools small objects on top, while jemalloc backs the
+        larger allocations and fragments far less than glibc. Otherwise we use
+        plain pymalloc/glibc and cap glibc arenas to keep RSS down."""
+        choice = self.bench.config.gunicorn.memory_allocator
+        jemalloc = _jemalloc_path() if choice in ("auto", "jemalloc") else None
+        if jemalloc:
+            return {"LD_PRELOAD": jemalloc}
         arenas = self.bench.config.gunicorn.malloc_arena_max
         if arenas and arenas > 0:
             return {"MALLOC_ARENA_MAX": str(arenas)}

--- a/bench_cli/managers/process_manager.py
+++ b/bench_cli/managers/process_manager.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import functools
 import os
-import re
 import signal
 import subprocess
 import sys
@@ -18,28 +16,6 @@ from bench_cli.managers.gunicorn_manager import GunicornManager
 
 if TYPE_CHECKING:
     from bench_cli.core.bench import Bench
-
-# Purge freed pages back to the OS immediately (MADV_DONTNEED) instead of
-# jemalloc's lazy default, so RSS shrinks promptly — what matters on
-# memory-overcommitted hosts. Synchronous on free, so it is fork-safe (no
-# background thread, which would not survive gunicorn's fork anyway).
-_JEMALLOC_CONF = "dirty_decay_ms:0,muzzy_decay_ms:0"
-
-
-@functools.lru_cache(maxsize=1)
-def _jemalloc_path() -> str | None:
-    """Full path to libjemalloc on this host, or None if not installed.
-
-    Parses ``ldconfig -p`` (the loader cache); the path is suitable for
-    LD_PRELOAD."""
-    try:
-        out = subprocess.run(["ldconfig", "-p"], capture_output=True, text=True, timeout=5).stdout
-    except (OSError, subprocess.SubprocessError):
-        return None
-    # e.g. "libjemalloc.so.2 (libc6,x86-64) => /lib/x86_64-linux-gnu/libjemalloc.so.2"
-    match = re.search(r"^\s*libjemalloc\.so.*=>\s*(\S+)", out, re.MULTILINE)
-    return match.group(1) if match else None
-
 
 def _cli_root() -> Path:
     import bench_cli as _pkg
@@ -231,16 +207,7 @@ class ProcessManager:
         return pd
 
     def _py_memory_env(self) -> dict:
-        """Allocator/RSS tuning env for the Python procs. The web process passes
-        it to gunicorn, whose companions inherit it by forking the master.
-
-        "jemalloc" LD_PRELOADs jemalloc tuned to return freed pages to the OS
-        immediately (pymalloc still pools small objects on top); it falls back to
-        the pymalloc path if libjemalloc is not installed. "pymalloc" is stock
-        CPython on glibc, with the glibc arena cap to keep RSS down."""
-        if self.bench.config.gunicorn.memory_allocator == "jemalloc":
-            if jemalloc := _jemalloc_path():
-                return {"LD_PRELOAD": jemalloc, "MALLOC_CONF": _JEMALLOC_CONF}
+        """Cap glibc malloc arenas for the Python procs to keep idle RSS down."""
         arenas = self.bench.config.gunicorn.malloc_arena_max
         if arenas and arenas > 0:
             return {"MALLOC_ARENA_MAX": str(arenas)}

--- a/bench_cli/managers/process_manager.py
+++ b/bench_cli/managers/process_manager.py
@@ -19,6 +19,13 @@ from bench_cli.managers.gunicorn_manager import GunicornManager
 if TYPE_CHECKING:
     from bench_cli.core.bench import Bench
 
+# Purge freed pages back to the OS immediately (MADV_DONTNEED) instead of
+# jemalloc's lazy default, so RSS shrinks promptly — what matters on
+# memory-overcommitted hosts. Synchronous on free, so it is fork-safe (no
+# background thread, which would not survive gunicorn's fork anyway).
+_JEMALLOC_CONF = "dirty_decay_ms:0,muzzy_decay_ms:0"
+
+
 @functools.lru_cache(maxsize=1)
 def _jemalloc_path() -> str | None:
     """Full path to libjemalloc on this host, or None if not installed.
@@ -227,14 +234,13 @@ class ProcessManager:
         """Allocator/RSS tuning env for the Python procs. The web process passes
         it to gunicorn, whose companions inherit it by forking the master.
 
-        With jemalloc (the default when the lib is present) we only LD_PRELOAD
-        it — pymalloc still pools small objects on top, while jemalloc backs the
-        larger allocations and fragments far less than glibc. Otherwise we use
-        plain pymalloc/glibc and cap glibc arenas to keep RSS down."""
-        choice = self.bench.config.gunicorn.memory_allocator
-        jemalloc = _jemalloc_path() if choice in ("auto", "jemalloc") else None
-        if jemalloc:
-            return {"LD_PRELOAD": jemalloc}
+        "jemalloc" LD_PRELOADs jemalloc tuned to return freed pages to the OS
+        immediately (pymalloc still pools small objects on top); it falls back to
+        the pymalloc path if libjemalloc is not installed. "pymalloc" is stock
+        CPython on glibc, with the glibc arena cap to keep RSS down."""
+        if self.bench.config.gunicorn.memory_allocator == "jemalloc":
+            if jemalloc := _jemalloc_path():
+                return {"LD_PRELOAD": jemalloc, "MALLOC_CONF": _JEMALLOC_CONF}
         arenas = self.bench.config.gunicorn.malloc_arena_max
         if arenas and arenas > 0:
             return {"MALLOC_ARENA_MAX": str(arenas)}

--- a/bench_cli/managers/systemd_process_manager.py
+++ b/bench_cli/managers/systemd_process_manager.py
@@ -77,12 +77,16 @@ class SystemdProcessManager(ProcessManager):
         defs = self._prod_process_definitions()
         units = set(self._unit_name(pd.name) for pd in defs) | {self._target_name(), self._admin_socket_name()}
 
-        # Remove stale user-unit symlinks pointing to this bench's config dir.
+        # Stop dropped units (e.g. socketio after enabling companion mode) so they
+        # release their ports; an orphaned process makes the companion crash-loop on bind.
+        self._reap_stale_units(units)
+
+        # Remove stale symlinks pointing to this bench's config dir, including broken ones.
         for dst in self.user_unit_dir.iterdir():
-            if not (dst.is_symlink() and dst.exists()):
+            if not dst.is_symlink():
                 continue
             try:
-                points_to_bench = dst.resolve().parent == self.systemd_conf_dir.resolve()
+                points_to_bench = dst.resolve(strict=False).parent == self.systemd_conf_dir.resolve()
             except OSError:
                 continue
             if points_to_bench and dst.name not in units:
@@ -110,6 +114,31 @@ class SystemdProcessManager(ProcessManager):
         env = self._systemctl_env()
         run_command(self._systemctl("daemon-reload"), env=env)
         run_command(self._systemctl("enable", self._target_name()), env=env)
+
+    def _installed_bench_units(self) -> set[str]:
+        """Names of this bench's currently-loaded .service/.socket units."""
+        result = subprocess.run(
+            self._systemctl(
+                "list-units", "--all", "--no-legend", "--plain",
+                "--type=service,socket", f"{self.bench.config.name}-*",
+            ),
+            capture_output=True,
+            text=True,
+            env=self._systemctl_env(),
+        )
+        units = set()
+        for line in result.stdout.splitlines():
+            parts = line.split()
+            if parts and (parts[0].endswith(".service") or parts[0].endswith(".socket")):
+                units.add(parts[0])
+        return units
+
+    def _reap_stale_units(self, desired: set[str]) -> None:
+        """Stop+disable this bench's loaded units not in ``desired`` (best-effort)."""
+        env = self._systemctl_env()
+        for unit in self._installed_bench_units() - desired:
+            subprocess.run(self._systemctl("stop", unit), capture_output=True, env=env)
+            subprocess.run(self._systemctl("disable", unit), capture_output=True, env=env)
 
     def is_configured(self) -> bool:
         result = subprocess.run(

--- a/bench_cli/managers/systemd_process_manager.py
+++ b/bench_cli/managers/systemd_process_manager.py
@@ -5,8 +5,14 @@ import re
 import subprocess
 from pathlib import Path
 
+from bench_cli.managers.admin_env_manager import AdminEnvManager
+from bench_cli.managers.gunicorn_manager import GunicornManager
 from bench_cli.managers.process_manager import ProcessDefinition, ProcessManager, _cli_root
 from bench_cli.utils import run_command
+
+# Hardcoded for testing: stop the socket-activated admin after this many seconds
+# of inactivity. The next request re-activates it via the systemd socket.
+_ADMIN_IDLE_TIMEOUT = 60
 
 
 class SystemdProcessManager(ProcessManager):
@@ -22,6 +28,9 @@ class SystemdProcessManager(ProcessManager):
 
     def _unit_name(self, service_name: str) -> str:
         return f"{self.bench.config.name}-{service_name}.service"
+
+    def _admin_socket_name(self) -> str:
+        return f"{self.bench.config.name}-admin.socket"
 
     def _target_name(self) -> str:
         return f"{self.bench.config.name}.target"
@@ -39,22 +48,26 @@ class SystemdProcessManager(ProcessManager):
         return ["systemctl", "--user", *args]
 
     def generate_config(self) -> None:
-        from bench_cli.managers.admin_env_manager import AdminEnvManager
-
         AdminEnvManager(_cli_root()).ensure()
         self._ensure_gunicorn_config()
+        GunicornManager(self.bench).generate_admin_config()
         self.systemd_conf_dir.mkdir(parents=True, exist_ok=True)
 
         # Remove stale unit files (e.g. after switching process managers or enabling
         # companion mode, which drops socketio/worker services).
         target_file = self._target_name()
         for path in list(self.systemd_conf_dir.iterdir()):
-            if path.is_file() and (path.suffix == ".service" or path.name == target_file):
+            if path.is_file() and (path.suffix in (".service", ".socket") or path.name == target_file):
                 path.unlink()
 
         defs = self._prod_process_definitions()
         for pd in defs:
-            (self.systemd_conf_dir / self._unit_name(pd.name)).write_text(self._render_unit(pd))
+            if pd.name == "admin":
+                # Socket-activated + idle-stopping; not part of the target.
+                (self.systemd_conf_dir / self._unit_name("admin")).write_text(self._render_admin_service())
+                (self.systemd_conf_dir / self._admin_socket_name()).write_text(self._render_admin_socket())
+            else:
+                (self.systemd_conf_dir / self._unit_name(pd.name)).write_text(self._render_unit(pd))
         (self.systemd_conf_dir / self._target_name()).write_text(self._render_target(defs))
 
     def install_config(self) -> None:
@@ -62,7 +75,7 @@ class SystemdProcessManager(ProcessManager):
 
         self.user_unit_dir.mkdir(parents=True, exist_ok=True)
         defs = self._prod_process_definitions()
-        units = set(self._unit_name(pd.name) for pd in defs) | {self._target_name()}
+        units = set(self._unit_name(pd.name) for pd in defs) | {self._target_name(), self._admin_socket_name()}
 
         # Remove stale user-unit symlinks pointing to this bench's config dir.
         for dst in self.user_unit_dir.iterdir():
@@ -185,8 +198,63 @@ class SystemdProcessManager(ProcessManager):
         ]
         return "\n".join(lines) + "\n"
 
+    def _render_admin_socket(self) -> str:
+        cfg = self.bench.config.admin
+        return (
+            "\n".join(
+                [
+                    "[Unit]",
+                    f"Description={self.bench.config.name} admin (socket)",
+                    f"PartOf={self._target_name()}",
+                    "",
+                    "[Socket]",
+                    f"ListenStream=127.0.0.1:{cfg.internal_port}",
+                    "",
+                    "[Install]",
+                    f"WantedBy={self._target_name()}",
+                ]
+            )
+            + "\n"
+        )
+
+    def _render_admin_service(self) -> str:
+        cli_root = _cli_root()
+        gunicorn = AdminEnvManager(cli_root).gunicorn
+        admin_conf = GunicornManager(self.bench).admin_config_path
+        log_file = self.bench.logs_path / "admin.log"
+        return (
+            "\n".join(
+                [
+                    "[Unit]",
+                    f"Description={self.bench.config.name} admin",
+                    f"PartOf={self._target_name()}",
+                    f"Requires={self._admin_socket_name()}",
+                    f"After={self._admin_socket_name()}",
+                    "",
+                    "[Service]",
+                    "Type=simple",
+                    f"WorkingDirectory={cli_root}",
+                    f"Environment=BENCH_ADMIN_ROOT={self.bench.path}",
+                    f"Environment=PYTHONPATH={cli_root}",
+                    f"Environment=BENCH_ADMIN_IDLE_TIMEOUT={_ADMIN_IDLE_TIMEOUT}",
+                    "Environment=MALLOC_ARENA_MAX=2",
+                    f"ExecStart={gunicorn} -c {admin_conf} admin.backend.wsgi:application",
+                    # Re-activation happens via the socket, not systemd restart.
+                    "Restart=no",
+                    f"StandardOutput=append:{log_file}",
+                    f"StandardError=append:{log_file}.error.log",
+                ]
+            )
+            + "\n"
+        )
+
     def _render_target(self, defs: list[ProcessDefinition]) -> str:
-        wants = " ".join(self._unit_name(pd.name) for pd in defs)
+        # The admin is socket-activated and on-demand, so the target wants its
+        # socket (the always-on listener), never the service itself.
+        wants = " ".join(
+            self._admin_socket_name() if pd.name == "admin" else self._unit_name(pd.name)
+            for pd in defs
+        )
         return (
             "\n".join(
                 [

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,6 +58,8 @@ threads = 4             # threads per worker (used by gthread worker class)
 timeout = 120
 worker_class = "sync"
 malloc_arena_max = 2    # cap glibc malloc arenas to reduce RSS; 0 = leave unset
+malloc_trim_requests = 100  # trim freed heap after N requests; 0 = disable
+malloc_trim_interval = 300  # trim freed heap every N seconds, even when idle; 0 = disable
 
 # ── Let's Encrypt (production only) ──────────────────────────────────────────
 [letsencrypt]
@@ -193,6 +195,8 @@ Omit this section entirely for development benches. The section is only read by 
 | `timeout` | int | no | `120` | Request timeout in seconds. |
 | `worker_class` | string | no | `sync` | Gunicorn worker class. |
 | `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to reduce RSS. `0` leaves the system default unset. |
+| `malloc_trim_requests` | int | no | `100` | Wakes the heap-trim timer early once this many requests have been served, so memory is returned promptly under load. `0` disables the request trigger. |
+| `malloc_trim_interval` | int | no | `300` | Interval (seconds) of a background timer thread in each web worker that calls `malloc_trim(0)` to return freed glibc heap to the OS — fires even when the worker is idle, reclaiming RSS after a transient spike. `0` disables the timer. Both knobs `0` removes the hook entirely. |
 
 ### `[letsencrypt]` _(production only)_
 
@@ -253,7 +257,7 @@ bench validates `bench.toml` before executing any command. Violations produce a 
 5. Worker counts must be positive integers.
 6. `letsencrypt.email` must match a basic email pattern (`^[^@]+@[^@]+\.[^@]+$`) when present.
 7. `nginx.http_port` and `nginx.https_port` must be distinct.
-8. `gunicorn.workers`, `gunicorn.threads`, and `gunicorn.timeout` must be positive integers; `gunicorn.worker_class` must be a non-empty string; `gunicorn.malloc_arena_max` must be a non-negative integer.
+8. `gunicorn.workers`, `gunicorn.threads`, and `gunicorn.timeout` must be positive integers; `gunicorn.worker_class` must be a non-empty string; `gunicorn.malloc_arena_max`, `gunicorn.malloc_trim_requests`, and `gunicorn.malloc_trim_interval` must be non-negative integers.
 9. `mariadb.version` and `redis.version`, when present, must match `^\d+(\.\d+)*$` (e.g. `"10.6"`, `"7"`, `"7.0"`).
 10. When `volume.enabled = true`: `pool` and `device` must be non-empty; `reservation` and `quota` values must match a valid ZFS size pattern (e.g. `"10G"`, `"500M"`, `"1T"`); quota must be greater than reservation for both datasets.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,7 +58,8 @@ threads = 4             # threads per worker (used by gthread worker class)
 timeout = 120
 worker_class = "sync"
 malloc_arena_max = 2    # cap glibc malloc arenas to reduce RSS; 0 = leave unset
-memory_allocator = "pymalloc"  # pymalloc (prod) | jemalloc (demo/overcommit: eager RAM release)
+max_requests = 0        # recycle the web worker after N requests to release heap; 0 = disabled
+max_requests_jitter = 0 # random +/- spread on max_requests
 
 # ── Let's Encrypt (production only) ──────────────────────────────────────────
 [letsencrypt]
@@ -193,8 +194,9 @@ Omit this section entirely for development benches. The section is only read by 
 | `threads` | int | no | `4` | Threads per worker. Used by the `gthread` worker class. |
 | `timeout` | int | no | `120` | Request timeout in seconds. |
 | `worker_class` | string | no | `sync` | Gunicorn worker class. |
-| `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to reduce RSS. `0` leaves the system default unset. |
-| `memory_allocator` | string | no | `pymalloc` | Allocator for the web/companion/worker Python processes. **`pymalloc`** (default) is stock CPython on glibc — best throughput, for production; `malloc_arena_max` caps glibc arenas here. **`jemalloc`** `LD_PRELOAD`s jemalloc tuned with `MALLOC_CONF=dirty_decay_ms:0,muzzy_decay_ms:0` so freed pages are returned to the OS immediately (`MADV_DONTNEED`) instead of lazily — for small/demo benches and memory-overcommitted hosts (e.g. Firecracker), where eagerly releasing RAM matters more than peak throughput. pymalloc still pools small objects on top. Falls back to `pymalloc` if `libjemalloc` is not installed. |
+| `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to keep idle RSS down on these multi-threaded processes. `0` leaves the system default unset. |
+| `max_requests` | int | no | `0` | Recycle each web worker after this many requests, re-forking it from the preloaded master to release the heap it accreted under load. `0` disables it (safe for production); set e.g. `2000` on demo/overcommit benches to bound RSS. |
+| `max_requests_jitter` | int | no | `0` | Random ± spread on `max_requests` so workers don't all recycle at once. |
 
 ### `[letsencrypt]` _(production only)_
 
@@ -255,7 +257,7 @@ bench validates `bench.toml` before executing any command. Violations produce a 
 5. Worker counts must be positive integers.
 6. `letsencrypt.email` must match a basic email pattern (`^[^@]+@[^@]+\.[^@]+$`) when present.
 7. `nginx.http_port` and `nginx.https_port` must be distinct.
-8. `gunicorn.workers`, `gunicorn.threads`, and `gunicorn.timeout` must be positive integers; `gunicorn.worker_class` must be a non-empty string; `gunicorn.malloc_arena_max` must be a non-negative integer; `gunicorn.memory_allocator` must be `jemalloc` or `pymalloc`.
+8. `gunicorn.workers`, `gunicorn.threads`, and `gunicorn.timeout` must be positive integers; `gunicorn.worker_class` must be a non-empty string; `gunicorn.malloc_arena_max`, `gunicorn.max_requests`, and `gunicorn.max_requests_jitter` must be non-negative integers.
 9. `mariadb.version` and `redis.version`, when present, must match `^\d+(\.\d+)*$` (e.g. `"10.6"`, `"7"`, `"7.0"`).
 10. When `volume.enabled = true`: `pool` and `device` must be non-empty; `reservation` and `quota` values must match a valid ZFS size pattern (e.g. `"10G"`, `"500M"`, `"1T"`); quota must be greater than reservation for both datasets.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,7 +58,7 @@ threads = 4             # threads per worker (used by gthread worker class)
 timeout = 120
 worker_class = "sync"
 malloc_arena_max = 2    # cap glibc malloc arenas to reduce RSS; 0 = leave unset
-memory_allocator = "auto"  # auto | jemalloc | pymalloc (auto picks jemalloc if installed)
+memory_allocator = "pymalloc"  # pymalloc (prod) | jemalloc (demo/overcommit: eager RAM release)
 
 # ── Let's Encrypt (production only) ──────────────────────────────────────────
 [letsencrypt]
@@ -194,7 +194,7 @@ Omit this section entirely for development benches. The section is only read by 
 | `timeout` | int | no | `120` | Request timeout in seconds. |
 | `worker_class` | string | no | `sync` | Gunicorn worker class. |
 | `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to reduce RSS. `0` leaves the system default unset. |
-| `memory_allocator` | string | no | `auto` | System allocator for the web/companion/worker Python processes. `auto` uses **jemalloc** (via `LD_PRELOAD`) when `libjemalloc` is present on the host, otherwise the stock **pymalloc**/glibc. jemalloc fragments less than glibc on long-running processes; pymalloc still pools small objects on top either way. `jemalloc` / `pymalloc` force the choice (explicit `jemalloc` falls back to pymalloc if the lib is missing). `malloc_arena_max` only applies on the pymalloc path. |
+| `memory_allocator` | string | no | `pymalloc` | Allocator for the web/companion/worker Python processes. **`pymalloc`** (default) is stock CPython on glibc — best throughput, for production; `malloc_arena_max` caps glibc arenas here. **`jemalloc`** `LD_PRELOAD`s jemalloc tuned with `MALLOC_CONF=dirty_decay_ms:0,muzzy_decay_ms:0` so freed pages are returned to the OS immediately (`MADV_DONTNEED`) instead of lazily — for small/demo benches and memory-overcommitted hosts (e.g. Firecracker), where eagerly releasing RAM matters more than peak throughput. pymalloc still pools small objects on top. Falls back to `pymalloc` if `libjemalloc` is not installed. |
 
 ### `[letsencrypt]` _(production only)_
 
@@ -255,7 +255,7 @@ bench validates `bench.toml` before executing any command. Violations produce a 
 5. Worker counts must be positive integers.
 6. `letsencrypt.email` must match a basic email pattern (`^[^@]+@[^@]+\.[^@]+$`) when present.
 7. `nginx.http_port` and `nginx.https_port` must be distinct.
-8. `gunicorn.workers`, `gunicorn.threads`, and `gunicorn.timeout` must be positive integers; `gunicorn.worker_class` must be a non-empty string; `gunicorn.malloc_arena_max` must be a non-negative integer; `gunicorn.memory_allocator` must be one of `auto`, `jemalloc`, `pymalloc`.
+8. `gunicorn.workers`, `gunicorn.threads`, and `gunicorn.timeout` must be positive integers; `gunicorn.worker_class` must be a non-empty string; `gunicorn.malloc_arena_max` must be a non-negative integer; `gunicorn.memory_allocator` must be `jemalloc` or `pymalloc`.
 9. `mariadb.version` and `redis.version`, when present, must match `^\d+(\.\d+)*$` (e.g. `"10.6"`, `"7"`, `"7.0"`).
 10. When `volume.enabled = true`: `pool` and `device` must be non-empty; `reservation` and `quota` values must match a valid ZFS size pattern (e.g. `"10G"`, `"500M"`, `"1T"`); quota must be greater than reservation for both datasets.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -58,8 +58,7 @@ threads = 4             # threads per worker (used by gthread worker class)
 timeout = 120
 worker_class = "sync"
 malloc_arena_max = 2    # cap glibc malloc arenas to reduce RSS; 0 = leave unset
-malloc_trim_requests = 100  # trim freed heap after N requests; 0 = disable
-malloc_trim_interval = 300  # trim freed heap every N seconds, even when idle; 0 = disable
+memory_allocator = "auto"  # auto | jemalloc | pymalloc (auto picks jemalloc if installed)
 
 # ── Let's Encrypt (production only) ──────────────────────────────────────────
 [letsencrypt]
@@ -195,8 +194,7 @@ Omit this section entirely for development benches. The section is only read by 
 | `timeout` | int | no | `120` | Request timeout in seconds. |
 | `worker_class` | string | no | `sync` | Gunicorn worker class. |
 | `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to reduce RSS. `0` leaves the system default unset. |
-| `malloc_trim_requests` | int | no | `100` | Wakes the heap-trim timer early once this many requests have been served, so memory is returned promptly under load. `0` disables the request trigger. |
-| `malloc_trim_interval` | int | no | `300` | Interval (seconds) of a background timer thread in each web worker that calls `malloc_trim(0)` to return freed glibc heap to the OS — fires even when the worker is idle, reclaiming RSS after a transient spike. `0` disables the timer. Both knobs `0` removes the hook entirely. |
+| `memory_allocator` | string | no | `auto` | System allocator for the web/companion/worker Python processes. `auto` uses **jemalloc** (via `LD_PRELOAD`) when `libjemalloc` is present on the host, otherwise the stock **pymalloc**/glibc. jemalloc fragments less than glibc on long-running processes; pymalloc still pools small objects on top either way. `jemalloc` / `pymalloc` force the choice (explicit `jemalloc` falls back to pymalloc if the lib is missing). `malloc_arena_max` only applies on the pymalloc path. |
 
 ### `[letsencrypt]` _(production only)_
 
@@ -257,7 +255,7 @@ bench validates `bench.toml` before executing any command. Violations produce a 
 5. Worker counts must be positive integers.
 6. `letsencrypt.email` must match a basic email pattern (`^[^@]+@[^@]+\.[^@]+$`) when present.
 7. `nginx.http_port` and `nginx.https_port` must be distinct.
-8. `gunicorn.workers`, `gunicorn.threads`, and `gunicorn.timeout` must be positive integers; `gunicorn.worker_class` must be a non-empty string; `gunicorn.malloc_arena_max`, `gunicorn.malloc_trim_requests`, and `gunicorn.malloc_trim_interval` must be non-negative integers.
+8. `gunicorn.workers`, `gunicorn.threads`, and `gunicorn.timeout` must be positive integers; `gunicorn.worker_class` must be a non-empty string; `gunicorn.malloc_arena_max` must be a non-negative integer; `gunicorn.memory_allocator` must be one of `auto`, `jemalloc`, `pymalloc`.
 9. `mariadb.version` and `redis.version`, when present, must match `^\d+(\.\d+)*$` (e.g. `"10.6"`, `"7"`, `"7.0"`).
 10. When `volume.enabled = true`: `pool` and `device` must be non-empty; `reservation` and `quota` values must match a valid ZFS size pattern (e.g. `"10G"`, `"500M"`, `"1T"`); quota must be greater than reservation for both datasets.
 

--- a/docs/production.md
+++ b/docs/production.md
@@ -133,7 +133,7 @@ threads = 4                          # threads per worker (used by gthread)
 timeout = 120
 worker_class = "sync"
 malloc_arena_max = 2                 # cap glibc malloc arenas; 0 = unset
-memory_allocator = "auto"            # auto | jemalloc | pymalloc (auto picks jemalloc if installed)
+memory_allocator = "pymalloc"        # pymalloc (prod) | jemalloc (demo/overcommit: eager RAM release)
 ```
 
 Gunicorn binds automatically to `127.0.0.1:<bench.http_port>` and `preload_app` is always enabled.
@@ -145,7 +145,7 @@ Gunicorn binds automatically to `127.0.0.1:<bench.http_port>` and `preload_app` 
 | `timeout` | int | no | `120` | Request timeout in seconds. |
 | `worker_class` | string | no | `sync` | Gunicorn worker class. |
 | `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to reduce RSS. `0` leaves the system default unset. |
-| `memory_allocator` | string | no | `auto` | System allocator for the web/companion/worker Python processes. `auto` uses jemalloc (via `LD_PRELOAD`) when `libjemalloc` is on the host, else stock pymalloc/glibc. jemalloc fragments less than glibc over long runtimes; pymalloc still pools small objects on top. `jemalloc` / `pymalloc` force the choice (explicit `jemalloc` falls back if missing). `malloc_arena_max` applies only on the pymalloc path. |
+| `memory_allocator` | string | no | `pymalloc` | Allocator for the web/companion/worker Python processes. `pymalloc` (default) is stock CPython on glibc — best throughput, for production (`malloc_arena_max` applies here). `jemalloc` `LD_PRELOAD`s jemalloc tuned with `MALLOC_CONF=dirty_decay_ms:0,muzzy_decay_ms:0` to return freed pages to the OS immediately — for small/demo benches and overcommitted hosts (e.g. Firecracker). Falls back to `pymalloc` if `libjemalloc` is missing. |
 
 ### `letsencrypt` section (new)
 
@@ -363,7 +363,7 @@ class GunicornConfig:
     timeout: int = 120
     worker_class: str = 'sync'
     malloc_arena_max: int = 2
-    memory_allocator: str = 'auto'
+    memory_allocator: str = 'pymalloc'
 ```
 
 #### `LetsEncryptConfig`

--- a/docs/production.md
+++ b/docs/production.md
@@ -133,7 +133,8 @@ threads = 4                          # threads per worker (used by gthread)
 timeout = 120
 worker_class = "sync"
 malloc_arena_max = 2                 # cap glibc malloc arenas; 0 = unset
-memory_allocator = "pymalloc"        # pymalloc (prod) | jemalloc (demo/overcommit: eager RAM release)
+max_requests = 0                     # recycle web worker after N requests to release heap; 0 = disabled
+max_requests_jitter = 0              # random +/- spread on max_requests
 ```
 
 Gunicorn binds automatically to `127.0.0.1:<bench.http_port>` and `preload_app` is always enabled.
@@ -144,8 +145,9 @@ Gunicorn binds automatically to `127.0.0.1:<bench.http_port>` and `preload_app` 
 | `threads` | int | no | `4` | Threads per worker. Used by the `gthread` worker class. |
 | `timeout` | int | no | `120` | Request timeout in seconds. |
 | `worker_class` | string | no | `sync` | Gunicorn worker class. |
-| `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to reduce RSS. `0` leaves the system default unset. |
-| `memory_allocator` | string | no | `pymalloc` | Allocator for the web/companion/worker Python processes. `pymalloc` (default) is stock CPython on glibc — best throughput, for production (`malloc_arena_max` applies here). `jemalloc` `LD_PRELOAD`s jemalloc tuned with `MALLOC_CONF=dirty_decay_ms:0,muzzy_decay_ms:0` to return freed pages to the OS immediately — for small/demo benches and overcommitted hosts (e.g. Firecracker). Falls back to `pymalloc` if `libjemalloc` is missing. |
+| `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to keep idle RSS down. `0` leaves the system default unset. |
+| `max_requests` | int | no | `0` | Recycle each web worker after this many requests, re-forking it from the preloaded master to return heap accreted under load. `0` disables it (safe for production); set e.g. `2000` on demo/overcommit benches to bound RSS. |
+| `max_requests_jitter` | int | no | `0` | Random ± spread on `max_requests` so workers don't all recycle at once. |
 
 ### `letsencrypt` section (new)
 
@@ -363,7 +365,8 @@ class GunicornConfig:
     timeout: int = 120
     worker_class: str = 'sync'
     malloc_arena_max: int = 2
-    memory_allocator: str = 'pymalloc'
+    max_requests: int = 0
+    max_requests_jitter: int = 0
 ```
 
 #### `LetsEncryptConfig`

--- a/docs/production.md
+++ b/docs/production.md
@@ -133,8 +133,7 @@ threads = 4                          # threads per worker (used by gthread)
 timeout = 120
 worker_class = "sync"
 malloc_arena_max = 2                 # cap glibc malloc arenas; 0 = unset
-malloc_trim_requests = 100           # trim heap after N requests; 0 = disable
-malloc_trim_interval = 300           # trim heap every N seconds, even when idle; 0 = disable
+memory_allocator = "auto"            # auto | jemalloc | pymalloc (auto picks jemalloc if installed)
 ```
 
 Gunicorn binds automatically to `127.0.0.1:<bench.http_port>` and `preload_app` is always enabled.
@@ -146,8 +145,7 @@ Gunicorn binds automatically to `127.0.0.1:<bench.http_port>` and `preload_app` 
 | `timeout` | int | no | `120` | Request timeout in seconds. |
 | `worker_class` | string | no | `sync` | Gunicorn worker class. |
 | `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to reduce RSS. `0` leaves the system default unset. |
-| `malloc_trim_requests` | int | no | `100` | Wakes the heap-trim timer early once this many requests have been served, returning memory promptly under load. `0` disables the request trigger. |
-| `malloc_trim_interval` | int | no | `300` | Interval (seconds) of a background timer thread in each web worker that calls `malloc_trim(0)` to return freed glibc heap to the OS — fires even when idle, reclaiming RSS after a transient spike. `0` disables the timer; both knobs `0` removes the hook. |
+| `memory_allocator` | string | no | `auto` | System allocator for the web/companion/worker Python processes. `auto` uses jemalloc (via `LD_PRELOAD`) when `libjemalloc` is on the host, else stock pymalloc/glibc. jemalloc fragments less than glibc over long runtimes; pymalloc still pools small objects on top. `jemalloc` / `pymalloc` force the choice (explicit `jemalloc` falls back if missing). `malloc_arena_max` applies only on the pymalloc path. |
 
 ### `letsencrypt` section (new)
 
@@ -365,8 +363,7 @@ class GunicornConfig:
     timeout: int = 120
     worker_class: str = 'sync'
     malloc_arena_max: int = 2
-    malloc_trim_requests: int = 100
-    malloc_trim_interval: int = 300
+    memory_allocator: str = 'auto'
 ```
 
 #### `LetsEncryptConfig`

--- a/docs/production.md
+++ b/docs/production.md
@@ -131,6 +131,8 @@ threads = 4                          # threads per worker (used by gthread)
 timeout = 120
 worker_class = "sync"
 malloc_arena_max = 2                 # cap glibc malloc arenas; 0 = unset
+malloc_trim_requests = 100           # trim heap after N requests; 0 = disable
+malloc_trim_interval = 300           # trim heap every N seconds, even when idle; 0 = disable
 ```
 
 Gunicorn binds automatically to `127.0.0.1:<bench.http_port>` and `preload_app` is always enabled.
@@ -142,6 +144,8 @@ Gunicorn binds automatically to `127.0.0.1:<bench.http_port>` and `preload_app` 
 | `timeout` | int | no | `120` | Request timeout in seconds. |
 | `worker_class` | string | no | `sync` | Gunicorn worker class. |
 | `malloc_arena_max` | int | no | `2` (new benches); `0` if absent | Caps glibc malloc arenas (`MALLOC_ARENA_MAX`) for the web/companion/worker Python processes to reduce RSS. `0` leaves the system default unset. |
+| `malloc_trim_requests` | int | no | `100` | Wakes the heap-trim timer early once this many requests have been served, returning memory promptly under load. `0` disables the request trigger. |
+| `malloc_trim_interval` | int | no | `300` | Interval (seconds) of a background timer thread in each web worker that calls `malloc_trim(0)` to return freed glibc heap to the OS — fires even when idle, reclaiming RSS after a transient spike. `0` disables the timer; both knobs `0` removes the hook. |
 
 ### `letsencrypt` section (new)
 
@@ -359,6 +363,8 @@ class GunicornConfig:
     timeout: int = 120
     worker_class: str = 'sync'
     malloc_arena_max: int = 2
+    malloc_trim_requests: int = 100
+    malloc_trim_interval: int = 300
 ```
 
 #### `LetsEncryptConfig`

--- a/docs/production.md
+++ b/docs/production.md
@@ -80,7 +80,9 @@ use_companion_manager = false    # run scheduler/workers/socketio inside gunicor
 
 ### Companion manager
 
-When `use_companion_manager = true`, the generated `config/gunicorn.conf.py` includes `companion_workers` for the scheduler, each RQ worker, and socket.io. Gunicorn forks a companion manager that supervises these processes, so they share the preloaded application memory copy-on-write.
+When `use_companion_manager = true`, the generated `config/gunicorn.conf.py` includes `companion_workers` for a single RQ worker-pool and socket.io. Gunicorn forks a companion manager that supervises these processes, so they share the preloaded application memory copy-on-write.
+
+The worker-pool runs every queue with `num_workers` equal to the total worker count across all `[workers]` groups (queues are the deduped union of every group's queues). The Frappe scheduler runs as a thread inside the pool workers, so it needs no companion of its own — one fewer process than the legacy per-worker layout.
 
 In this mode the supervisor/systemd configs only manage the Gunicorn web process (plus admin and Redis). The web service gets an extended stop timeout (1600s) so Gunicorn has time to drain all companions before SIGKILL.
 
@@ -428,7 +430,8 @@ class GunicornManager:
         """Write config/gunicorn.conf.py from bench.toml [gunicorn] settings.
 
         When production.use_companion_manager is true, the config also
-        includes companion_workers for scheduler, RQ workers, and socket.io.
+        includes companion_workers for an RQ worker-pool (with the scheduler
+        embedded) and socket.io.
         """
 
     def upstream_server(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = []
 bench = "bench_cli.cli:main"
 
 [project.optional-dependencies]
-admin = ["flask>=3.0", "psutil>=5.9", "pymysql>=1.1"]
+admin = ["flask>=3.0", "psutil>=5.9", "pymysql>=1.1", "gunicorn>=21.2"]
 test = ["pytest>=8.0", "pytest-cov>=5.0"]
 
 [tool.setuptools.packages.find]

--- a/tests/test_admin_watchdog.py
+++ b/tests/test_admin_watchdog.py
@@ -1,0 +1,70 @@
+"""Tests for the socket-activated admin's idle watchdog (admin.backend.app)."""
+from __future__ import annotations
+
+import signal
+from unittest.mock import patch
+
+from admin.backend.app import _install_idle_watchdog
+
+
+class _FakeApp:
+    def __init__(self) -> None:
+        self.before_request_funcs: list = []
+
+    def before_request(self, fn):
+        self.before_request_funcs.append(fn)
+        return fn
+
+
+def test_watchdog_noop_without_env(monkeypatch) -> None:
+    monkeypatch.delenv("BENCH_ADMIN_IDLE_TIMEOUT", raising=False)
+    app = _FakeApp()
+    with patch("threading.Thread") as thread:
+        _install_idle_watchdog(app)
+    thread.assert_not_called()
+    assert app.before_request_funcs == []
+
+
+def test_watchdog_noop_when_timeout_not_positive(monkeypatch) -> None:
+    monkeypatch.setenv("BENCH_ADMIN_IDLE_TIMEOUT", "0")
+    app = _FakeApp()
+    with patch("threading.Thread") as thread:
+        _install_idle_watchdog(app)
+    thread.assert_not_called()
+
+
+def test_watchdog_registers_touch_and_thread(monkeypatch) -> None:
+    monkeypatch.setenv("BENCH_ADMIN_IDLE_TIMEOUT", "60")
+    app = _FakeApp()
+    with patch("threading.Thread") as thread:
+        _install_idle_watchdog(app)
+    assert len(app.before_request_funcs) == 1
+    thread.assert_called_once()
+    assert thread.call_args.kwargs.get("daemon") is True
+
+
+def test_watchdog_kills_parent_after_idle(monkeypatch) -> None:
+    monkeypatch.setenv("BENCH_ADMIN_IDLE_TIMEOUT", "60")
+    app = _FakeApp()
+    captured: dict = {}
+
+    def fake_thread(target=None, daemon=None):
+        captured["target"] = target
+
+        class _T:
+            def start(self_inner):
+                pass
+
+        return _T()
+
+    # time advances past the timeout on the first sleep; getppid → arbiter.
+    times = iter([0.0, 1000.0])
+    with patch("threading.Thread", side_effect=fake_thread), patch(
+        "admin.backend.app.time.monotonic", side_effect=lambda: next(times)
+    ), patch("admin.backend.app.time.sleep"), patch(
+        "admin.backend.app.os.getppid", return_value=4242
+    ), patch("admin.backend.app.os.kill") as kill:
+        _install_idle_watchdog(app)
+        captured["target"]()
+
+    kill.assert_called_once_with(4242, signal.SIGTERM)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -426,3 +426,10 @@ def test_toml_writer_volume_device_backing() -> None:
     assert 'backing = "device"' in toml
     assert 'device = "/dev/sdb"' in toml
     assert "[volume.image]" not in toml
+
+
+def test_admin_internal_port_is_port_plus_one() -> None:
+    from bench_cli.config.admin_config import AdminConfig
+
+    assert AdminConfig(port=8002).internal_port == 8003
+    assert AdminConfig(port=9100).internal_port == 9101

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -44,7 +44,7 @@ def test_gunicorn_config_defaults() -> None:
     assert cfg.threads == 4
     assert cfg.timeout == 120
     assert cfg.worker_class == "sync"
-    assert cfg.memory_allocator == "pymalloc"
+    assert cfg.malloc_arena_max == 2
 
 
 def test_gunicorn_default_bind_uses_bench_http_port(tmp_path: Path) -> None:
@@ -428,19 +428,17 @@ def test_systemd_web_service_has_long_timeout_in_companion_mode(tmp_path: Path) 
 
 
 def test_malloc_arena_max_in_units(tmp_path: Path) -> None:
-    # The arena cap only applies on the pymalloc path; force it so the test does
-    # not depend on whether jemalloc happens to be installed on the host.
     from bench_cli.managers.supervisor_process_manager import SupervisorProcessManager
     from bench_cli.managers.systemd_process_manager import SystemdProcessManager
 
-    bench = make_bench(tmp_path, gunicorn=GunicornConfig(memory_allocator="pymalloc"))  # default arena 2
+    bench = make_bench(tmp_path, gunicorn=GunicornConfig())  # default arena 2
     systemd = SystemdProcessManager(bench)
     web = next(pd for pd in systemd._prod_process_definitions() if pd.name == "web")
     assert "Environment=MALLOC_ARENA_MAX=2" in systemd._render_unit(web)
     assert 'MALLOC_ARENA_MAX="2"' in SupervisorProcessManager(bench)._render_program(web, "web")
 
     # 0 disables the cap (no env emitted).
-    bench0 = make_bench(tmp_path, gunicorn=GunicornConfig(memory_allocator="pymalloc", malloc_arena_max=0))
+    bench0 = make_bench(tmp_path, gunicorn=GunicornConfig(malloc_arena_max=0))
     systemd0 = SystemdProcessManager(bench0)
     web0 = next(pd for pd in systemd0._prod_process_definitions() if pd.name == "web")
     assert "MALLOC_ARENA_MAX" not in systemd0._render_unit(web0)
@@ -451,48 +449,45 @@ def test_malloc_arena_max_validation(tmp_path: Path) -> None:
         make_bench(tmp_path, gunicorn=GunicornConfig(malloc_arena_max=-1)).config.validate()
 
 
-# ── memory allocator ──────────────────────────────────────────────────────────
+def test_py_memory_env_caps_glibc_arenas(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path, GunicornConfig(malloc_arena_max=2))
+    assert ProcessManager(bench)._py_memory_env() == {"MALLOC_ARENA_MAX": "2"}
+
+    bench0 = make_bench(tmp_path, GunicornConfig(malloc_arena_max=0))
+    assert ProcessManager(bench0)._py_memory_env() == {}
 
 
-def test_memory_allocator_validation(tmp_path: Path) -> None:
-    with pytest.raises(ConfigError, match="memory_allocator"):
-        make_bench(tmp_path, gunicorn=GunicornConfig(memory_allocator="auto")).config.validate()
-    for value in ("jemalloc", "pymalloc"):
-        make_bench(tmp_path, gunicorn=GunicornConfig(memory_allocator=value)).config.validate()
+# ── max_requests worker recycling ───────────────────────────────────────────────
 
 
-def test_toml_writer_includes_memory_allocator(tmp_path: Path) -> None:
+def test_max_requests_emitted_when_enabled(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path, gunicorn=GunicornConfig(max_requests=2000, max_requests_jitter=200))
+    bench.config_path.mkdir(parents=True, exist_ok=True)
+    GunicornManager(bench).generate_config()
+    content = (bench.config_path / "gunicorn.conf.py").read_text()
+    assert "max_requests = 2000" in content
+    assert "max_requests_jitter = 200" in content
+
+
+def test_max_requests_absent_when_disabled(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path, gunicorn=GunicornConfig(max_requests=0))
+    bench.config_path.mkdir(parents=True, exist_ok=True)
+    GunicornManager(bench).generate_config()
+    content = (bench.config_path / "gunicorn.conf.py").read_text()
+    assert "max_requests" not in content
+
+
+def test_max_requests_validation(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError, match="max_requests"):
+        make_bench(tmp_path, gunicorn=GunicornConfig(max_requests=-1)).config.validate()
+    with pytest.raises(ConfigError, match="max_requests_jitter"):
+        make_bench(tmp_path, gunicorn=GunicornConfig(max_requests_jitter=-1)).config.validate()
+
+
+def test_toml_writer_includes_max_requests(tmp_path: Path) -> None:
     from bench_cli.config.toml_writer import bench_config_to_toml
 
-    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="jemalloc"))
+    bench = make_bench(tmp_path, GunicornConfig(max_requests=2000, max_requests_jitter=200))
     toml = bench_config_to_toml(bench.config)
-    assert 'memory_allocator = "jemalloc"' in toml
-
-
-def test_py_memory_env_jemalloc_releases_memory_aggressively(tmp_path: Path) -> None:
-    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="jemalloc", malloc_arena_max=2))
-    manager = ProcessManager(bench)
-    with patch("bench_cli.managers.process_manager._jemalloc_path", return_value="/lib/libjemalloc.so.2"):
-        env = manager._py_memory_env()
-    assert env["LD_PRELOAD"] == "/lib/libjemalloc.so.2"
-    # Immediate purge to the OS; no glibc arena cap on the jemalloc path.
-    assert env["MALLOC_CONF"] == "dirty_decay_ms:0,muzzy_decay_ms:0"
-    assert "MALLOC_ARENA_MAX" not in env
-
-
-def test_py_memory_env_pymalloc_caps_glibc_arenas(tmp_path: Path) -> None:
-    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="pymalloc", malloc_arena_max=2))
-    manager = ProcessManager(bench)
-    # pymalloc never LD_PRELOADs jemalloc even when it is installed.
-    with patch("bench_cli.managers.process_manager._jemalloc_path", return_value="/lib/libjemalloc.so.2"):
-        env = manager._py_memory_env()
-    assert env == {"MALLOC_ARENA_MAX": "2"}
-
-
-def test_py_memory_env_jemalloc_falls_back_when_missing(tmp_path: Path) -> None:
-    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="jemalloc", malloc_arena_max=2))
-    manager = ProcessManager(bench)
-    # libjemalloc absent -> fall back to the pymalloc path (arena cap).
-    with patch("bench_cli.managers.process_manager._jemalloc_path", return_value=None):
-        env = manager._py_memory_env()
-    assert env == {"MALLOC_ARENA_MAX": "2"}
+    assert "max_requests = 2000" in toml
+    assert "max_requests_jitter = 200" in toml

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -44,8 +44,7 @@ def test_gunicorn_config_defaults() -> None:
     assert cfg.threads == 4
     assert cfg.timeout == 120
     assert cfg.worker_class == "sync"
-    assert cfg.malloc_trim_requests == 100
-    assert cfg.malloc_trim_interval == 300
+    assert cfg.memory_allocator == "auto"
 
 
 def test_gunicorn_default_bind_uses_bench_http_port(tmp_path: Path) -> None:
@@ -429,17 +428,19 @@ def test_systemd_web_service_has_long_timeout_in_companion_mode(tmp_path: Path) 
 
 
 def test_malloc_arena_max_in_units(tmp_path: Path) -> None:
+    # The arena cap only applies on the pymalloc path; force it so the test does
+    # not depend on whether jemalloc happens to be installed on the host.
     from bench_cli.managers.supervisor_process_manager import SupervisorProcessManager
     from bench_cli.managers.systemd_process_manager import SystemdProcessManager
 
-    bench = make_bench(tmp_path, gunicorn=GunicornConfig())  # default 2
+    bench = make_bench(tmp_path, gunicorn=GunicornConfig(memory_allocator="pymalloc"))  # default arena 2
     systemd = SystemdProcessManager(bench)
     web = next(pd for pd in systemd._prod_process_definitions() if pd.name == "web")
     assert "Environment=MALLOC_ARENA_MAX=2" in systemd._render_unit(web)
     assert 'MALLOC_ARENA_MAX="2"' in SupervisorProcessManager(bench)._render_program(web, "web")
 
     # 0 disables the cap (no env emitted).
-    bench0 = make_bench(tmp_path, gunicorn=GunicornConfig(malloc_arena_max=0))
+    bench0 = make_bench(tmp_path, gunicorn=GunicornConfig(memory_allocator="pymalloc", malloc_arena_max=0))
     systemd0 = SystemdProcessManager(bench0)
     web0 = next(pd for pd in systemd0._prod_process_definitions() if pd.name == "web")
     assert "MALLOC_ARENA_MAX" not in systemd0._render_unit(web0)
@@ -450,79 +451,54 @@ def test_malloc_arena_max_validation(tmp_path: Path) -> None:
         make_bench(tmp_path, gunicorn=GunicornConfig(malloc_arena_max=-1)).config.validate()
 
 
-# ── malloc_trim timer hook ────────────────────────────────────────────────────
+# ── memory allocator ──────────────────────────────────────────────────────────
 
 
-def _gen_gunicorn_config(tmp_path: Path, gunicorn: GunicornConfig | None = None, *, companion: bool = False) -> str:
-    bench = make_bench(tmp_path, gunicorn)
-    bench.config.production.use_companion_manager = companion
-    bench.config_path.mkdir(parents=True, exist_ok=True)
-    GunicornManager(bench).generate_config()
-    return (bench.config_path / "gunicorn.conf.py").read_text()
+def test_memory_allocator_validation(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError, match="memory_allocator"):
+        make_bench(tmp_path, gunicorn=GunicornConfig(memory_allocator="tcmalloc")).config.validate()
+    for value in ("auto", "jemalloc", "pymalloc"):
+        make_bench(tmp_path, gunicorn=GunicornConfig(memory_allocator=value)).config.validate()
 
 
-def test_malloc_trim_hook_in_standalone_config(tmp_path: Path) -> None:
-    content = _gen_gunicorn_config(tmp_path)
-    # A real timer thread, started per worker, drives the periodic trim.
-    assert "def post_worker_init(worker):" in content
-    assert "def _malloc_trim_loop():" in content
-    assert "_malloc_trim_event.wait(timeout)" in content
-    assert "_libc.malloc_trim(0)" in content
-    # Default: trim every 300s, wake early at 100 requests.
-    assert "timeout = 300 or None" in content
-    assert "_malloc_trim_count >= 100" in content
-    assert "def post_request(worker, req, environ, resp):" in content
-    compile(content, "gunicorn.conf.py", "exec")
-
-
-def test_malloc_trim_hook_in_companion_config(tmp_path: Path) -> None:
-    content = _gen_gunicorn_config(tmp_path, companion=True)
-    assert "def post_worker_init(worker):" in content
-    assert "_libc.malloc_trim(0)" in content
-    # Coexists with the existing companion hooks.
-    assert "def when_ready(server):" in content
-    compile(content, "gunicorn.conf.py", "exec")
-
-
-def test_malloc_trim_hook_honours_custom_thresholds(tmp_path: Path) -> None:
-    content = _gen_gunicorn_config(tmp_path, GunicornConfig(malloc_trim_requests=50, malloc_trim_interval=60))
-    assert "timeout = 60 or None" in content
-    assert "_malloc_trim_count >= 50" in content
-
-
-def test_malloc_trim_hook_omitted_when_both_disabled(tmp_path: Path) -> None:
-    content = _gen_gunicorn_config(tmp_path, GunicornConfig(malloc_trim_requests=0, malloc_trim_interval=0))
-    assert "post_worker_init" not in content
-    assert "malloc_trim" not in content
-
-
-def test_malloc_trim_interval_only_omits_post_request(tmp_path: Path) -> None:
-    # No request threshold -> pure periodic timer, no post_request hook.
-    content = _gen_gunicorn_config(tmp_path, GunicornConfig(malloc_trim_requests=0, malloc_trim_interval=300))
-    assert "timeout = 300 or None" in content
-    assert "def post_request" not in content
-    compile(content, "gunicorn.conf.py", "exec")
-
-
-def test_malloc_trim_requests_only_waits_indefinitely(tmp_path: Path) -> None:
-    # No interval -> thread blocks until the request counter wakes it.
-    content = _gen_gunicorn_config(tmp_path, GunicornConfig(malloc_trim_requests=100, malloc_trim_interval=0))
-    assert "timeout = 0 or None" in content
-    assert "def post_request(worker, req, environ, resp):" in content
-    compile(content, "gunicorn.conf.py", "exec")
-
-
-def test_malloc_trim_validation(tmp_path: Path) -> None:
-    with pytest.raises(ConfigError, match="malloc_trim_requests"):
-        make_bench(tmp_path, gunicorn=GunicornConfig(malloc_trim_requests=-1)).config.validate()
-    with pytest.raises(ConfigError, match="malloc_trim_interval"):
-        make_bench(tmp_path, gunicorn=GunicornConfig(malloc_trim_interval=-1)).config.validate()
-
-
-def test_toml_writer_includes_malloc_trim(tmp_path: Path) -> None:
+def test_toml_writer_includes_memory_allocator(tmp_path: Path) -> None:
     from bench_cli.config.toml_writer import bench_config_to_toml
 
-    bench = make_bench(tmp_path, GunicornConfig(malloc_trim_requests=50, malloc_trim_interval=60))
+    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="jemalloc"))
     toml = bench_config_to_toml(bench.config)
-    assert "malloc_trim_requests = 50" in toml
-    assert "malloc_trim_interval = 60" in toml
+    assert 'memory_allocator = "jemalloc"' in toml
+
+
+def test_py_memory_env_uses_jemalloc_when_available(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="auto", malloc_arena_max=2))
+    manager = ProcessManager(bench)
+    with patch("bench_cli.managers.process_manager._jemalloc_path", return_value="/lib/libjemalloc.so.2"):
+        env = manager._py_memory_env()
+    # Only LD_PRELOAD: pymalloc stays on top, glibc arena cap is irrelevant.
+    assert env == {"LD_PRELOAD": "/lib/libjemalloc.so.2"}
+
+
+def test_py_memory_env_falls_back_to_pymalloc_when_jemalloc_missing(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="auto", malloc_arena_max=2))
+    manager = ProcessManager(bench)
+    with patch("bench_cli.managers.process_manager._jemalloc_path", return_value=None):
+        env = manager._py_memory_env()
+    assert env == {"MALLOC_ARENA_MAX": "2"}
+
+
+def test_py_memory_env_pymalloc_skips_jemalloc_lookup(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="pymalloc", malloc_arena_max=2))
+    manager = ProcessManager(bench)
+    # Even if jemalloc is installed, an explicit pymalloc choice ignores it.
+    with patch("bench_cli.managers.process_manager._jemalloc_path", return_value="/lib/libjemalloc.so.2"):
+        env = manager._py_memory_env()
+    assert "LD_PRELOAD" not in env
+    assert env == {"MALLOC_ARENA_MAX": "2"}
+
+
+def test_py_memory_env_explicit_jemalloc_missing_falls_back(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="jemalloc", malloc_arena_max=0))
+    manager = ProcessManager(bench)
+    with patch("bench_cli.managers.process_manager._jemalloc_path", return_value=None):
+        env = manager._py_memory_env()
+    assert env == {}  # no jemalloc, arena cap disabled -> nothing to set

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -44,7 +44,7 @@ def test_gunicorn_config_defaults() -> None:
     assert cfg.threads == 4
     assert cfg.timeout == 120
     assert cfg.worker_class == "sync"
-    assert cfg.memory_allocator == "auto"
+    assert cfg.memory_allocator == "pymalloc"
 
 
 def test_gunicorn_default_bind_uses_bench_http_port(tmp_path: Path) -> None:
@@ -456,8 +456,8 @@ def test_malloc_arena_max_validation(tmp_path: Path) -> None:
 
 def test_memory_allocator_validation(tmp_path: Path) -> None:
     with pytest.raises(ConfigError, match="memory_allocator"):
-        make_bench(tmp_path, gunicorn=GunicornConfig(memory_allocator="tcmalloc")).config.validate()
-    for value in ("auto", "jemalloc", "pymalloc"):
+        make_bench(tmp_path, gunicorn=GunicornConfig(memory_allocator="auto")).config.validate()
+    for value in ("jemalloc", "pymalloc"):
         make_bench(tmp_path, gunicorn=GunicornConfig(memory_allocator=value)).config.validate()
 
 
@@ -469,36 +469,30 @@ def test_toml_writer_includes_memory_allocator(tmp_path: Path) -> None:
     assert 'memory_allocator = "jemalloc"' in toml
 
 
-def test_py_memory_env_uses_jemalloc_when_available(tmp_path: Path) -> None:
-    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="auto", malloc_arena_max=2))
+def test_py_memory_env_jemalloc_releases_memory_aggressively(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="jemalloc", malloc_arena_max=2))
     manager = ProcessManager(bench)
     with patch("bench_cli.managers.process_manager._jemalloc_path", return_value="/lib/libjemalloc.so.2"):
         env = manager._py_memory_env()
-    # Only LD_PRELOAD: pymalloc stays on top, glibc arena cap is irrelevant.
-    assert env == {"LD_PRELOAD": "/lib/libjemalloc.so.2"}
+    assert env["LD_PRELOAD"] == "/lib/libjemalloc.so.2"
+    # Immediate purge to the OS; no glibc arena cap on the jemalloc path.
+    assert env["MALLOC_CONF"] == "dirty_decay_ms:0,muzzy_decay_ms:0"
+    assert "MALLOC_ARENA_MAX" not in env
 
 
-def test_py_memory_env_falls_back_to_pymalloc_when_jemalloc_missing(tmp_path: Path) -> None:
-    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="auto", malloc_arena_max=2))
-    manager = ProcessManager(bench)
-    with patch("bench_cli.managers.process_manager._jemalloc_path", return_value=None):
-        env = manager._py_memory_env()
-    assert env == {"MALLOC_ARENA_MAX": "2"}
-
-
-def test_py_memory_env_pymalloc_skips_jemalloc_lookup(tmp_path: Path) -> None:
+def test_py_memory_env_pymalloc_caps_glibc_arenas(tmp_path: Path) -> None:
     bench = make_bench(tmp_path, GunicornConfig(memory_allocator="pymalloc", malloc_arena_max=2))
     manager = ProcessManager(bench)
-    # Even if jemalloc is installed, an explicit pymalloc choice ignores it.
+    # pymalloc never LD_PRELOADs jemalloc even when it is installed.
     with patch("bench_cli.managers.process_manager._jemalloc_path", return_value="/lib/libjemalloc.so.2"):
         env = manager._py_memory_env()
-    assert "LD_PRELOAD" not in env
     assert env == {"MALLOC_ARENA_MAX": "2"}
 
 
-def test_py_memory_env_explicit_jemalloc_missing_falls_back(tmp_path: Path) -> None:
-    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="jemalloc", malloc_arena_max=0))
+def test_py_memory_env_jemalloc_falls_back_when_missing(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path, GunicornConfig(memory_allocator="jemalloc", malloc_arena_max=2))
     manager = ProcessManager(bench)
+    # libjemalloc absent -> fall back to the pymalloc path (arena cap).
     with patch("bench_cli.managers.process_manager._jemalloc_path", return_value=None):
         env = manager._py_memory_env()
-    assert env == {}  # no jemalloc, arena cap disabled -> nothing to set
+    assert env == {"MALLOC_ARENA_MAX": "2"}

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -419,7 +419,7 @@ def test_malloc_arena_max_validation(tmp_path: Path) -> None:
         make_bench(tmp_path, gunicorn=GunicornConfig(malloc_arena_max=-1)).config.validate()
 
 
-# ── malloc_trim post_request hook ─────────────────────────────────────────────
+# ── malloc_trim timer hook ────────────────────────────────────────────────────
 
 
 def _gen_gunicorn_config(tmp_path: Path, gunicorn: GunicornConfig | None = None, *, companion: bool = False) -> str:
@@ -432,17 +432,21 @@ def _gen_gunicorn_config(tmp_path: Path, gunicorn: GunicornConfig | None = None,
 
 def test_malloc_trim_hook_in_standalone_config(tmp_path: Path) -> None:
     content = _gen_gunicorn_config(tmp_path)
-    assert "def post_request(worker, req, environ, resp):" in content
+    # A real timer thread, started per worker, drives the periodic trim.
+    assert "def post_worker_init(worker):" in content
+    assert "def _malloc_trim_loop():" in content
+    assert "_malloc_trim_event.wait(timeout)" in content
     assert "_libc.malloc_trim(0)" in content
-    assert 'st["count"] >= 100' in content
-    assert '(now - st["last"]) >= 300' in content
-    # The generated config must be valid Python.
+    # Default: trim every 300s, wake early at 100 requests.
+    assert "timeout = 300 or None" in content
+    assert "_malloc_trim_count >= 100" in content
+    assert "def post_request(worker, req, environ, resp):" in content
     compile(content, "gunicorn.conf.py", "exec")
 
 
 def test_malloc_trim_hook_in_companion_config(tmp_path: Path) -> None:
     content = _gen_gunicorn_config(tmp_path, companion=True)
-    assert "def post_request(worker, req, environ, resp):" in content
+    assert "def post_worker_init(worker):" in content
     assert "_libc.malloc_trim(0)" in content
     # Coexists with the existing companion hooks.
     assert "def when_ready(server):" in content
@@ -451,19 +455,29 @@ def test_malloc_trim_hook_in_companion_config(tmp_path: Path) -> None:
 
 def test_malloc_trim_hook_honours_custom_thresholds(tmp_path: Path) -> None:
     content = _gen_gunicorn_config(tmp_path, GunicornConfig(malloc_trim_requests=50, malloc_trim_interval=60))
-    assert 'st["count"] >= 50' in content
-    assert '(now - st["last"]) >= 60' in content
+    assert "timeout = 60 or None" in content
+    assert "_malloc_trim_count >= 50" in content
 
 
 def test_malloc_trim_hook_omitted_when_both_disabled(tmp_path: Path) -> None:
     content = _gen_gunicorn_config(tmp_path, GunicornConfig(malloc_trim_requests=0, malloc_trim_interval=0))
-    assert "post_request" not in content
+    assert "post_worker_init" not in content
     assert "malloc_trim" not in content
 
 
-def test_malloc_trim_single_knob_disabled_uses_false_branch(tmp_path: Path) -> None:
+def test_malloc_trim_interval_only_omits_post_request(tmp_path: Path) -> None:
+    # No request threshold -> pure periodic timer, no post_request hook.
     content = _gen_gunicorn_config(tmp_path, GunicornConfig(malloc_trim_requests=0, malloc_trim_interval=300))
-    assert "False or (now - st[\"last\"]) >= 300" in content
+    assert "timeout = 300 or None" in content
+    assert "def post_request" not in content
+    compile(content, "gunicorn.conf.py", "exec")
+
+
+def test_malloc_trim_requests_only_waits_indefinitely(tmp_path: Path) -> None:
+    # No interval -> thread blocks until the request counter wakes it.
+    content = _gen_gunicorn_config(tmp_path, GunicornConfig(malloc_trim_requests=100, malloc_trim_interval=0))
+    assert "timeout = 0 or None" in content
+    assert "def post_request(worker, req, environ, resp):" in content
     compile(content, "gunicorn.conf.py", "exec")
 
 

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -118,6 +118,22 @@ def test_gunicorn_manager_generates_config_file(tmp_path: Path) -> None:
     assert "preload_app = True" in content
 
 
+def test_gunicorn_manager_generates_admin_config(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    bench.config_path.mkdir(parents=True, exist_ok=True)
+
+    GunicornManager(bench).generate_admin_config()
+
+    config_path = bench.config_path / "admin-gunicorn.conf.py"
+    assert config_path.exists()
+    content = config_path.read_text()
+    assert f'bind = "127.0.0.1:{bench.config.admin.internal_port}"' in content
+    assert "workers = 1" in content
+    assert 'worker_class = "gthread"' in content
+    # No preload so create_app (and its idle watchdog) runs in the worker.
+    assert "preload_app = False" in content
+
+
 def test_gunicorn_manager_bind_uses_bench_http_port(tmp_path: Path) -> None:
     config = BenchConfig._from_dict({
         "bench": {"name": "test-bench", "python": "3.14", "http_port": 9000},

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -44,6 +44,8 @@ def test_gunicorn_config_defaults() -> None:
     assert cfg.threads == 4
     assert cfg.timeout == 120
     assert cfg.worker_class == "sync"
+    assert cfg.malloc_trim_requests == 100
+    assert cfg.malloc_trim_interval == 300
 
 
 def test_gunicorn_default_bind_uses_bench_http_port(tmp_path: Path) -> None:
@@ -415,3 +417,67 @@ def test_malloc_arena_max_in_units(tmp_path: Path) -> None:
 def test_malloc_arena_max_validation(tmp_path: Path) -> None:
     with pytest.raises(ConfigError):
         make_bench(tmp_path, gunicorn=GunicornConfig(malloc_arena_max=-1)).config.validate()
+
+
+# ── malloc_trim post_request hook ─────────────────────────────────────────────
+
+
+def _gen_gunicorn_config(tmp_path: Path, gunicorn: GunicornConfig | None = None, *, companion: bool = False) -> str:
+    bench = make_bench(tmp_path, gunicorn)
+    bench.config.production.use_companion_manager = companion
+    bench.config_path.mkdir(parents=True, exist_ok=True)
+    GunicornManager(bench).generate_config()
+    return (bench.config_path / "gunicorn.conf.py").read_text()
+
+
+def test_malloc_trim_hook_in_standalone_config(tmp_path: Path) -> None:
+    content = _gen_gunicorn_config(tmp_path)
+    assert "def post_request(worker, req, environ, resp):" in content
+    assert "_libc.malloc_trim(0)" in content
+    assert 'st["count"] >= 100' in content
+    assert '(now - st["last"]) >= 300' in content
+    # The generated config must be valid Python.
+    compile(content, "gunicorn.conf.py", "exec")
+
+
+def test_malloc_trim_hook_in_companion_config(tmp_path: Path) -> None:
+    content = _gen_gunicorn_config(tmp_path, companion=True)
+    assert "def post_request(worker, req, environ, resp):" in content
+    assert "_libc.malloc_trim(0)" in content
+    # Coexists with the existing companion hooks.
+    assert "def when_ready(server):" in content
+    compile(content, "gunicorn.conf.py", "exec")
+
+
+def test_malloc_trim_hook_honours_custom_thresholds(tmp_path: Path) -> None:
+    content = _gen_gunicorn_config(tmp_path, GunicornConfig(malloc_trim_requests=50, malloc_trim_interval=60))
+    assert 'st["count"] >= 50' in content
+    assert '(now - st["last"]) >= 60' in content
+
+
+def test_malloc_trim_hook_omitted_when_both_disabled(tmp_path: Path) -> None:
+    content = _gen_gunicorn_config(tmp_path, GunicornConfig(malloc_trim_requests=0, malloc_trim_interval=0))
+    assert "post_request" not in content
+    assert "malloc_trim" not in content
+
+
+def test_malloc_trim_single_knob_disabled_uses_false_branch(tmp_path: Path) -> None:
+    content = _gen_gunicorn_config(tmp_path, GunicornConfig(malloc_trim_requests=0, malloc_trim_interval=300))
+    assert "False or (now - st[\"last\"]) >= 300" in content
+    compile(content, "gunicorn.conf.py", "exec")
+
+
+def test_malloc_trim_validation(tmp_path: Path) -> None:
+    with pytest.raises(ConfigError, match="malloc_trim_requests"):
+        make_bench(tmp_path, gunicorn=GunicornConfig(malloc_trim_requests=-1)).config.validate()
+    with pytest.raises(ConfigError, match="malloc_trim_interval"):
+        make_bench(tmp_path, gunicorn=GunicornConfig(malloc_trim_interval=-1)).config.validate()
+
+
+def test_toml_writer_includes_malloc_trim(tmp_path: Path) -> None:
+    from bench_cli.config.toml_writer import bench_config_to_toml
+
+    bench = make_bench(tmp_path, GunicornConfig(malloc_trim_requests=50, malloc_trim_interval=60))
+    toml = bench_config_to_toml(bench.config)
+    assert "malloc_trim_requests = 50" in toml
+    assert "malloc_trim_interval = 60" in toml

--- a/tests/test_gunicorn.py
+++ b/tests/test_gunicorn.py
@@ -295,9 +295,12 @@ def test_gunicorn_config_includes_companion_workers(tmp_path: Path) -> None:
     content = (bench.config_path / "gunicorn.conf.py").read_text()
     assert "companion_control_socket" in content
     assert "companion_workers" in content
-    assert "frappe.gunicorn_companion:run_scheduler" in content
-    assert "frappe.gunicorn_companion:run_worker" in content
+    # A single worker-pool runs all queues with the scheduler embedded as a
+    # thread, so there is no separate scheduler or per-group worker companion.
+    assert "frappe.gunicorn_companion:run_worker_pool" in content
     assert "frappe.gunicorn_companion:run_socketio" in content
+    assert "run_scheduler" not in content
+    assert "FRAPPE_COMPANION_NUM_WORKERS" in content
     assert 'wsgi_app = "frappe.app:application"' in content
     assert "on_starting" in content
     assert "when_ready" in content
@@ -321,6 +324,34 @@ def test_gunicorn_config_uses_explicit_combined_worker_group(tmp_path: Path) -> 
     assert '"FRAPPE_COMPANION_QUEUE": "default,short,long"' in content
     assert '"FRAPPE_COMPANION_QUEUE": "short"' not in content
     assert '"FRAPPE_COMPANION_QUEUE": "long"' not in content
+    # A single group of one worker -> one pool worker.
+    assert '"FRAPPE_COMPANION_NUM_WORKERS": "1"' in content
+
+
+def test_worker_pool_aggregates_groups_into_one_pool(tmp_path: Path) -> None:
+    # Multiple groups collapse into a single pool: deduped queue union and the
+    # summed worker count drive one run_worker_pool companion.
+    config = BenchConfig._from_dict({
+        "bench": {"name": "test-bench", "python": "3.14", "http_port": 8000, "socketio_port": 9000},
+        "apps": [{"name": "frappe", "repo": "https://github.com/frappe/frappe", "branch": "version-16"}],
+        "mariadb": {"root_password": "root"},
+        "redis": {"cache_port": 13000, "queue_port": 11000},
+        "workers": [
+            {"queues": ["default"], "count": 2},
+            {"queues": ["short"], "count": 1},
+            {"queues": ["long", "default"], "count": 1},
+        ],
+        "production": {"process_manager": "supervisor", "use_companion_manager": True},
+    })
+    bench = Bench(config, tmp_path)
+    bench.config_path.mkdir(parents=True, exist_ok=True)
+
+    GunicornManager(bench).generate_config()
+
+    content = (bench.config_path / "gunicorn.conf.py").read_text()
+    assert content.count("run_worker_pool") == 1
+    assert '"FRAPPE_COMPANION_QUEUE": "default,short,long"' in content  # union, order-preserving, deduped
+    assert '"FRAPPE_COMPANION_NUM_WORKERS": "4"' in content  # 2 + 1 + 1
 
 
 def test_gunicorn_config_excludes_companion_without_flag(tmp_path: Path) -> None:

--- a/tests/test_managers_extra.py
+++ b/tests/test_managers_extra.py
@@ -336,6 +336,57 @@ def test_systemd_generate_config_writes_unit_files(tmp_path: Path) -> None:
     assert (mgr.systemd_conf_dir / "test-bench.target").exists()
 
 
+def test_systemd_admin_socket_listens_on_internal_port(tmp_path: Path) -> None:
+    mgr = _make_systemd_manager(tmp_path)
+    socket_unit = mgr._render_admin_socket()
+    internal = mgr.bench.config.admin.internal_port
+    assert "[Socket]" in socket_unit
+    assert f"ListenStream=127.0.0.1:{internal}" in socket_unit
+    assert "WantedBy=test-bench.target" in socket_unit
+
+
+def test_systemd_admin_service_runs_gunicorn_with_idle_timeout(tmp_path: Path) -> None:
+    mgr = _make_systemd_manager(tmp_path)
+    service = mgr._render_admin_service()
+    assert "admin.backend.wsgi:application" in service
+    assert "Environment=BENCH_ADMIN_IDLE_TIMEOUT=60" in service
+    assert "Requires=test-bench-admin.socket" in service
+    assert "After=test-bench-admin.socket" in service
+    # Re-activation is via the socket, not a systemd restart loop.
+    assert "Restart=no" in service
+
+
+def test_systemd_target_wants_admin_socket_not_service(tmp_path: Path) -> None:
+    from bench_cli.managers.process_manager import ProcessDefinition
+
+    mgr = _make_systemd_manager(tmp_path)
+    defs = [
+        ProcessDefinition("web", "x", tmp_path / "logs" / "web.log"),
+        ProcessDefinition("admin", "x", tmp_path / "logs" / "admin.log"),
+    ]
+    target = mgr._render_target(defs)
+    assert "test-bench-admin.socket" in target
+    assert "test-bench-admin.service" not in target
+    assert "test-bench-web.service" in target
+
+
+def test_systemd_generate_config_writes_admin_socket(tmp_path: Path) -> None:
+    from bench_cli.managers.process_manager import ProcessDefinition
+
+    mgr = _make_systemd_manager(tmp_path)
+    mgr.systemd_conf_dir.mkdir(parents=True, exist_ok=True)
+    fake_defs = [
+        ProcessDefinition("web", "/env/bin/python serve", tmp_path / "logs" / "web.log"),
+        ProcessDefinition("admin", "/env/bin/python -m admin", tmp_path / "logs" / "admin.log"),
+    ]
+    with patch("bench_cli.managers.admin_env_manager.AdminEnvManager"):
+        with patch.object(mgr, "_prod_process_definitions", return_value=fake_defs):
+            mgr.generate_config()
+    assert (mgr.systemd_conf_dir / "test-bench-admin.socket").exists()
+    assert (mgr.systemd_conf_dir / "test-bench-admin.service").exists()
+    assert (mgr.bench.config_path / "admin-gunicorn.conf.py").exists()
+
+
 def test_systemd_is_running_true_when_systemctl_exits_zero(tmp_path: Path) -> None:
     mgr = _make_systemd_manager(tmp_path)
     with patch("subprocess.run") as mock_run:

--- a/tests/test_nginx_config.py
+++ b/tests/test_nginx_config.py
@@ -89,6 +89,45 @@ def test_include_conf_content(tmp_path: Path) -> None:
     assert nginx_dir in content
 
 
+_ADMIN_SYSTEMD_DATA: dict = {
+    **_BASE_DATA,
+    "production": {"process_manager": "systemd", "nginx": True},
+    "admin": {"enabled": True, "port": 8002, "password": "x"},
+}
+
+
+def test_admin_domainless_proxy_under_systemd(tmp_path: Path) -> None:
+    bench = _make_bench(tmp_path, _ADMIN_SYSTEMD_DATA)
+    bench.create_directories()
+    (tmp_path / "sites" / "site1.example.com").mkdir(parents=True)
+    (tmp_path / "sites" / "site1.example.com" / "site_config.json").write_text("{}")
+
+    manager = NginxManager(bench)
+    manager.generate_config(ssl_ready=False)
+
+    admin_conf = tmp_path / "config" / "nginx" / "sites" / "_admin.conf"
+    assert admin_conf.exists()
+    content = admin_conf.read_text()
+    assert "server_name _;" in content
+    assert "listen 8002;" in content
+    # Forwards to the socket-activated gunicorn on the internal port, not admin.port.
+    assert f"proxy_pass         http://127.0.0.1:{bench.config.admin.internal_port};" in content
+
+
+def test_admin_no_domainless_proxy_without_systemd(tmp_path: Path) -> None:
+    data = copy.deepcopy(_ADMIN_SYSTEMD_DATA)
+    data["production"]["process_manager"] = "supervisor"
+    bench = _make_bench(tmp_path, data)
+    bench.create_directories()
+    (tmp_path / "sites" / "site1.example.com").mkdir(parents=True)
+    (tmp_path / "sites" / "site1.example.com" / "site_config.json").write_text("{}")
+
+    manager = NginxManager(bench)
+    manager.generate_config(ssl_ready=False)
+
+    assert not (tmp_path / "config" / "nginx" / "sites" / "_admin.conf").exists()
+
+
 def test_server_name_includes_all_domains(tmp_path: Path) -> None:
     bench = _make_bench(tmp_path, _BASE_DATA)
     manager = NginxManager(bench)


### PR DESCRIPTION
- Admin service takes ~40 MB memory. None is going to access it everytime. After a specific time, the service can be shutdown. On new request only, it can wake up.
- Do malloc trimming periodically (default: 5mins) or after specified no of requests (default : 100) to reclaim memory. 
- Socketio was broken on prod setup, fixed

Defaults are set for small sites. These could be disabled or increased for large prod sites.