### PR TITLE
fix: regenerate redis configs on start so upgraded benches self-heal

### DIFF
--- a/bench_cli/managers/process_manager.py
+++ b/bench_cli/managers/process_manager.py
@@ -84,12 +84,22 @@ class ProcessManager:
 
     def generate_config(self) -> None:
         AdminEnvManager(_cli_root()).ensure()
+        self._ensure_redis_config()
         self._ensure_gunicorn_config()
         lines = [f"{pd.name}: {pd.command}\n" for pd in self._process_definitions()]
         self.procfile_path.write_text("".join(lines))
 
     def _ensure_gunicorn_config(self) -> None:
         GunicornManager(self.bench).generate_config()
+
+    def _ensure_redis_config(self) -> None:
+        # The generated process config (Procfile/supervisor/systemd) runs
+        # redis-server against config/redis_{cache,queue}.conf. Regenerate them
+        # here so an upgrade that changes the redis config layout self-heals on
+        # the next start, rather than failing with a missing config file.
+        from bench_cli.managers.redis_manager import RedisManager
+
+        RedisManager(self.bench.config.redis, self.bench).generate_configs()
 
     # ── Lifecycle ───────────────────────────────────────────────────────────
 

--- a/bench_cli/managers/supervisor_process_manager.py
+++ b/bench_cli/managers/supervisor_process_manager.py
@@ -33,6 +33,7 @@ class SupervisorProcessManager(ProcessManager):
 
     def generate_config(self) -> None:
         AdminEnvManager(_cli_root()).ensure()
+        self._ensure_redis_config()
         self._ensure_gunicorn_config()
         self.supervisor_dir.mkdir(parents=True, exist_ok=True)
         self.supervisor_conf_path.write_text(self._render_supervisord_conf())

--- a/bench_cli/managers/systemd_process_manager.py
+++ b/bench_cli/managers/systemd_process_manager.py
@@ -49,6 +49,7 @@ class SystemdProcessManager(ProcessManager):
 
     def generate_config(self) -> None:
         AdminEnvManager(_cli_root()).ensure()
+        self._ensure_redis_config()
         self._ensure_gunicorn_config()
         GunicornManager(self.bench).generate_admin_config()
         self.systemd_conf_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -231,6 +231,20 @@ def test_honcho_generate_config_writes_procfile(tmp_path: Path) -> None:
     assert "redis_cache:" in content
 
 
+def test_honcho_generate_config_writes_redis_configs(tmp_path: Path) -> None:
+    # The generated Procfile runs `redis-server config/redis_{cache,queue}.conf`,
+    # so generate_config must (re)create those files. Regression: an upgraded
+    # bench whose config dir predates the split redis layout used to fail to
+    # start with "can't open config file".
+    bench = make_bench(tmp_path)
+    bench.create_directories()
+    process_manager = ProcessManager(bench)
+    process_manager.generate_config()
+
+    assert (tmp_path / "config" / "redis_cache.conf").exists()
+    assert (tmp_path / "config" / "redis_queue.conf").exists()
+
+
 def test_honcho_generate_config_procfile_format(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
     bench.create_directories()


### PR DESCRIPTION
The PR was generated because dashboard of my bench CLI was broken. The PR was generated while LLM tried to fix it, and found this issue in the process. I later asked to clarify the fix. Following is the brief in simpler language on the fix.

## Problem

The generated process config (Procfile / supervisor / systemd) runs `redis-server config/redis_cache.conf` and `redis-server config/redis_queue.conf`. But those two files are only written by `bench init` and `bench setup config` — **never** by `ProcessManager.generate_config()`, which is what `bench start` calls.

A bench created **before** the split-redis-config layout (single `config/redis.conf`) therefore has no `redis_cache.conf` / `redis_queue.conf`. After upgrading bench-cli, `bench start` fails:

- `redis_cache` exits with `Fatal error, can't open config file '.../config/redis_cache.conf'`
- the foreground runner tears down the whole process group when any process exits
- so nothing stays up — including the admin dashboard on `:8002`

Reproduced on a real upgraded bench: `bench start` → admin never binds `:8002`, dashboard won't load.

## Fix

Call a new `_ensure_redis_config()` from `generate_config()` in all three process managers (foreground, supervisor, systemd). It regenerates the redis configs via the existing `RedisManager.generate_configs()`, so an existing bench **self-heals on the next `bench start`** rather than requiring a manual `bench setup config`.

`generate_config()` already writes the Procfile that *references* these files, so generating them in the same place keeps them in sync.

## Verification

- Deleted `redis_cache.conf` / `redis_queue.conf` from a real bench, ran `bench start` → both files were regenerated and the full stack (web `:8000`, admin `:8002`, redis `:13000`/`:11000`, workers, scheduler) came up cleanly; dashboard returns HTTP 200.
- Added regression test `test_honcho_generate_config_writes_redis_configs`.
- Full suite: **424 passed, 5 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)