### PR TITLE
fix(admin): show all benches in switcher, not just running ones

### DIFF
--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -29,6 +29,7 @@ from bench_cli.commands.admin import _cli_root
 from bench_cli.commands.new import NewCommand
 from bench_cli.config.bench_config import BenchConfig
 from bench_cli.exceptions import BenchError, ConfigError
+from bench_cli.utils import iter_sibling_benches
 
 _STATIC_DIR = Path(__file__).parent / "static"
 _OPEN_PATHS = {"/api/status", "/api/login", "/api/logout"}
@@ -156,27 +157,38 @@ def create_app(bench_root: Path) -> Flask:
 
     @app.route("/api/benches/")
     def api_benches():
-        benches_dir = bench_root.parent
-        running = []
-        for bench_dir in sorted(benches_dir.iterdir()):
-            if not bench_dir.is_dir():
-                continue
-            toml_path = bench_dir / "bench.toml"
-            if not toml_path.exists():
-                continue
+        def _is_running(port: int) -> bool:
             try:
-                with open(toml_path, "rb") as f:
-                    config = tomllib.load(f)
-                port = config.get("admin", {}).get("port")
-                name = config.get("bench", {}).get("name", bench_dir.name)
-                if not port:
-                    continue
                 with socket.create_connection(("127.0.0.1", port), timeout=0.5):
                     pass
-                running.append({"name": name, "port": port})
-            except Exception:
-                continue
-        return jsonify(running)
+                return True
+            except OSError:
+                return False
+
+        def _entry(bench_dir: Path, config: BenchConfig) -> dict | None:
+            port = config.admin.port
+            if not port:
+                return None
+            return {
+                "name": config.name or bench_dir.name,
+                "port": port,
+                "running": _is_running(port),
+            }
+
+        benches = []
+        try:
+            current = BenchConfig.from_file(bench_root / "bench.toml")
+            entry = _entry(bench_root, current)
+            if entry:
+                benches.append(entry)
+        except Exception:
+            pass
+        for bench_dir, config in iter_sibling_benches(bench_root):
+            entry = _entry(bench_dir, config)
+            if entry:
+                benches.append(entry)
+        benches.sort(key=lambda b: b["name"])
+        return jsonify(benches)
 
     @app.route("/api/benches/new", methods=["POST"])
     def api_benches_new():

--- a/admin/frontend/src/components/AppSidebar.vue
+++ b/admin/frontend/src/components/AppSidebar.vue
@@ -23,12 +23,23 @@ const route = useRoute()
 const benches = ref([])
 const showBenchDialog = ref(false)
 const currentPort = window.location.port
+const benchName = ref('Bench')
 
 async function loadBenches() {
   try {
     const response = await fetch('/api/benches/')
     if (response.ok) {
       benches.value = await response.json()
+    }
+  } catch { }
+}
+
+async function loadBenchName() {
+  try {
+    const response = await fetch('/api/status')
+    if (response.ok) {
+      const data = await response.json()
+      if (data.name) benchName.value = data.name
     }
   } catch { }
 }
@@ -49,9 +60,9 @@ function openBenchDialog() {
   })
 }
 
-function switchBench(port) {
-  if (String(port) === String(currentPort)) return
-  window.location.href = `${window.location.protocol}//${window.location.hostname}:${port}`
+function switchBench(bench) {
+  if (!bench.running || String(bench.port) === String(currentPort)) return
+  window.location.href = `${window.location.protocol}//${window.location.hostname}:${bench.port}`
 }
 
 const showNewBenchDialog = ref(false)
@@ -119,8 +130,8 @@ async function createBench() {
   }
 }
 
