### PR TITLE
fix: Mariadb & Build

### DIFF
--- a/admin/backend/readers/app_reader.py
+++ b/admin/backend/readers/app_reader.py
@@ -5,6 +5,8 @@ import zlib
 from dataclasses import dataclass
 from pathlib import Path
 
+from bench_cli.utils import git_has_local_changes
+
 
 @dataclass
 class AppInfo:
@@ -130,7 +132,7 @@ class AppReader:
             is_cloned=True,
             current_commit=sha[:7] if sha else "",
             commit_message=self._git_commit_message(git_dir, sha),
-            uncommitted_changes=self._git_is_dirty(app_path),
+            uncommitted_changes=git_has_local_changes(app_path),
             installed_version=self._pip_version(name),
             has_update=bool(remote_sha and sha and remote_sha != sha),
         )
@@ -206,14 +208,6 @@ class AppReader:
         if ref_file.exists():
             return ref_file.read_text().strip()
         return self._read_packed_ref(git_dir, f"refs/remotes/origin/{branch}")
-
-    def _git_is_dirty(self, app_path: Path) -> bool:
-        result = subprocess.run(
-            ["git", "-C", str(app_path), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-        )
-        return bool(result.stdout.strip()) if result.returncode == 0 else False
 
     def _pip_version(self, name: str) -> str:
         lib_dir = self._bench_root / "env" / "lib"

--- a/admin/backend/readers/app_reader.py
+++ b/admin/backend/readers/app_reader.py
@@ -17,7 +17,7 @@ class AppInfo:
     is_cloned: bool
     current_commit: str
     commit_message: str
-    uncommitted_changes: bool
+    has_local_changes: bool
     installed_version: str
     has_update: bool
 
@@ -115,7 +115,7 @@ class AppReader:
                 is_cloned=False,
                 current_commit="",
                 commit_message="",
-                uncommitted_changes=False,
+                has_local_changes=False,
                 installed_version=self._pip_version(name),
                 has_update=False,
             )
@@ -132,7 +132,7 @@ class AppReader:
             is_cloned=True,
             current_commit=sha[:7] if sha else "",
             commit_message=self._git_commit_message(git_dir, sha),
-            uncommitted_changes=git_has_local_changes(app_path),
+            has_local_changes=git_has_local_changes(app_path),
             installed_version=self._pip_version(name),
             has_update=bool(remote_sha and sha and remote_sha != sha),
         )

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -90,7 +90,7 @@ def site_apps(name: str):
                     "commit": info.current_commit,
                     "version": info.installed_version,
                     "repo": info.repo,
-                    "is_dirty": info.uncommitted_changes,
+                    "has_local_changes": info.has_local_changes,
                 }
             )
         except Exception:

