### PR TITLE
refactor(wizard): Drop process manager and domain config from setup UI

### DIFF
--- a/admin/backend/tasks/jobs/wizard_setup_task.py
+++ b/admin/backend/tasks/jobs/wizard_setup_task.py
@@ -1,27 +1,21 @@
 from __future__ import annotations
 
 from bench_cli.commands.init import InitCommand
-from bench_cli.commands.setup.production import SetupProductionCommand
 
 from .base_task import BaseTask
 
 
 class WizardSetupTask(BaseTask):
-    """The whole wizard as a single task: initialize the bench, then deploy it to
-    production when the user chose a process manager during setup.
+    """Initialize the bench — the only thing the setup wizard does.
 
-    Running both in one task gives the frontend one continuous stream to follow
-    and one state to resume — no stitching two tasks (and two SSE connections)
-    together, and no in-between window where the bench looks initialized but the
-    deploy hasn't started. The production deploy is just another step in the same
-    output, prefixed with an `[N/M]` marker so the wizard names it like the rest.
+    The wizard gets a development-ready bench up; production is a deliberate,
+    separate step the user runs from the terminal afterwards (`bench setup
+    production --admin-domain ... --tls`). Keeping the wizard to init alone
+    gives the frontend one continuous stream to follow and one state to resume.
     """
 
     def run(self) -> None:
         InitCommand(self.bench).run()
-        if self.bench.config.production.process_manager:
-            print("[1/1] Deploying to production", flush=True)
-            SetupProductionCommand(self.bench).run()
 
 
 if __name__ == "__main__":

--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -16,10 +16,9 @@ def wizard_marker_path(bench_root: Path) -> Path:
 
     Written when the wizard kicks off its setup task and cleared when setup
     finishes (and as a safety-net by /api/status once the bench is fully set up).
-    It keeps /api/status on the wizard during the run's in-between window — after
-    init the bench looks 'initialized' even though the production deploy hasn't
-    enabled it yet — without mistaking an independent `setup production` from
-    Settings or the CLI (which never writes it) for a wizard session.
+    It keeps /api/status on the wizard while init runs — env/bin/python can appear
+    partway through, making the bench look 'initialized' before the task is done —
+    so a reload returns to the wizard rather than a half-built dashboard.
     """
     return bench_root / ".wizard-active"
 
@@ -163,12 +162,11 @@ def _validate(data: dict) -> str | None:
 
 @setup_bp.route("/start", methods=["POST"])
 def start_setup():
-    """Run the whole wizard as one task: initialize the bench and, when a
-    production process manager was chosen, deploy it — see WizardSetupTask.
+    """Run the wizard as one task that initializes the bench — see WizardSetupTask.
 
     A single task means the wizard follows one continuous output stream and, on a
