### PR TITLE
fix(new-site): don't crash when /etc/hosts update needs sudo

### DIFF
--- a/bench_cli/commands/new_site.py
+++ b/bench_cli/commands/new_site.py
@@ -82,12 +82,19 @@ class NewSiteCommand(Command):
             if entry in line.split("#", 1)[0].split():
                 return
 
-        subprocess.run(
-            ["sudo", "tee", "-a", str(hosts_path)],
-            input=f"{entry}\n".encode(),
-            capture_output=True,
-            check=True,
-        )
+        try:
+            subprocess.run(
+                ["sudo", "-n", "tee", "-a", str(hosts_path)],
+                input=f"{entry}\n".encode(),
+                capture_output=True,
+                check=True,
+            )
+        except (subprocess.CalledProcessError, OSError) as e:
+            print(
+                f"Warning: could not add '{entry}' to {hosts_path}: {e}.\n"
+                f"  Add it manually to reach the site by name.",
+                file=sys.stderr,
+            )
 
     def _reload_nginx(self) -> None:
         if not self.bench.config.production.nginx:


### PR DESCRIPTION
## What

`bench new-site` crashed with a traceback when it couldn't update `/etc/hosts`, even though the site had already been created successfully.

```
subprocess.CalledProcessError: Command '['sudo', 'tee', '-a', '/etc/hosts']' returned non-zero exit status 1.
```

`_add_to_hosts()` is a best-effort step that runs *after* the site is created. In non-interactive contexts (e.g. the admin backend `new_site_task.py`) `sudo` has no TTY to prompt for a password, so `sudo tee` exits non-zero and the whole command aborts — confusingly printing both "Site created successfully" and a traceback.

## Changes

- Use `sudo -n` so the call fails fast instead of hanging on a password prompt in non-interactive environments.
- Catch the failure and print a `Warning:` to stderr (with the entry to add manually) instead of raising — matching the best-effort error handling already used in `remove_app.py`, `volume.py`, and `init.py`.

## How to test

1. In a context without passwordless sudo (or run the admin backend new-site task), create a new site in dev mode.
2. Before: command crashes with `CalledProcessError`.
3. After: site is created, and a warning is printed if the `/etc/hosts` entry can't be added.

## Note

In fully automated setups the `/etc/hosts` entry still won't be added. A passwordless sudoers rule for that specific `tee`, or a different name-resolution approach (dnsmasq/nginx), would be the longer-term fix.