### PR TITLE
feat(update): CLI/GUI parity, --apps filter, fail-fast, and ZFS rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Each bench lives on a single dataset (`<pool>/<bench>`) holding both its files a
 | `bench new-site <name>` | Create a site |
 | `bench rename-site <old> <new>` | Rename a site (checks the hostname is free across all benches) |
 | `bench build` | Download pre-built assets (use `--force` to rebuild from source) |
-| `bench update` | git pull + reinstall + migrate all sites |
+| `bench update [--apps ..]` | git pull → reinstall deps → rebuild assets → migrate all sites; fails fast on the first error; on ZFS benches takes a snapshot first and auto-rolls back on failure |
 | `bench upgrade` | Pull latest bench-cli and download the admin frontend |
 | `bench setup config` | Regenerate Procfile and config files from bench.toml |
 | `bench build-admin` | Rebuild admin frontend assets from source |

--- a/admin/backend/tasks/jobs/update_task.py
+++ b/admin/backend/tasks/jobs/update_task.py
@@ -11,14 +11,12 @@ class UpdateTask(BaseTask):
     def _parser(cls):
         p = super()._parser()
         p.add_argument("--apps", nargs="*", default=None)
-        p.add_argument("--sites", nargs="*", default=None)
         p.add_argument("--task-log", default=None)
         return p
 
     def __init__(self, bench, bench_root, args):
         super().__init__(bench, bench_root, args)
         self._apps_filter = set(args.apps) if args.apps else None
-        self._sites_filter = set(args.sites) if args.sites else None
         self._task_log = Path(args.task_log) if getattr(args, "task_log", None) else None
 
     def run(self) -> None:
@@ -27,7 +25,6 @@ class UpdateTask(BaseTask):
                 self.bench,
                 skip_confirm=True,
                 apps=self._apps_filter,
-                sites=self._sites_filter,
                 task_log=self._task_log,
             ).run()
         except MigrateError:

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -141,8 +141,6 @@ class TaskRunner:
                 argv += ["--task-log", str(task_dir / "output.log")]
             if args.get("apps"):
                 argv += ["--apps"] + list(args["apps"])
-            if args.get("sites"):
-                argv += ["--sites"] + list(args["sites"])
             return argv
         if command == "get-app":
             argv = [sys.executable, "-m", "admin.backend.tasks.jobs.get_app_task", str(self._bench_root), args["repo"]]

--- a/bench_cli/commands/update.py
+++ b/bench_cli/commands/update.py
@@ -19,21 +19,28 @@ class UpdateCommand(Command):
     help = "Pull latest code and migrate sites."
 
     @classmethod
+    def add_arguments(cls, parser):
+        parser.add_argument(
+            "--apps",
+            nargs="+",
+            metavar="APP",
+            help="Limit git pull + reinstall to these apps (default: all).",
+        )
+
+    @classmethod
     def from_args(cls, args, bench):
-        return cls(bench, skip_confirm=args.yes)
+        return cls(bench, skip_confirm=args.yes, apps=set(args.apps) if args.apps else None)
 
     def __init__(
         self,
         bench: "Bench",
         skip_confirm: bool = False,
         apps: set | None = None,
-        sites: set | None = None,
         task_log: Path | None = None,
     ) -> None:
         self.bench = bench
         self.skip_confirm = skip_confirm
         self._apps_filter = apps  # None = all apps
-        self._sites_filter = sites  # None = all sites
         self._task_log = task_log
         self.tag: str | None = None
         self._current_step: str | None = None
@@ -198,8 +205,6 @@ class UpdateCommand(Command):
 
     def _migrate_sites(self) -> None:
         for site in self.bench.sites():
-            if self._sites_filter is not None and site.config.name not in self._sites_filter:
-                continue
             print(f"Migrating {site.config.name}...")
             try:
                 site.migrate()

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -385,45 +385,59 @@ bench build --force  # skip download, rebuild from source
 
 ## `bench update`
 
-Pulls the latest commits for all apps, reinstalls Python packages, and migrates all sites.
+Pulls the latest commits for all apps, reinstalls Python packages, rebuilds assets, and migrates all sites. Fails fast on the first error. When the bench sits on a ZFS volume, a snapshot is taken before any changes are made and the bench is automatically rolled back if anything goes wrong.
 
-### Pre-conditions
+```
+bench update [--yes] [--apps <app> ...]
+```
 
-- `bench init` has been run.
-- All processes are stopped (warn the user if any Procfile processes are detected running).
+| Flag | Description |
+|------|-------------|
+| `--yes` / `-y` | Skip the "processes are running" confirmation prompt. |
+| `--apps <name> ...` | Limit git pull + reinstall to the named apps (default: all). |
 
 ### Steps
 
 ```
-1.  Warn if processes are running
-2.  For each app: git pull
-3.  For each app: uv pip install -e
-4.  For each site: bench migrate
+[pre]     Take a snapshot           (ZFS benches only)
+[fetch]   Fetch latest code         git pull for each app
+[install] Install dependencies      uv pip install -e for each app
+[assets]  Build assets              bench build for each app
+[migrate] Migrate sites             bench migrate for each site
+[restart] Restart services          reload_web
+[done]    Done
 ```
 