-    reload, simply reattaches to the one running task instead of guessing which of
-    two phases it was in.
+    reload, simply reattaches to the one running task. Production is a separate
+    step the user runs from the terminal afterwards (`bench setup production`).
     """
     from bench_cli.config.bench_config import BenchConfig
     from bench_cli.managers.volume_manager import VolumeManager

--- a/admin/frontend/src/App.vue
+++ b/admin/frontend/src/App.vue
@@ -14,6 +14,9 @@ const adminError = ref('')
 const authenticated = ref(false)
 const benchName = ref('')
 const wizardMode = ref(false)
+// Setup sets this once it has shut the wizard server down and is guiding the user
+// back to the terminal, so the reconnect overlay doesn't bury that instruction.
+const awaitingTerminal = ref(false)
 
 async function loadStatus() {
   const response = await fetch('/api/status')
@@ -46,9 +49,9 @@ function onSetupDone() {
 </script>
 
 <template>
-  <ConnectionGuard />
+  <ConnectionGuard :paused="awaitingTerminal" />
   <div v-if="loading" class="flex h-screen items-center justify-center bg-surface-gray-2" />
-  <Setup v-else-if="wizardMode" @done="onSetupDone" />
+  <Setup v-else-if="wizardMode" @done="onSetupDone" @awaiting-terminal="awaitingTerminal = true" />
   <div v-else-if="adminError" class="flex h-screen items-center justify-center p-8">
     <Alert theme="red" title="Admin Unavailable" :description="adminError" />
   </div>

--- a/admin/frontend/src/components/ConnectionGuard.vue
+++ b/admin/frontend/src/components/ConnectionGuard.vue
@@ -2,6 +2,10 @@
 import { ref, onMounted, onBeforeUnmount } from 'vue'
 import { LoadingIndicator } from 'frappe-ui'
 
+// `paused` suppresses the overlay while another flow is deliberately taking the
+// server down (e.g. the setup wizard handing off to the terminal) — otherwise the
+// reconnect loader would cover that screen and never resolve.
+const props = defineProps({ paused: { type: Boolean, default: false } })
 
 const down = ref(false)
 let timer = null
@@ -18,6 +22,11 @@ async function pingOk(url) {
 
 async function tick() {
   if (stopped) return
+  if (props.paused) {
+    down.value = false
+    timer = setTimeout(tick, 3000)
+    return
+  }
   if (!down.value) {
     down.value = !(await pingOk(`${window.location.origin}/api/ping`))
   } else {
@@ -44,7 +53,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div v-if="down" class="fixed inset-0 z-[9999] flex items-center justify-center gap-3 bg-surface-white">
+  <div v-if="down && !paused" class="fixed inset-0 z-[9999] flex items-center justify-center gap-3 bg-surface-white">
     <LoadingIndicator class="h-6 w-6 text-ink-gray-5" />
     <p class="text-xl text-ink-gray-7">Reconnecting to bench</p>
   </div>

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -545,14 +545,14 @@ function backToConfig() {
         </div>
 
         <div v-else-if="step === 'done'" class="flex flex-col gap-4 py-2">
-          <p class="text-sm text-ink-gray-7">Your bench is ready. Head back to your terminal and pick how to run it:</p>
+          <p class="text-sm text-ink-gray-7">Your bench is ready. Run one of these in your terminal:</p>
           <div>
             <p class="text-xs font-medium text-ink-gray-6">Develop locally</p>
             <code class="mt-1 block rounded bg-surface-gray-2 px-2 py-1.5 font-mono text-sm text-ink-gray-8 select-all">bench start</code>
           </div>
           <div>
-            <p class="text-xs font-medium text-ink-gray-6">…or deploy to production</p>
-            <code class="mt-1 block rounded bg-surface-gray-2 px-2 py-1.5 font-mono text-sm text-ink-gray-8 select-all">bench setup production --admin-domain &lt;your-domain&gt; --tls</code>
+            <p class="text-xs font-medium text-ink-gray-6">Deploy to production</p>
+            <code class="mt-1 block rounded bg-surface-gray-2 px-2 py-1.5 font-mono text-sm text-ink-gray-8 select-all">bench setup production --admin-domain &lt;your-domain&gt; --tls --letsencrypt-email &lt;you@example.com&gt;</code>
           </div>
           <p class="text-xs text-ink-gray-5">
             <code class="font-mono">bench start</code> reloads this page automatically once the bench is back.

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -13,9 +13,6 @@ const error = ref('')
 const loading = ref(false)
 const benchName = ref('')
 const isLinux = ref(true)
-// The host's native production manager: 'openrc' on Alpine, 'systemd' elsewhere.
-// Set from the backend so the wizard offers the right default per platform.
-const nativeProcessManager = ref('systemd')
 const dedicatedWillInstall = ref(false)  // true when a new dedicated instance will be created
 const sharedWillInstall = ref(false)     // true when the system/shared MariaDB isn't installed yet
 
@@ -31,14 +28,12 @@ const dbPasswordDescription = computed(() =>
 )
 
 // ── setup-task streaming state ─────────────────────────────────────────────
-// The whole wizard runs as one task (init + optional production deploy). It
-// streams `[N/M] description` lines, which name the current step. deployedProduction
-// records whether that run includes the production deploy, so onStreamDone knows
-// whether to redirect to the bench's domain or tell the user to `bench start`.
+// The wizard initializes the bench as one task, streaming `[N/M] description`
+// lines that name the current step. Production is a deliberate, separate step
+// the user runs from the terminal afterwards (`bench setup production`).
 const taskStream = ref(null)
 const streamUrl = ref('')
 const currentStep = ref('Starting…')
-const deployedProduction = ref(false)
 const showDetails = ref(false)
 
 const form = ref({
@@ -55,10 +50,6 @@ const form = ref({
   volume_image_size: '60G',
   volume_reservation: '15G',
   volume_quota: '60G',
-  production_process_manager: 'none',
-  admin_domain: '',
-  admin_tls: false,
-  letsencrypt_email: '',
 })
 
 // ── framework branch dropdown (fetched from the admin backend) ────────────
@@ -169,20 +160,6 @@ watch(dbWillInstall, (fresh) => {
 }, { immediate: true })
 watch(() => [form.value.volume_backing, form.value.volume_device, form.value.volume_image_size], applySmartSizes)
 
-// ── process manager ────────────────────────────────────────────────────────
-// The native manager (systemd/OpenRC) is the recommended option; supervisor is
-// the cross-platform alternative. macOS has no production managers at all.
-const PM_LABELS = { systemd: 'Systemd', openrc: 'OpenRC', supervisor: 'Supervisor' }
-const processManagerOptions = computed(() => {
-  if (!isLinux.value) return [{ label: 'Development — run it yourself', value: 'none' }]
-  const native = nativeProcessManager.value
-  return [
-    { label: 'Development — run it yourself', value: 'none' },
-    { label: `${PM_LABELS[native] || native} — recommended`, value: native },
-    { label: 'Supervisor — alternative', value: 'supervisor' },
-  ]
-})
-
 // ── step flow ──────────────────────────────────────────────────────────────
 const configSteps = computed(() => {
   const steps = ['passwords', 'database', 'customize']
@@ -219,19 +196,14 @@ async function loadConfig() {
     const data = await res.json()
     benchName.value = data.bench_name || ''
     isLinux.value = data.is_linux !== false
-    nativeProcessManager.value = data.native_process_manager || 'systemd'
     availableDevices.value = data.available_devices || []
     rootfsFreeBytes.value = data.rootfs_free_bytes || 0
     for (const key of Object.keys(form.value)) {
       if (data[key] !== undefined) form.value[key] = data[key]
     }
     clampImageSize()
-    // Whether the saved config deploys to production. Read before the default
-    // below rewrites a 'none' selection, so a resumed run routes correctly.
-    deployedProduction.value = !!data.production_process_manager && data.production_process_manager !== 'none'
     if (isLinux.value) {
       form.value.dedicated_db = data.mariadb_instance ? 'dedicated' : 'shared'
-      if (form.value.production_process_manager === 'none') form.value.production_process_manager = nativeProcessManager.value
     }
     // One task, one resume rule: if it's still running, reattach to its stream.
     // Otherwise start at the first config step.
@@ -292,9 +264,10 @@ function onStreamDone(success) {
     return
   }
   step.value = 'done'
-  // Production deploys live behind their domain; dev benches need a `bench start`.
-  if (deployedProduction.value) finishAndRedirectToDomain()
-  else shutdownAndPoll()
+  // The bench is initialized; the user runs `bench start` (or `bench setup
+  // production`) from the terminal next. Shut the wizard server down and, if
+  // they pick `bench start`, the page reloads once the bench is back.
+  shutdownAndPoll()
 }
 
 function failWith(message) {
@@ -387,14 +360,6 @@ function validateStorage() {
 
 async function initialize() {
   error.value = ''
-  if (form.value.production_process_manager !== 'none' && !form.value.admin_domain.trim()) {
-    error.value = 'Admin domain is required for a production process manager.'
-    return
-  }
-  if (form.value.admin_tls && !form.value.letsencrypt_email.trim()) {
-    error.value = 'An email address is required for Let\'s Encrypt.'
-    return
-  }
   const storageError = validateStorage()
   if (storageError) {
     error.value = storageError
@@ -403,8 +368,6 @@ async function initialize() {
   loading.value = true
   try {
     await saveConfig()
-    // The saved config decides whether this run deploys to production.
-    deployedProduction.value = form.value.production_process_manager !== 'none'
     const data = await postJson('/api/setup/start', {})
     if (!data.ok) throw new Error(data.error || 'Failed to start setup.')
     step.value = 'running'
@@ -414,16 +377,6 @@ async function initialize() {
   } finally {
     loading.value = false
   }
-}
-
-async function finishAndRedirectToDomain() {
-  try {
-    await postJson('/api/setup/finish', {})
-  } catch {}
-  // The admin now lives behind nginx at its domain, not the local wizard port.
-  const scheme = form.value.admin_tls === true ? 'https' : 'http'
-  const url = `${scheme}://${form.value.admin_domain.trim()}`
-  setTimeout(() => { window.location.href = url }, 2500)
 }
 
 async function shutdownAndPoll() {
@@ -521,38 +474,6 @@ function backToConfig() {
           />
           <FormControl label="Frappe repository" v-model="form.app_repo" />
           <FormControl
-            type="select"
-            label="Production process manager"
-            v-model="form.production_process_manager"
-            :options="processManagerOptions"
-          />
-          <div v-if="form.production_process_manager !== 'none'" class="flex flex-col gap-3">
-            <div>
-              <FormControl
-                type="text"
-                label="Admin domain"
-                v-model="form.admin_domain"
-                placeholder="my-admin.example.com"
-              />
-              <p class="mt-1 text-xs text-ink-gray-5">
-                After init the bench is deployed to production and reachable at this domain.
-              </p>
-            </div>
-            <FormControl
-              type="checkbox"
-              label="Set up HTTPS with Let's Encrypt"
-              v-model="form.admin_tls"
-            />
-            <FormControl
-              v-if="form.admin_tls"
-              type="email"
-              label="Let's Encrypt email"
-              v-model="form.letsencrypt_email"
-              placeholder="you@example.com"
-              description="Used for certificate expiry notices. Sites on public domains will get HTTPS automatically."
-            />
-          </div>
-          <FormControl
             v-if="isLinux && form.dedicated_db === 'dedicated'"
             type="checkbox"
             label="Use volumes (snapshots & backups)"
@@ -596,8 +517,8 @@ function backToConfig() {
 
         <div v-else-if="isRunning" class="flex flex-col gap-4">
           <!-- A single status line, named by the task's current `[N/M] description`
-               step (init's steps, then "Deploying to production"). No progress bar.
-               The terminal stays collapsed unless something fails. -->
+               step (init's steps). No progress bar. The terminal stays collapsed
+               unless something fails. -->
           <p class="text-sm text-ink-gray-7">{{ currentStep }}</p>
           <button
             type="button"
@@ -623,15 +544,18 @@ function backToConfig() {
           <ErrorMessage v-if="error" :message="error" />
         </div>
 
-        <div v-else-if="step === 'done'" class="flex flex-col items-center gap-3 py-6 text-center">
-          <p class="text-sm text-ink-gray-7">Your bench is ready.</p>
-          <p v-if="deployedProduction" class="text-sm text-ink-gray-5">
-            Taking you to your bench…
-          </p>
-          <p v-else class="text-sm text-ink-gray-5">
-            Run
-            <code class="rounded bg-surface-gray-2 px-1 font-mono">bench start</code>
-            in your terminal to start your bench — this page will reload automatically once it's back.
+        <div v-else-if="step === 'done'" class="flex flex-col gap-4 py-2">
+          <p class="text-sm text-ink-gray-7">Your bench is ready. Head back to your terminal and pick how to run it:</p>
+          <div>
+            <p class="text-xs font-medium text-ink-gray-6">Develop locally</p>
+            <code class="mt-1 block rounded bg-surface-gray-2 px-2 py-1.5 font-mono text-sm text-ink-gray-8 select-all">bench start</code>
+          </div>
+          <div>
+            <p class="text-xs font-medium text-ink-gray-6">…or deploy to production</p>
+            <code class="mt-1 block rounded bg-surface-gray-2 px-2 py-1.5 font-mono text-sm text-ink-gray-8 select-all">bench setup production --admin-domain &lt;your-domain&gt; --tls</code>
+          </div>
+          <p class="text-xs text-ink-gray-5">
+            <code class="font-mono">bench start</code> reloads this page automatically once the bench is back.
           </p>
         </div>
       </div>

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { Button, FormControl, FormLabel, Password, Slider, ErrorMessage, FeatherIcon } from 'frappe-ui'
 import TaskStream from '../components/TaskStream.vue'
 
-const emit = defineEmits(['done'])
+const emit = defineEmits(['done', 'awaiting-terminal'])
 
 // Starts as 'loading' so a reload resolves the resume phase from the backend
 // before rendering — otherwise the wizard flashes step 1 (passwords) on every
@@ -264,9 +264,9 @@ function onStreamDone(success) {
     return
   }
   step.value = 'done'
-  // The bench is initialized; the user runs `bench start` (or `bench setup
-  // production`) from the terminal next. Shut the wizard server down and, if
-  // they pick `bench start`, the page reloads once the bench is back.
+  // Hand off to the terminal: pause the reconnect overlay before shutting the
+  // wizard server down, so the done-screen instructions stay visible.
+  emit('awaiting-terminal')
   shutdownAndPoll()
 }
 

--- a/bench_cli/commands/new.py
+++ b/bench_cli/commands/new.py
@@ -20,7 +20,8 @@ class NewCommand(Command):
         parser.add_argument(
             "--admin-domain",
             default="",
-            help="Admin domain for this bench (defaults to <name>-admin.localhost).",
+            help="Admin domain for this bench. Optional for development; "
+                 "required by 'bench setup production' (pass it there if omitted here).",
         )
 
     @classmethod
@@ -60,9 +61,12 @@ class NewCommand(Command):
         offset = self._pick_port_offset(self.target_directory)
         print("Writing bench.toml")
         admin_tls = self.admin_tls if self.admin_tls is not None else self._sibling_admin_tls()
+        # admin.domain is left empty unless given: development serves the admin on
+        # localhost, and 'bench setup production' requires a real domain (via its
+        # --admin-domain flag or here), erroring rather than deploying a placeholder.
         settings = {
             "admin_password": secrets.token_hex(nbytes=5),
-            "admin_domain": self.admin_domain or f"{self.name}-admin.localhost",
+            "admin_domain": self.admin_domain,
             "admin_tls": admin_tls,
         }
         if self.process_manager:
@@ -92,7 +96,7 @@ class NewCommand(Command):
         print(f"\nBench '{self.name}' created at {self.target_directory}")
         print("\nNext step:")
         print("  bench start")
-        print(f"  Open http://localhost:{admin_port} — the setup wizard guides you through the rest,")
+        print(f"  Then open http://localhost:{admin_port} — the setup wizard takes it from there.")
 
     def _sibling_letsencrypt_email(self) -> str:
         """The Let's Encrypt email from any sibling bench that has one, so a new

