### PR TITLE
feat: auto-enable SSL for new sites when Let's Encrypt is configured

### DIFF
--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -52,6 +52,7 @@ const form = ref({
   production_process_manager: 'none',
   admin_domain: '',
   admin_tls: false,
+  letsencrypt_email: '',
 })
 
 // ── framework branch dropdown (fetched from the admin backend) ────────────
@@ -358,6 +359,10 @@ async function initialize() {
     error.value = 'Admin domain is required for a production process manager.'
     return
   }
+  if (form.value.admin_tls && !form.value.letsencrypt_email.trim()) {
+    error.value = 'An email address is required for Let\'s Encrypt.'
+    return
+  }
   const storageError = validateStorage()
   if (storageError) {
     error.value = storageError
@@ -526,16 +531,31 @@ function backToConfig() {
                 ]
               : [{ label: 'Development — run it yourself', value: 'none' }]"
           />
-          <div v-if="form.production_process_manager !== 'none'">
+          <div v-if="form.production_process_manager !== 'none'" class="flex flex-col gap-3">
+            <div>
+              <FormControl
+                type="text"
+                label="Admin domain"
+                v-model="form.admin_domain"
+                placeholder="my-admin.example.com"
+              />
+              <p class="mt-1 text-xs text-ink-gray-5">
+                After init the bench is deployed to production and reachable at this domain.
+              </p>
+            </div>
             <FormControl
-              type="text"
-              label="Admin domain"
-              v-model="form.admin_domain"
-              placeholder="my-admin.example.com"
+              type="checkbox"
+              label="Set up HTTPS with Let's Encrypt"
+              v-model="form.admin_tls"
             />
-            <p class="mt-1 text-xs text-ink-gray-5">
-              After init the bench is deployed to production and reachable at this domain.
-            </p>
+            <FormControl
+              v-if="form.admin_tls"
+              type="email"
+              label="Let's Encrypt email"
+              v-model="form.letsencrypt_email"
+              placeholder="you@example.com"
+              description="Used for certificate expiry notices. Sites on public domains will get HTTPS automatically."
+            />
           </div>
           <FormControl
             v-if="isLinux && form.dedicated_db === 'dedicated'"

--- a/bench_cli/commands/new_site.py
+++ b/bench_cli/commands/new_site.py
@@ -42,7 +42,8 @@ class NewSiteCommand(Command):
         from bench_cli.core.site import Site
 
         self._validate()
-        site = Site(SiteConfig(name=self.name, apps=self.apps, admin_password=self.admin_password), self.bench)
+        ssl = self._should_enable_ssl()
+        site = Site(SiteConfig(name=self.name, apps=self.apps, admin_password=self.admin_password, ssl=ssl), self.bench)
         print(f"Creating site '{self.name}'...")
         sys.stdout.flush()
         site.create()
@@ -51,6 +52,8 @@ class NewSiteCommand(Command):
         self.build_missing_assets()
         self._add_to_hosts()
         self._reload_nginx()
+        if ssl:
+            self._obtain_cert(site)
 
     def build_missing_assets(self):
         from bench_cli.managers.python_env_manager import PythonEnvManager
@@ -61,6 +64,25 @@ class NewSiteCommand(Command):
         for app in self.bench.apps():
             if not (assets_dir / app.config.name).exists():
                 manager.build_assets_for_app(app)
+
+    def _should_enable_ssl(self) -> bool:
+        from bench_cli.managers.letsencrypt_manager import _is_public_domain, letsencrypt_active
+
+        return letsencrypt_active(self.bench) and _is_public_domain(self.name)
+
+    def _obtain_cert(self, site) -> None:
+        from bench_cli.managers.letsencrypt_manager import LetsEncryptManager
+        from bench_cli.managers.nginx_manager import NginxManager
+
+        if not self.bench.config.production.enabled:
+            return
+        print("Obtaining SSL certificate...")
+        sys.stdout.flush()
+        mgr = LetsEncryptManager(self.bench)
+        mgr.obtain(site.config)
+        nginx_mgr = NginxManager(self.bench)
+        nginx_mgr.generate_config(ssl_ready=True)
+        nginx_mgr.reload()
 
     def _validate(self) -> None:
         from bench_cli.utils import host_owner

--- a/bench_cli/managers/letsencrypt_manager.py
+++ b/bench_cli/managers/letsencrypt_manager.py
@@ -20,6 +20,11 @@ def _is_public_domain(domain: str) -> bool:
     return bool(domain) and not domain.endswith(".localhost")
 
 
+def letsencrypt_active(bench: "Bench") -> bool:
+    """True if this bench is configured to obtain its own TLS certificates."""
+    return bool(bench.config.letsencrypt.email) and bench.config.admin.tls
+
+
 def needs_letsencrypt(bench: "Bench") -> bool:
     """True if any certificate is obtainable: an SSL site, or a public admin
     domain. Requires letsencrypt.email to be configured."""


### PR DESCRIPTION
- Setup wizard asks for HTTPS + Let's Encrypt email in the customize step (shown when a production process manager is selected)
- `bench new-site` sets `ssl=True` and obtains a cert automatically when letsencrypt is active and the domain is public
- Add `letsencrypt_active()` helper to centralise the "is this bench its own TLS terminator?" check

Prompts:
> on my remote server ssh root@64.227.182.89 i have setup a fresh bench-cli on my domain rmehta.io. i have setup letsencrypt but can't connect via https, can you debug?
> in the bench new site command, let's set ssl true for sites if letsencrypt is setup
> ask the user in the setup wizard if the it is a public domain so we can setup ssl from the get go