--- a/admin/frontend/src/components/SettingsModal.vue
+++ b/admin/frontend/src/components/SettingsModal.vue
@@ -338,7 +338,7 @@ watch(() => props.modelValue, (val) => {
                       <div class="flex items-center gap-2 flex-wrap">
                         <span class="text-sm font-medium text-ink-gray-9">{{ appTitleMap[app.name] || app.name }}</span>
                         <Badge v-if="app.branch" :label="app.branch" theme="gray" size="sm" />
-                        <Badge v-if="app.uncommitted_changes" label="Modified" theme="orange" size="sm" />
+                        <Badge v-if="app.has_local_changes" label="Modified" theme="orange" size="sm" />
                       </div>
                       <p class="text-xs text-ink-gray-4 font-mono mt-0.5">{{ app.name }}</p>
                     </div>

--- a/admin/frontend/src/pages/SiteDetail.vue
+++ b/admin/frontend/src/pages/SiteDetail.vue
@@ -674,7 +674,7 @@ onMounted(() => {
                   <div class="flex min-w-0 flex-col gap-y-0.5">
                     <p class="text-sm font-medium leading-snug text-ink-gray-9">{{ titleMap[app] || app }}</p>
                     <div v-if="appDetailMap[app]" class="flex items-center gap-1.5">
-                      <span v-if="appDetailMap[app].is_dirty"
+                      <span v-if="appDetailMap[app].has_local_changes"
                         class="inline-flex items-center rounded px-0.5 py-0.5 text-xs font-medium bg-amber-100 text-amber-700 dark:bg-amber-900/60 dark:text-amber-300">
                         Modified
                       </span>

--- a/bench_cli/commands/init.py
+++ b/bench_cli/commands/init.py
@@ -194,12 +194,13 @@ class InitCommand(Command):
             pkg.update()
 
         mariadb_manager = MariaDBManager(self.bench.config.mariadb)
+        freshly_installed = not mariadb_manager.is_installed()
+        mariadb_manager.install()
+
         if mariadb_manager.is_dedicated:
             # Install the package only; the instance is provisioned after volume
             # setup (see _do_run) so a ZFS-backed datadir, if any, is mounted
             # before mariadb-install-db runs against it.
-            freshly_installed = not mariadb_manager.is_installed()
-            mariadb_manager.install()
             if freshly_installed and is_linux():
                 # apt auto-starts the shared mariadb service on port 3306 after
                 # installation. Stop and disable it so the dedicated instance can
@@ -207,10 +208,17 @@ class InitCommand(Command):
                 mariadb_manager.stop_shared()
 
         else:
-            freshly_installed = not mariadb_manager.is_installed()
-            mariadb_manager.install()
-            mariadb_manager.start()
-            if freshly_installed:
+            port_config_written = mariadb_manager.configure_shared_port()
+            if port_config_written:
+                # Config was written (or updated) — restart to apply the new port.
+                # systemctl/rc-service restart also starts a stopped service.
+                mariadb_manager.restart()
+            else:
+                mariadb_manager.start()
+            if freshly_installed or mariadb_manager.is_unsecured():
+                # Either the binary was just installed, or it was installed earlier
+                # for a dedicated instance but the shared datadir is still unsecured
+                # (root uses unix-socket auth with no password).
                 mariadb_manager.secure_installation()
             elif not mariadb_manager.check_credentials():
                 raise RuntimeError(

--- a/bench_cli/managers/mariadb_manager.py
+++ b/bench_cli/managers/mariadb_manager.py
@@ -113,6 +113,12 @@ class MariaDBManager:
         else:
             run_command(service_command("start", self.service_unit()))
 
+    def restart(self) -> None:
+        if is_macos():
+            run_command(["brew", "services", "restart", self._brew_package()])
+        else:
+            run_command(service_command("restart", self.service_unit()))
+
     def stop(self) -> None:
         if is_macos():
             run_command(["brew", "services", "stop", self._brew_package()])
@@ -169,6 +175,29 @@ class MariaDBManager:
             input=script.stdout,
             check=True,
         )
+
+    def configure_shared_port(self) -> bool:
+        """Write a drop-in config so the shared mariadb service listens on the
+        configured port.  Returns True if a config was written (the caller must
+        restart the service to apply it).  No-op when port is the default 3306,
+        when this is a dedicated instance, or on macOS (Homebrew config paths vary), or when
+        the shared port override already exists."""
+        conf_dir = "/etc/my.cnf.d" if is_alpine() else _CONF_DIR
+        conf_path = f"{conf_dir}/99-bench-shared-port.cnf"
+
+        if self.is_dedicated or self.config.port == 3306 or is_macos() or Path(conf_path).exists():
+            return False
+        content = f"[mariadbd]\nport = {self.config.port}\n"
+        import os
+        import tempfile
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".cnf", delete=False) as f:
+            f.write(content)
+            tmp = f.name
+        try:
+            run_command(["sudo", "install", "-m", "644", tmp, conf_path])
+        finally:
+            os.unlink(tmp)
+        return True
 
     def provision_instance(self, staging_dir: Path) -> None:
         """Create, configure, start and secure this bench's MariaDB instance
@@ -335,6 +364,17 @@ class MariaDBManager:
             if self.service_is_active() and Path(socket).exists():
                 return
             time.sleep(0.5)
+
+    def is_unsecured(self) -> bool:
+        """True if the admin account has no password and is reachable via
+        unix-socket auth (i.e. a fresh, not-yet-secured install).  Uses the
+        same privileged connection path as _run_sql_as_superuser — no MYSQL_PWD."""
+        cmd = ["mariadb"] if is_macos() else _privileged(["mariadb"])
+        if self.is_dedicated:
+            cmd.append(f"--socket={self.instance_socket()}")
+        cmd += ["-u", self.config.admin_user, "--batch", "--skip-column-names", "-e", "SELECT 1"]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        return result.returncode == 0
 
     def check_credentials(self, password: str | None = None) -> bool:
         """True if the admin user can connect with the given password (default:

--- a/bench_cli/managers/python_env_manager.py
+++ b/bench_cli/managers/python_env_manager.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from bench_cli.exceptions import BenchError
 from bench_cli.platform import get_package_manager, is_alpine, is_macos, which
-from bench_cli.utils import get_yarn_bin, run_command
+from bench_cli.utils import get_yarn_bin, git_has_local_changes, run_command
 
 if TYPE_CHECKING:
     from bench_cli.core.app import App
@@ -156,12 +156,12 @@ class PythonEnvManager:
         app_public_dir = app.path / app.config.name / "public"
         dist_dir = app_public_dir / "dist"
 
-        if not self._has_local_commits(app) and self._try_download_prebuilt_assets(app, app_public_dir, dist_dir):
-            return
-
-        if self._has_prebuilt_assets(dist_dir):
-            self._setup_prebuilt_assets(app.config.name, app_public_dir, dist_dir)
-            return
+        if not git_has_local_changes(app.path):
+            if self._try_download_prebuilt_assets(app, app_public_dir, dist_dir):
+                return
+            if self._has_prebuilt_assets(dist_dir):
+                self._setup_prebuilt_assets(app.config.name, app_public_dir, dist_dir)
+                return
 
         if (app.path / "package.json").exists():
             self._ensure_yarn_install(app.path)
@@ -202,22 +202,6 @@ class PythonEnvManager:
             cwd=path,
             stream_output=True,
         )
-
-    @staticmethod
-    def _has_local_commits(app: "App") -> bool:
-        """True when the app has commits not yet on its upstream branch, meaning
-        prebuilt release assets won't reflect local changes."""
-        import subprocess
-
-        r = subprocess.run(
-            ["git", "rev-list", "--count", "@{u}..HEAD"],
-            capture_output=True,
-            text=True,
-            cwd=app.path,
-        )
-        if r.returncode != 0:
-            return False
-        return r.stdout.strip() not in ("", "0")
 
     def _try_download_prebuilt_assets(self, app: "App", app_public_dir: Path, dist_dir: Path) -> bool:
         branch = self._app_branch(app)

--- a/bench_cli/managers/python_env_manager.py
+++ b/bench_cli/managers/python_env_manager.py
@@ -142,6 +142,9 @@ class PythonEnvManager:
                 )
 
     def build_assets(self) -> None:
+        for app in self.bench.apps():
+            if (app.path / "package.json").exists():
+                self._ensure_yarn_install(app.path)
         run_command(
             [*self.bench.frappe_call, "frappe", "build", "--force"],
             cwd=self.bench.sites_path,
@@ -153,7 +156,7 @@ class PythonEnvManager:
         app_public_dir = app.path / app.config.name / "public"
         dist_dir = app_public_dir / "dist"
 
-        if self._try_download_prebuilt_assets(app, app_public_dir, dist_dir):
+        if not self._has_local_commits(app) and self._try_download_prebuilt_assets(app, app_public_dir, dist_dir):
             return
 
         if self._has_prebuilt_assets(dist_dir):
@@ -161,13 +164,7 @@ class PythonEnvManager:
             return
 
         if (app.path / "package.json").exists():
-            print(f"  Installing JS dependencies for {app.config.name}...")
-            sys.stdout.flush()
-            run_command(
-                [get_yarn_bin(), "install", "--frozen-lockfile"],
-                cwd=app.path,
-                stream_output=True,
-            )
+            self._ensure_yarn_install(app.path)
 
         print(f"  Building assets for {app.config.name}...")
         sys.stdout.flush()
@@ -187,6 +184,40 @@ class PythonEnvManager:
                     cwd=app.path / frontend_dir,
                     stream_output=True,
                 )
+
+    def _ensure_yarn_install(self, path: Path) -> None:
+        """Run yarn install only when node_modules is absent or yarn.lock has changed.
+        Fresh clone — node_modules/ is gitignored and doesn't exist, so integrity.exists() is False → falls through to yarn install. ✓
+        After yarn install — integrity file is written now, which is always newer than yarn.lock (which was set to the clone time) → skips on subsequent calls. ✓
+        After git pull that changes yarn.lock — git sets the mtime of checked-out files to the time of the checkout operation, so yarn.lock gets a fresh mtime newer than the old integrity file → runs yarn install. ✓"""
+        integrity = path / "node_modules" / ".yarn-integrity"
+        lock = path / "yarn.lock"
+        if integrity.exists() and (not lock.exists() or lock.stat().st_mtime <= integrity.stat().st_mtime):
+            return
+        app_name = path.name
+        print(f"  Installing JS dependencies for {app_name}...")
+        sys.stdout.flush()
+        run_command(
+            [get_yarn_bin(), "install", "--frozen-lockfile"],
+            cwd=path,
+            stream_output=True,
+        )
+
+    @staticmethod
+    def _has_local_commits(app: "App") -> bool:
+        """True when the app has commits not yet on its upstream branch, meaning
+        prebuilt release assets won't reflect local changes."""
+        import subprocess
+
+        r = subprocess.run(
+            ["git", "rev-list", "--count", "@{u}..HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=app.path,
+        )
+        if r.returncode != 0:
+            return False
+        return r.stdout.strip() not in ("", "0")
 
     def _try_download_prebuilt_assets(self, app: "App", app_public_dir: Path, dist_dir: Path) -> bool:
         branch = self._app_branch(app)

--- a/bench_cli/utils.py
+++ b/bench_cli/utils.py
@@ -133,6 +133,24 @@ def write_toml(path: Path, data: dict) -> None:
     path.write_text(out.getvalue())
 
 
+def git_has_local_changes(path: Path) -> bool:
+    """True if the repo at *path* has uncommitted edits or commits not yet on upstream."""
+    import subprocess
+
+    r = subprocess.run(
+        ["git", "status", "--porcelain"],
+        capture_output=True, text=True, cwd=path,
+    )
+    if r.returncode == 0 and r.stdout.strip():
+        return True
+
+    r = subprocess.run(
+        ["git", "rev-list", "--count", "@{u}..HEAD"],
+        capture_output=True, text=True, cwd=path,
+    )
+    return r.returncode == 0 and r.stdout.strip() not in ("", "0")
+
+
 def get_yarn_bin() -> str:
     if yarn := shutil.which("yarn"):
         return yarn


### PR DESCRIPTION
- If a dedicated mariadb instance is created, creating shared ones after that creates port conflict.
  - ensure we update the shared db conf file with the bench.toml mariadb port.

- When running `bench build --force` smartly run `yarn install` based on yarn lock and yarn integrity file `mtime`


Fixes: https://github.com/frappe/bench-cli/issues/103