--- a/bench_cli/commands/setup/production.py
+++ b/bench_cli/commands/setup/production.py
@@ -31,33 +31,44 @@ class SetupProductionCommand(Command):
         parser.add_argument(
             "--admin-domain",
             default=None,
-            help="Admin domain (defaults to admin.domain in bench.toml).",
+            help="Admin domain the deployment is reached at (required: pass it here "
+                 "or set admin.domain in bench.toml).",
         )
         parser.add_argument(
             "--tls",
             dest="admin_tls",
             action="store_true",
+            default=None,  # None = leave the bench.toml value untouched; only --tls turns it on
             help="Terminate TLS via Let's Encrypt for the admin and SSL-enabled sites. "
                  "Omit to serve plain HTTP (a central proxy may terminate TLS upstream).",
+        )
+        parser.add_argument(
+            "--letsencrypt-email",
+            dest="letsencrypt_email",
+            default=None,
+            help="Contact email for Let's Encrypt (required with --tls unless "
+                 "letsencrypt.email is already set in bench.toml).",
         )
 
     @classmethod
     def from_args(cls, args, bench):
         return cls(bench, process_manager=args.process_manager, admin_domain=args.admin_domain,
-                   admin_tls=args.admin_tls)
+                   admin_tls=args.admin_tls, letsencrypt_email=args.letsencrypt_email)
 
     def __init__(self, bench: "Bench", process_manager: Optional[str] = None, admin_domain: Optional[str] = None,
-                 admin_tls: Optional[bool] = None) -> None:
+                 admin_tls: Optional[bool] = None, letsencrypt_email: Optional[str] = None) -> None:
         self.bench = bench
         self._pm_arg = process_manager
         self._domain_arg = admin_domain
         self._tls_arg = admin_tls
