### PR TITLE
fix(cli-ui): added conditions to track the status of current task

### DIFF
--- a/admin/frontend/src/components/TaskProgressModal.vue
+++ b/admin/frontend/src/components/TaskProgressModal.vue
@@ -31,8 +31,8 @@ const stepSections = computed(() => {
     const endedAt = next ? next.ts : null
     let status
     if (next) status = 'done'
-    else if (!streaming.value && task.value?.status === 'failed') status = 'failed'
-    else if (!streaming.value) status = 'done'
+    else if (task.value?.status === 'success') status = 'done'
+    else if (task.value?.status === 'failed' || task.value?.status === 'killed') status = 'failed'
     else status = 'running'
     sections.push({ key: m.key, label: m.label, startedAt: m.ts, endedAt, status })
   }

--- a/admin/frontend/src/pages/TaskDetail.vue
+++ b/admin/frontend/src/pages/TaskDetail.vue
@@ -67,10 +67,10 @@ const stepSections = computed(() => {
     let status
     if (next) {
       status = 'done'
-    } else if (!streaming.value && task.value?.status === 'failed') {
-      status = 'failed'
-    } else if (!streaming.value) {
+    } else if (task.value?.status === 'success') {
       status = 'done'
+    } else if (task.value?.status === 'failed' || task.value?.status === 'killed') {
+      status = 'failed'
     } else {
       status = 'running'
     }


### PR DESCRIPTION
Fixes #93.

### Before
- Conditions to update the state in UI were not in sync with the task being processed on the fly.
- Previously, when streaming was `false` the conditions would mark a task as done.

### After
- Streaming is no longer involved, status is inferred directly from the task's status field.