-#### Step 1 — Warn if processes are running
+Each step emits a `##[step:KEY,TIMESTAMP] Label` marker that the admin UI uses to display a live progress timeline with per-step status and duration.
 
-If `pids/bench.pid` exists and the process is alive, print a warning and ask the user to confirm before continuing. In non-interactive mode (`--yes` flag), skip the prompt and proceed.
+### ZFS snapshot and automatic rollback
 
-#### Step 2 — git pull for each app
+When `volume.enabled = true` in `bench.toml`, the update command:
 
-For each app discovered in `apps/`:
-```
-git -C apps/<name> pull
-```
+1. Enters maintenance mode before touching anything.
+2. Takes a timestamped snapshot (`YYYYMMDD-HHMMSS`) covering both the bench dataset and the MariaDB dataset (via the snapshot orchestrator).
+3. Runs the normal fetch → install → assets → migrate → restart sequence.
+4. **On failure:** marks the failed step, prints the full traceback, then rolls back to the snapshot and reloads the web service so the bench returns to a known-good state.
+5. Exits maintenance mode in the `finally` block whether or not the update succeeded.
 
-#### Step 3 — uv pip install -e for each app
+#### Log preservation across rollback
 
-`PythonEnvManager.install_app(app)` re-runs `uv pip install -e apps/<name>` to pick up any new Python dependencies.
+Because the task directory lives inside the ZFS dataset, a pool revert would erase `output.log` along with everything else. To keep the complete log:
 
-#### Step 4 — bench migrate for each site
+1. The current log is copied to `/tmp/bench-update-rollback-<tag>.log` before the rollback runs.
+2. The rollback step's own output is appended to that `/tmp` file (via `redirect_stdout`/`redirect_stderr`).
+3. After the revert, a fresh `output.log` is written from the `/tmp` copy and `sys.stdout`/`sys.stderr` are redirected there so subsequent steps (restart, maintenance-mode release) are also captured.
 
-For each site discovered in `sites/`:
-```
-env/bin/bench --site <site.name> migrate
-```
+### Pre-conditions
 
-If migration fails on one site, print the error and continue with remaining sites. Exit with a non-zero code at the end if any migration failed.
+- `bench init` has been run.
+- All processes are stopped (a warning is printed if any Procfile processes are detected running; use `--yes` to skip the confirmation).
+
+### Failure behaviour
+
+- Fails fast on the first error in any step (app pull, install, asset build, or site migration).
+- Raises `MigrateError`, which `UpdateTask` catches to set the exit code to 1.
+- On ZFS benches the bench is rolled back before exiting; on non-ZFS benches the process exits immediately after printing the traceback.
 
 ---
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -131,7 +131,7 @@ class TaskRunner:
 | `clear-cache` | `site` | `env/bin/bench --site <site> clear-cache` |
 | `install-app` | `site`, `app` | `env/bin/bench --site <site> install-app <app>` |
 | `build` | — | `env/bin/bench build` |
-| `update` | `apps` (optional list), `sites` (optional list) | `python -m admin.backend.tasks.jobs.update_task --bench-root <root> --apps [...] --sites [...] --task-log <output.log>` |
+| `update` | `apps` (optional list) | `python -m admin.backend.tasks.jobs.update_task --bench-root <root> --apps [...] --task-log <output.log>` |
 | `reload-supervisor` | — | `supervisorctl -c config/supervisor.conf reload` |
 
 All paths in `command_argv` are absolute (resolved from `bench_root`) so the child process does not depend on `$CWD`.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -131,7 +131,7 @@ class TaskRunner:
 | `clear-cache` | `site` | `env/bin/bench --site <site> clear-cache` |
 | `install-app` | `site`, `app` | `env/bin/bench --site <site> install-app <app>` |
 | `build` | — | `env/bin/bench build` |
-| `update` | — | `env/bin/bench update --yes` |
+| `update` | `apps` (optional list), `sites` (optional list) | `python -m admin.backend.tasks.jobs.update_task --bench-root <root> --apps [...] --sites [...] --task-log <output.log>` |
 | `reload-supervisor` | — | `supervisorctl -c config/supervisor.conf reload` |
 
 All paths in `command_argv` are absolute (resolved from `bench_root`) so the child process does not depend on `$CWD`.


### PR DESCRIPTION
## Summary

- **`--apps` filter exposed on the CLI** — `bench update --apps frappe erpnext` now works; previously the flag only existed in the admin task runner
- **`--sites` filter removed** — updating always migrates all sites (same as the GUI); partial-site updates are ambiguous when ZFS rollback must restore the whole volume anyway
- **Fail fast** — the update aborts on the first error in any step instead of collecting failures and exiting at the end
- **Docs updated** — README.md, docs/commands.md, and docs/tasks.md reflect the new step sequence, flags, ZFS snapshot/rollback flow, and log-preservation mechanism