+        self._email_arg = letsencrypt_email
         self._existing_admin_domain = bench.config.admin.domain
         self._registered_admin_domain: Optional[str] = None
 
     def run(self) -> None:
         self._require_linux()
         self._resolve_target()
+        self._require_production_inputs()
         self._check_admin_domain()
         self._register_admin_domain()
         try:
@@ -114,6 +125,24 @@ class SetupProductionCommand(Command):
             self.bench.config.admin.domain = self._domain_arg
         if self._tls_arg is not None:
             self.bench.config.admin.tls = self._tls_arg
+        if self._email_arg:
+            self.bench.config.letsencrypt.email = self._email_arg
+
+    def _require_production_inputs(self) -> None:
+        """Fail early and clearly on inputs the setup wizard no longer collects: an
+        admin domain (always) and a Let's Encrypt email (only with --tls). Better
+        here than deep inside nginx/cert work, or as a silently-skipped cert."""
+        if not self.bench.config.admin.domain:
+            raise BenchError(
+                "An admin domain is required to deploy to production. "
+                "Pass --admin-domain <domain> (e.g. --admin-domain admin.example.com), "
+                "or set admin.domain in bench.toml."
+            )
+        if self.bench.config.admin.tls and not self.bench.config.letsencrypt.email:
+            raise BenchError(
+                "A contact email is required with --tls for Let's Encrypt. "
+                "Pass --letsencrypt-email <email>, or set letsencrypt.email in bench.toml."
+            )
 
     def _installed_manager(self) -> Optional[str]:
         """Which process manager already has a deployment on disk, if any —

--- a/bench_cli/commands/setup/production.py
+++ b/bench_cli/commands/setup/production.py
@@ -130,15 +130,18 @@ class SetupProductionCommand(Command):
 
     def _require_production_inputs(self) -> None:
         """Fail early and clearly on inputs the setup wizard no longer collects: an