-const header = {
-  title: 'Bench',
+const header = computed(() => ({
+  title: benchName.value,
   logo: '/logos/frappe-icon.png',
   menuItems: [
     { label: 'Settings', icon: LucideSettings, onClick: () => emit('open-settings') },
@@ -128,7 +139,7 @@ const header = {
     { label: 'New Bench', icon: LucidePlus, onClick: openNewBenchDialog },
     { label: 'Logout', icon: LucideLogOut, onClick: () => logout() },
   ],
-}
+}))
 
 const baseNavItems = [
   { label: 'Sites', to: '/', icon: LucideGlobe },
@@ -184,6 +195,7 @@ async function logout() {
 onMounted(() => {
   pollRunning()
   loadVolumeConfig()
+  loadBenchName()
   pollTimer = setInterval(pollRunning, 4000)
 })
 onUnmounted(() => clearInterval(pollTimer))
@@ -209,19 +221,25 @@ onUnmounted(() => clearInterval(pollTimer))
       <template #default>
         <div class="px-4 pb-6">
           <div v-if="benches.length === 0" class="text-sm text-ink-gray-5 py-2">
-            No other benches running.
+            No benches found.
           </div>
           <div v-else class="flex flex-col gap-1">
             <button
               v-for="bench in benches"
               :key="bench.port"
+              :disabled="!bench.running && String(bench.port) !== String(currentPort)"
               class="flex items-center justify-between rounded-lg px-3 py-2.5 text-sm transition-colors w-full text-left"
               :class="String(bench.port) === String(currentPort)
                 ? 'bg-surface-gray-2 text-ink-gray-9 font-medium cursor-default'
-                : 'text-ink-gray-7 hover:bg-surface-gray-2 cursor-pointer'"
-              @click="switchBench(bench.port)"
+                : bench.running
+                  ? 'text-ink-gray-7 hover:bg-surface-gray-2 cursor-pointer'
+                  : 'text-ink-gray-4 cursor-not-allowed'"
+              @click="switchBench(bench)"
             >
-              <span>{{ bench.name }}</span>
+              <span>
+                {{ bench.name }}
+                <span v-if="!bench.running" class="text-ink-gray-4">(stopped)</span>
+              </span>
               <LucideCheck v-if="String(bench.port) === String(currentPort)" class="h-4 w-4 text-ink-green-3" />
             </button>
           </div>

--- a/tests/test_admin_app.py
+++ b/tests/test_admin_app.py
@@ -7,7 +7,9 @@ from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch
 
+from bench_cli.config.bench_config import BenchConfig
 from bench_cli.config.bench_toml_builder import BenchTomlBuilder
+from bench_cli.config.toml_writer import bench_config_to_toml
 
 
 def _write_bench_toml(bench_dir: Path, name: str, **settings) -> None:
@@ -17,7 +19,15 @@ def _write_bench_toml(bench_dir: Path, name: str, **settings) -> None:
 
 def _write_raw_bench_toml(bench_dir: Path, name: str, admin_port: int) -> None:
     bench_dir.mkdir(parents=True, exist_ok=True)
-    (bench_dir / "bench.toml").write_text(f'[bench]\nname = "{name}"\n\n[admin]\nport = {admin_port}\n')
+    config = BenchConfig._from_dict(
+        {
+            "bench": {"name": name, "python": "3.14"},
+            "apps": [{"name": "frappe", "repo": "https://github.com/frappe/frappe", "branch": "develop"}],
+            "mariadb": {"root_password": "root"},
+            "admin": {"port": admin_port},
+        }
+    )
+    (bench_dir / "bench.toml").write_text(bench_config_to_toml(config))
 
 
 def _client(bench_root: Path, password: str = "secret"):
@@ -59,7 +69,7 @@ def test_api_benches_requires_auth(tmp_path: Path) -> None:
     assert resp.status_code == 401
 
 
-def test_api_benches_lists_only_running_benches(tmp_path: Path) -> None:
+def test_api_benches_lists_all_benches_with_running_flag(tmp_path: Path) -> None:
     benches_dir = tmp_path / "benches"
     client = _client(benches_dir / "current")
 
@@ -68,9 +78,9 @@ def test_api_benches_lists_only_running_benches(tmp_path: Path) -> None:
         _write_raw_bench_toml(benches_dir / "dead-bench", "dead-bench", admin_port=1)
         resp = client.get("/api/benches/")
 
-    names = [b["name"] for b in resp.get_json()]
-    assert "live-bench" in names
-    assert "dead-bench" not in names
+    running = {b["name"]: b["running"] for b in resp.get_json()}
+    assert running["live-bench"] is True
+    assert running["dead-bench"] is False
 
 
 # ── POST /api/benches/new ────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Closes #67.

In a multi-bench setup the switcher only showed benches whose admin port was currently accepting connections. Stopped benches disappeared entirely, so a multi-bench install looked like it had a single bench. The sidebar header also always read "Bench" instead of the actual bench name.

## Fix

- `/api/benches/` now lists **every** sibling bench (via the existing `iter_sibling_benches` util) plus the current one, each tagged with a `running` flag instead of being filtered out.
- The Change Bench dialog renders all benches. Stopped ones show `(stopped)`, are greyed out and disabled, so we never redirect to a dead port.
- The sidebar header now shows the real bench name, sourced from `/api/status`, instead of the hardcoded `"Bench"`.

## Tests

- Reworked the switcher test to assert all benches are returned with the correct `running` flag (live → `true`, stopped → `false`) rather than asserting stopped ones are dropped.
- Full unit suite: 349 passed.