### PR TITLE
feat: Serve sites and admin over IPv6

### DIFF
--- a/admin/backend/server.py
+++ b/admin/backend/server.py
@@ -56,7 +56,9 @@ def main() -> None:
     if args.dev and not os.environ.get("WERKZEUG_RUN_MAIN"):
         _start_vite_watch()
 
-    app.run(host="0.0.0.0", port=args.port, threaded=True, use_reloader=args.dev)
+    # "::" makes Werkzeug bind a dual-stack socket, so the admin is reachable
+    # over both IPv4 and IPv6 in dev (where there is no nginx in front).
+    app.run(host="::", port=args.port, threaded=True, use_reloader=args.dev)
 
 
 def _start_vite_watch() -> None:

--- a/bench_cli/managers/nginx_manager.py
+++ b/bench_cli/managers/nginx_manager.py
@@ -104,6 +104,7 @@ class NginxManager:
         return (
             f"server {{\n"
             f"    listen {http_port};\n"
+            f"    listen [::]:{http_port};\n"
             f"    server_name {server_name};\n\n"
             f"    root {bench_root}/sites;\n"
             f"    client_max_body_size {max_body};\n\n"
@@ -126,6 +127,7 @@ class NginxManager:
         return (
             f"server {{\n"
             f"    listen {http_port};\n"
+            f"    listen [::]:{http_port};\n"
             f"    server_name {server_name};\n\n"
             f"    location /.well-known/acme-challenge/ {{\n"
             f"        root {webroot};\n"
@@ -165,6 +167,7 @@ class NginxManager:
         return (
             f"server {{\n"
             f"    listen {https_port} ssl http2;\n"
+            f"    listen [::]:{https_port} ssl http2;\n"
             f"    server_name {server_name};\n\n"
             + ssl_directives
             + f"    root {bench_root}/sites;\n"
@@ -240,6 +243,7 @@ class NginxManager:
             return (
                 f"server {{\n"
                 f"    listen {http_port};\n"
+                f"    listen [::]:{http_port};\n"
                 f"    server_name {domain};\n\n"
                 + acme_block
                 + proxy_block
@@ -261,6 +265,7 @@ class NginxManager:
         return (
             f"server {{\n"
             f"    listen {http_port};\n"
+            f"    listen [::]:{http_port};\n"
             f"    server_name {domain};\n\n"
             + acme_block
             + f"    location / {{\n"
@@ -269,6 +274,7 @@ class NginxManager:
             f"}}\n\n"
             f"server {{\n"
             f"    listen {https_port} ssl http2;\n"
+            f"    listen [::]:{https_port} ssl http2;\n"
             f"    server_name {domain};\n\n"
             + ssl_directives
             + proxy_block
@@ -294,6 +300,7 @@ class NginxManager:
         return (
             f"server {{\n"
             f"    listen {self.bench.config.admin.port};\n"
+            f"    listen [::]:{self.bench.config.admin.port};\n"
             f"    server_name _;\n\n"
             + self._render_admin_proxy_location()
             + f"}}\n"

--- a/tests/test_nginx_config.py
+++ b/tests/test_nginx_config.py
@@ -110,6 +110,7 @@ def test_admin_domainless_proxy_under_systemd(tmp_path: Path) -> None:
     content = admin_conf.read_text()
     assert "server_name _;" in content
     assert "listen 8002;" in content
+    assert "listen [::]:8002;" in content
     # Forwards to the socket-activated gunicorn on the internal port, not admin.port.
     assert f"proxy_pass         http://127.0.0.1:{bench.config.admin.internal_port};" in content
 
@@ -163,9 +164,45 @@ def test_http_port_is_configurable(tmp_path: Path) -> None:
 
     assert "listen 8080;" in config
     assert "listen 80;" not in config
+    assert "listen [::]:8080;" in config
 
 
-# ── upstream block ────────────────────────────────────────────────────────────
+# ── IPv6 (dual-stack listeners) ───────────────────────────────────────────────
+
+
+def test_http_site_listens_dual_stack(tmp_path: Path) -> None:
+    bench = _make_bench(tmp_path, _BASE_DATA)
+    manager = NginxManager(bench)
+
+    config = manager._generate_site_config(_BASE_SITE, ssl_ready=False)
+
+    assert "listen 80;" in config
+    assert "listen [::]:80;" in config
+
+
+def test_https_site_listens_dual_stack(tmp_path: Path) -> None:
+    bench = _make_bench(tmp_path, _SSL_DATA)
+    manager = NginxManager(bench)
+
+    config = manager._generate_site_config(_SSL_SITE, ssl_ready=True)
+
+    # HTTP→HTTPS redirect block and the SSL block both listen on both stacks.
+    assert "listen 80;" in config
+    assert "listen [::]:80;" in config
+    assert "listen 443 ssl http2;" in config
+    assert "listen [::]:443 ssl http2;" in config
+
+
+def test_admin_domain_config_listens_dual_stack(tmp_path: Path) -> None:
+    data = copy.deepcopy(_SSL_DATA)
+    data["admin"] = {"enabled": True, "domain": "admin.example.com"}
+    bench = _make_bench(tmp_path, data)
+    manager = NginxManager(bench)
+
+    config = manager._generate_admin_config(ssl_ready=False)
+
+    assert "listen 80;" in config
+    assert "listen [::]:80;" in config
 
 
 def test_upstream_block_uses_bench_http_port(tmp_path: Path) -> None:


### PR DESCRIPTION
Emit dual-stack listen directives in all nginx server blocks and bind
the dev admin server to :: so both sites and the admin UI accept IPv4
and IPv6 clients.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