-        admin domain (always) and a Let's Encrypt email (only with --tls). Better
-        here than deep inside nginx/cert work, or as a silently-skipped cert."""
+        admin domain (always) and a Let's Encrypt email (only when --tls would
+        actually obtain a cert). Better here than deep inside nginx/cert work, or
+        as a silently-skipped cert."""
+        from bench_cli.managers.letsencrypt_manager import letsencrypt_email_required
+
         if not self.bench.config.admin.domain:
             raise BenchError(
                 "An admin domain is required to deploy to production. "
                 "Pass --admin-domain <domain> (e.g. --admin-domain admin.example.com), "
                 "or set admin.domain in bench.toml."
             )
-        if self.bench.config.admin.tls and not self.bench.config.letsencrypt.email:
+        if letsencrypt_email_required(self.bench) and not self.bench.config.letsencrypt.email:
             raise BenchError(
                 "A contact email is required with --tls for Let's Encrypt. "
                 "Pass --letsencrypt-email <email>, or set letsencrypt.email in bench.toml."

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -308,7 +308,8 @@ class BenchConfig:
             if self.production.enabled:
                 raise ConfigError(
                     f"admin.domain is required in production but is missing for bench '{self.name}'. "
-                    f"Set it in bench.toml (e.g. admin.example.com) or run 'bench setup production' to be prompted."
+                    f"Set it in bench.toml (e.g. admin.example.com) or pass "
+                    f"'bench setup production --admin-domain <domain>'."
                 )
             return
         if not _HOSTNAME_PATTERN.match(domain):

--- a/bench_cli/managers/letsencrypt_manager.py
+++ b/bench_cli/managers/letsencrypt_manager.py
@@ -52,18 +52,24 @@ def letsencrypt_active(bench: "Bench") -> bool:
     return bool(bench.config.letsencrypt.email) and bench.config.admin.tls
 
 
-def needs_letsencrypt(bench: "Bench") -> bool:
-    """True if any certificate is obtainable: an SSL site, or a public admin
-    domain. Requires letsencrypt.email to be configured."""
-    if not bench.config.letsencrypt.email:
-        return False
-    # admin.tls = False means a central proxy terminates TLS for the whole
-    # bench, so no certs are obtained here at all.
+def letsencrypt_email_required(bench: "Bench") -> bool:
+    """True if --tls would actually obtain a cert here — an SSL site or a public
+    admin domain — and so needs a contact email. Local domains (``*.localhost``)
+    never get certs, so no email is required for them.
+
+    admin.tls = False means a central proxy terminates TLS for the whole bench,
+    so no certs are obtained here at all.
+    """
     if not bench.config.admin.tls:
         return False
     if any(site.config.ssl and _is_public_domain(site.config.name) for site in bench.sites()):
         return True
     return _is_public_domain(bench.config.admin.domain)
+
+
+def needs_letsencrypt(bench: "Bench") -> bool:
+    """True if any certificate is obtainable. Requires letsencrypt.email to be set."""
+    return bool(bench.config.letsencrypt.email) and letsencrypt_email_required(bench)
 
 
 class LetsEncryptManager:

--- a/tests/test_setup_production.py
+++ b/tests/test_setup_production.py
@@ -131,6 +131,37 @@ def test_resolve_target_applies_admin_domain(tmp_path: Path) -> None:
     assert bench.config.admin.domain == "admin-new.example.com"
 
 
+def test_resolve_target_applies_letsencrypt_email(tmp_path: Path) -> None:
+    bench = _make_bench(tmp_path)
+    cmd = SetupProductionCommand(bench, process_manager="systemd", letsencrypt_email="me@example.com")
+    cmd._resolve_target()
+    assert bench.config.letsencrypt.email == "me@example.com"
+
+
+def test_require_production_inputs_needs_admin_domain(tmp_path: Path) -> None:
+    # Fresh, undeployed bench: empty domain, no process manager yet (so it loads).
+    bench = _make_bench(tmp_path, admin_domain="", process_manager="")
+    cmd = SetupProductionCommand(bench, process_manager="systemd")
+    cmd._resolve_target()
+    with pytest.raises(BenchError, match="admin domain is required"):
+        cmd._require_production_inputs()
+
+
+def test_require_production_inputs_needs_email_for_tls(tmp_path: Path) -> None:
+    bench = _make_bench(tmp_path, admin_domain="admin.example.com", tls=True, email="")
+    cmd = SetupProductionCommand(bench, process_manager="systemd")
+    cmd._resolve_target()
+    with pytest.raises(BenchError, match="contact email is required"):
+        cmd._require_production_inputs()
+
+
+def test_require_production_inputs_passes_with_domain_and_email(tmp_path: Path) -> None:
+    bench = _make_bench(tmp_path, admin_domain="admin.example.com", tls=True, email="me@example.com")
+    cmd = SetupProductionCommand(bench, process_manager="systemd")
+    cmd._resolve_target()
+    cmd._require_production_inputs()  # no raise
+
+
 def test_persist_production_state_writes_enabled_and_drops_nginx(tmp_path: Path) -> None:
     bench = _make_bench(tmp_path, process_manager="supervisor")
     # legacy nginx key present in toml


### PR DESCRIPTION
Switching between dev server and system manager is quite buggy due to killing own process and starting a new one.

Better to remove it and keep setup wizard simple. We will show guidance what to do next like run `bench start` or `bench setup production` from terminal.

After spawning up one prod bench, they can easily create new benches from ui easily.