### PR TITLE
feat(admin): add generate-session command for sid cookie sign-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ count = 1
 [admin]
 port = 8002
 password = "your-admin-password"   # required — admin refuses to start without this
+jwt_secret = "..."                 # auto-generated — signs admin session tokens (don't set by hand)
 domain = "admin.example.com"       # optional — serve admin behind this domain via nginx
 tls = false                        # server-wide HTTPS opt-in (Let's Encrypt); false = plain HTTP
 
@@ -206,6 +207,7 @@ Each bench lives on a single dataset (`<pool>/<bench>`) holding both its files a
 | `bench upgrade` | Pull latest bench-cli and download the admin frontend |
 | `bench setup config` | Regenerate Procfile and config files from bench.toml |
 | `bench build-admin` | Rebuild admin frontend assets from source |
+| `bench generate-session` | Issue a 5-minute, single-use admin sign-in link (`--full-path` for the URL) |
 | `bench setup nginx` | Generate and install nginx config |
 | `bench setup letsencrypt` | Obtain SSL certificates |
 | `bench setup production` | Full production setup — `--process-manager`, `--admin-domain`, `--tls` |
@@ -264,6 +266,7 @@ email = "ops@example.com"
 [admin]
 port = 8002
 password = "your-admin-password"
+jwt_secret = "..."             # auto-generated — signs admin session tokens (don't set by hand)
 domain = "admin.example.com"   # required in production — admin is served behind this domain
 tls = true                     # server-wide HTTPS via Let's Encrypt (omit/false = plain HTTP)
 ```

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Each bench lives on a single dataset (`<pool>/<bench>`) holding both its files a
 | `bench upgrade` | Pull latest bench-cli and download the admin frontend |
 | `bench setup config` | Regenerate Procfile and config files from bench.toml |
 | `bench build-admin` | Rebuild admin frontend assets from source |
-| `bench generate-session` | Issue a 5-minute, single-use admin sign-in link (`--full-path` for the URL) |
+| `bench generate-admin-session` | Issue a 5-minute, single-use admin sign-in link (`--full-path` for the URL) |
 | `bench setup nginx` | Generate and install nginx config |
 | `bench setup letsencrypt` | Obtain SSL certificates |
 | `bench setup production` | Full production setup — `--process-manager`, `--admin-domain`, `--tls` |

--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -333,7 +333,7 @@ def create_app(bench_root: Path) -> Flask:
         )
 
     @app.route("/api/login", methods=["POST"])
-    @rate_limit(10, 60)
+    @rate_limit(5, 60, user_ip=True)
     def api_login():
         try:
             config = BenchConfig.from_file(bench_root / "bench.toml")

--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hmac
 import http.client
 import os
 import re
@@ -206,6 +207,10 @@ def create_app(bench_root: Path) -> Flask:
 
         return verify_token(request.cookies.get("sid", ""), config.admin.jwt_secret)
 
+    def _set_sid_cookie(resp, sid: str, config: BenchConfig):
+        resp.set_cookie("sid", sid, max_age=24 * 3600, httponly=True,
+                        secure=config.production.enabled and config.admin.tls, samesite="Lax")
+
     def _check_password(config: BenchConfig):
         if not config.admin.password:
             return jsonify({"error": "No admin password configured in bench.toml", "enabled": False}), 503
@@ -275,7 +280,16 @@ def create_app(bench_root: Path) -> Flask:
         if not config.admin.password:
             return jsonify({"ok": False, "error": "No admin password configured in bench.toml"}), 503
         data = request.get_json(silent=True) or {}
-        if data.get("password") == config.admin.password:
+        sid = data.get("sid")
+        if sid:
+            from bench_cli.commands.generate_session import verify_token
+
+            if not verify_token(sid, config.admin.jwt_secret):
+                return jsonify({"ok": False, "error": "Invalid or expired session token"}), 401
+            resp = jsonify({"ok": True})
+            _set_sid_cookie(resp, sid, config)
+            return resp
+        if hmac.compare_digest(str(data.get("password", "")), config.admin.password):
             session["authenticated"] = True
             return jsonify({"ok": True})
         return jsonify({"ok": False, "error": "Incorrect password"}), 401
@@ -283,7 +297,9 @@ def create_app(bench_root: Path) -> Flask:
     @app.route("/api/logout", methods=["POST"])
     def api_logout():
         session.clear()
-        return jsonify({"ok": True})
+        resp = jsonify({"ok": True})
+        resp.delete_cookie("sid")
+        return resp
 
     @app.route("/api/benches/")
     def api_benches():

--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -199,10 +199,17 @@ def create_app(bench_root: Path) -> Flask:
             return jsonify({"error": "Admin is disabled", "enabled": False}), 503
         return None
 
+    def _is_authenticated(config: BenchConfig) -> bool:
+        if session.get("authenticated"):
+            return True
+        from bench_cli.commands.generate_session import verify_token
+
+        return verify_token(request.cookies.get("sid", ""), config.admin.jwt_secret)
+
     def _check_password(config: BenchConfig):
         if not config.admin.password:
             return jsonify({"error": "No admin password configured in bench.toml", "enabled": False}), 503
-        if not session.get("authenticated"):
+        if not _is_authenticated(config):
             return jsonify({"error": "Authentication required"}), 401
         return None
 
@@ -210,13 +217,14 @@ def create_app(bench_root: Path) -> Flask:
     def _guard():
         if not request.path.startswith("/api") or request.path in _OPEN_PATHS:
             return None
-        if request.path.startswith("/api/setup/"):
-            return None
+        is_setup = request.path.startswith("/api/setup/")
         try:
             config = _load_config()
-            return _check_enabled(config) or _check_password(config)
         except Exception as exc:
-            return jsonify({"error": str(exc), "enabled": False}), 503
+            return None if is_setup else (jsonify({"error": str(exc), "enabled": False}), 503)
+        if is_setup and not config.admin.password:
+            return None
+        return _check_enabled(config) or _check_password(config)
 
     @app.route("/api/ping")
     def api_ping():
@@ -254,7 +262,7 @@ def create_app(bench_root: Path) -> Flask:
                 "name": config.name,
                 "production": config.production.enabled,
                 "native_process_manager": native_process_manager(),
-                "authenticated": bool(session.get("authenticated")),
+                "authenticated": _is_authenticated(config),
             }
         )
 

--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import hmac
 import http.client
 import os
@@ -40,6 +41,52 @@ _NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 _ADMIN_DOMAIN_RE = re.compile(
     r"^(?=.{1,253}$)[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
 )
+
+
+class _SlidingWindow:
+    """In-memory request counter, keyed by an arbitrary string. Safe for the
+    admin's single gunicorn worker (one process, multiple threads)."""
+
+    def __init__(self, max_hits: int, window: int) -> None:
+        self._max = max_hits
+        self._window = window
+        self._hits: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+
+    def allow(self, key: str) -> bool:
+        now = time.monotonic()
+        with self._lock:
+            recent = [t for t in self._hits.get(key, []) if now - t < self._window]
+            if len(recent) >= self._max:
+                self._hits[key] = recent
+                return False
+            recent.append(now)
+            self._hits[key] = recent
+            return True
+
+
+def _client_ip() -> str:
+    # nginx overwrites X-Real-IP with the real client address (unspoofable);
+    # in dev there is no proxy, so fall back to the direct peer.
+    return request.headers.get("X-Real-IP") or request.remote_addr or "unknown"
+
+
+def rate_limit(attempts: int, seconds: int, user_ip: bool = True):
+    """Allow at most ``attempts`` calls per ``seconds`` (per client IP when
+    ``user_ip``, else globally), returning HTTP 429 once exceeded."""
+
+    def decorator(view):
+        window = _SlidingWindow(attempts, seconds)
+
+        @functools.wraps(view)
+        def wrapper(*args, **kwargs):
+            if not window.allow(_client_ip() if user_ip else "*"):
+                return jsonify({"ok": False, "error": "Too many attempts. Try again later."}), 429
+            return view(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
 
 
 def _port_open(port: int) -> bool:
@@ -267,6 +314,7 @@ def create_app(bench_root: Path) -> Flask:
         )
 
     @app.route("/api/login", methods=["POST"])
+    @rate_limit(10, 60)
     def api_login():
         try:
             config = BenchConfig.from_file(bench_root / "bench.toml")

--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -4,7 +4,6 @@ import hmac
 import http.client
 import os
 import re
-import secrets
 import socket
 import subprocess
 import tomllib
@@ -13,7 +12,7 @@ import threading
 import time
 from pathlib import Path
 
-from flask import Flask, jsonify, request, send_file, session
+from flask import Flask, jsonify, request, send_file
 
 from .views.apps import apps_bp
 from .views.dashboard import dashboard_bp
@@ -187,8 +186,6 @@ def create_app(bench_root: Path) -> Flask:
     app = Flask(__name__, static_folder=str(_STATIC_DIR), static_url_path="/static")
     app.config["BENCH_ROOT"] = bench_root
     app.config["TEMPLATES_AUTO_RELOAD"] = False
-    app.secret_key = secrets.token_hex(32)
-    app.config["SESSION_COOKIE_NAME"] = f"bench_session_{bench_root.name}"
 
     _install_idle_watchdog(app)
 
@@ -201,8 +198,6 @@ def create_app(bench_root: Path) -> Flask:
         return None
 
     def _is_authenticated(config: BenchConfig) -> bool:
-        if session.get("authenticated"):
-            return True
         from bench_cli.commands.generate_session import verify_token
 
         return verify_token(request.cookies.get("sid", ""), config.admin.jwt_secret)
@@ -279,24 +274,23 @@ def create_app(bench_root: Path) -> Flask:
             return jsonify({"ok": False, "error": str(exc)}), 503
         if not config.admin.password:
             return jsonify({"ok": False, "error": "No admin password configured in bench.toml"}), 503
+        from bench_cli.commands.generate_session import ensure_jwt_secret, issue_token, verify_token
+
         data = request.get_json(silent=True) or {}
         sid = data.get("sid")
         if sid:
-            from bench_cli.commands.generate_session import verify_token
-
             if not verify_token(sid, config.admin.jwt_secret):
                 return jsonify({"ok": False, "error": "Invalid or expired session token"}), 401
-            resp = jsonify({"ok": True})
-            _set_sid_cookie(resp, sid, config)
-            return resp
-        if hmac.compare_digest(str(data.get("password", "")), config.admin.password):
-            session["authenticated"] = True
-            return jsonify({"ok": True})
-        return jsonify({"ok": False, "error": "Incorrect password"}), 401
+        elif hmac.compare_digest(str(data.get("password", "")), config.admin.password):
+            sid = issue_token(ensure_jwt_secret(bench_root / "bench.toml"))
+        else:
+            return jsonify({"ok": False, "error": "Incorrect password"}), 401
+        resp = jsonify({"ok": True})
+        _set_sid_cookie(resp, sid, config)
+        return resp
 
     @app.route("/api/logout", methods=["POST"])
     def api_logout():
-        session.clear()
         resp = jsonify({"ok": True})
         resp.delete_cookie("sid")
         return resp

--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -65,6 +65,24 @@ class _SlidingWindow:
             return True
 
 
+class _UsedTokens:
+    """Tracks consumed one-time sign-in token ids so each can be used only once.
+    In-memory (single gunicorn worker); entries self-expire at the token's exp."""
+
+    def __init__(self) -> None:
+        self._used: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def use(self, jti: str, exp: float) -> bool:
+        now = time.time()
+        with self._lock:
+            self._used = {j: e for j, e in self._used.items() if e > now}
+            if jti in self._used:
+                return False
+            self._used[jti] = exp
+            return True
+
+
 def _client_ip() -> str:
     # nginx overwrites X-Real-IP with the real client address (unspoofable);
     # in dev there is no proxy, so fall back to the direct peer.
@@ -235,6 +253,7 @@ def create_app(bench_root: Path) -> Flask:
     app.config["TEMPLATES_AUTO_RELOAD"] = False
 
     _install_idle_watchdog(app)
+    used_logins = _UsedTokens()
 
     def _load_config():
         return BenchConfig.from_file(bench_root / "bench.toml")
@@ -322,19 +341,19 @@ def create_app(bench_root: Path) -> Flask:
             return jsonify({"ok": False, "error": str(exc)}), 503
         if not config.admin.password:
             return jsonify({"ok": False, "error": "No admin password configured in bench.toml"}), 503
-        from bench_cli.commands.generate_session import ensure_jwt_secret, issue_token, verify_token
+        from bench_cli.commands.generate_session import decode_token, ensure_jwt_secret, issue_token
 
         data = request.get_json(silent=True) or {}
         sid = data.get("sid")
-        if sid:
-            if not verify_token(sid, config.admin.jwt_secret):
-                return jsonify({"ok": False, "error": "Invalid or expired session token"}), 401
-        elif hmac.compare_digest(str(data.get("password", "")), config.admin.password):
-            sid = issue_token(ensure_jwt_secret(bench_root / "bench.toml"))
-        else:
+        if sid is not None:
+            payload = decode_token(sid, config.admin.jwt_secret)
+            jti = payload.get("jti") if payload else None
+            if not jti or not used_logins.use(jti, payload["exp"]):
+                return jsonify({"ok": False, "error": "Invalid or expired sign-in link"}), 401
+        elif not hmac.compare_digest(str(data.get("password", "")), config.admin.password):
             return jsonify({"ok": False, "error": "Incorrect password"}), 401
         resp = jsonify({"ok": True})
-        _set_sid_cookie(resp, sid, config)
+        _set_sid_cookie(resp, issue_token(ensure_jwt_secret(bench_root / "bench.toml")), config)
         return resp
 
     @app.route("/api/logout", methods=["POST"])

--- a/admin/frontend/src/App.vue
+++ b/admin/frontend/src/App.vue
@@ -30,8 +30,20 @@ async function loadStatus() {
   }
 }
 
+function consumeSidParam() {
+  const params = new URLSearchParams(window.location.search)
+  const sid = params.get('sid')
+  if (!sid) return
+  const secure = window.location.protocol === 'https:' ? '; Secure' : ''
+  document.cookie = `sid=${encodeURIComponent(sid)}; path=/; max-age=604800; SameSite=Lax${secure}`
+  params.delete('sid')
+  const query = params.toString()
+  window.history.replaceState({}, document.title, window.location.pathname + (query ? `?${query}` : '') + window.location.hash)
+}
+
 onMounted(async () => {
   initializeTheme()
+  consumeSidParam()
   try {
     await loadStatus()
   } catch {

--- a/admin/frontend/src/App.vue
+++ b/admin/frontend/src/App.vue
@@ -30,12 +30,17 @@ async function loadStatus() {
   }
 }
 
-function consumeSidParam() {
+async function consumeSidParam() {
   const params = new URLSearchParams(window.location.search)
   const sid = params.get('sid')
   if (!sid) return
-  const secure = window.location.protocol === 'https:' ? '; Secure' : ''
-  document.cookie = `sid=${encodeURIComponent(sid)}; path=/; max-age=604800; SameSite=Lax${secure}`
+  try {
+    await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sid }),
+    })
+  } catch {}
   params.delete('sid')
   const query = params.toString()
   window.history.replaceState({}, document.title, window.location.pathname + (query ? `?${query}` : '') + window.location.hash)
@@ -43,7 +48,7 @@ function consumeSidParam() {
 
 onMounted(async () => {
   initializeTheme()
-  consumeSidParam()
+  await consumeSidParam()
   try {
     await loadStatus()
   } catch {

--- a/bench_cli/commands/generate_session.py
+++ b/bench_cli/commands/generate_session.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import time
+import tomllib
+import urllib.parse
+from typing import TYPE_CHECKING
+
+from bench_cli.commands.base import Command
+from bench_cli.exceptions import BenchError
+from bench_cli.utils import write_toml
+
+if TYPE_CHECKING:
+    from bench_cli.core.bench import Bench
+
+_HEADER = {"alg": "HS256", "typ": "JWT"}
+DEFAULT_TTL = 7 * 24 * 3600
+
+
+def _b64(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
+
+
+def _unb64(text: str) -> bytes:
+    return base64.urlsafe_b64decode(text + "=" * (-len(text) % 4))
+
+
+def _sign(signing_input: str, secret: str) -> bytes:
+    return hmac.new(secret.encode(), signing_input.encode(), hashlib.sha256).digest()
+
+
+def issue_token(secret: str, ttl: int = DEFAULT_TTL, issued_at: float | None = None) -> str:
+    if not secret:
+        raise ValueError("JWT secret is not configured.")
+    now = int(issued_at or time.time())
+    body = ".".join(
+        _b64(json.dumps(part, separators=(",", ":")).encode())
+        for part in (_HEADER, {"sub": "admin", "iat": now, "exp": now + ttl})
+    )
+    return f"{body}.{_b64(_sign(body, secret))}"
+
+
+def verify_token(token: str, secret: str) -> bool:
+    if not token or not secret:
+        return False
+    try:
+        header_b64, payload_b64, signature_b64 = token.split(".")
+        if not hmac.compare_digest(_unb64(signature_b64), _sign(f"{header_b64}.{payload_b64}", secret)):
+            return False
+        exp = json.loads(_unb64(payload_b64)).get("exp")
+    except (ValueError, json.JSONDecodeError):
+        return False
+    return isinstance(exp, int) and time.time() < exp
+
+
+class GenerateSessionCommand(Command):
+    name = "generate-session"
+    help = "Issue a 7-day admin session token (use --full-path for a sign-in URL)."
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--full-path", action="store_true",
+                            help="Print the full admin URL with ?sid= instead of the bare token.")
+
+    @classmethod
+    def from_args(cls, args, bench):
+        return cls(bench, full_path=args.full_path)
+
+    def __init__(self, bench: "Bench", full_path: bool = False) -> None:
+        self.bench = bench
+        self.full_path = full_path
+
+    def run(self) -> None:
+        from bench_cli.admin_url import admin_url
+
+        if not self.bench.config.admin.password:
+            raise BenchError("Admin has no password set; configure [admin].password in bench.toml first.")
+        token = issue_token(self._jwt_secret())
+        if self.full_path:
+            print(f"{admin_url(self.bench.config)}/?sid={urllib.parse.quote(token, safe='')}")
+        else:
+            print(token)
+
+    def _jwt_secret(self) -> str:
+        secret = self.bench.config.admin.jwt_secret
+        if secret:
+            return secret
+        secret = secrets.token_urlsafe(32)
+        toml_path = self.bench.path / "bench.toml"
+        data = tomllib.loads(toml_path.read_text())
+        data.setdefault("admin", {})["jwt_secret"] = secret
+        write_toml(toml_path, data)
+        self.bench.config.admin.jwt_secret = secret
+        return secret

--- a/bench_cli/commands/generate_session.py
+++ b/bench_cli/commands/generate_session.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from bench_cli.core.bench import Bench
 
 _HEADER = {"alg": "HS256", "typ": "JWT"}
-DEFAULT_TTL = 7 * 24 * 3600
+DEFAULT_TTL = 24 * 3600
 
 
 def _b64(raw: bytes) -> str:
@@ -60,7 +60,7 @@ def verify_token(token: str, secret: str) -> bool:
 
 class GenerateSessionCommand(Command):
     name = "generate-session"
-    help = "Issue a 7-day admin session token (use --full-path for a sign-in URL)."
+    help = "Issue a 1-day admin session token (use --full-path for a sign-in URL)."
 
     @classmethod
     def add_arguments(cls, parser: argparse.ArgumentParser) -> None:

--- a/bench_cli/commands/generate_session.py
+++ b/bench_cli/commands/generate_session.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 
 _HEADER = {"alg": "HS256", "typ": "JWT"}
 DEFAULT_TTL = 24 * 3600
+LOGIN_TTL = 5 * 60
 
 
 def _b64(raw: bytes) -> str:
@@ -34,28 +35,42 @@ def _sign(signing_input: str, secret: str) -> bytes:
     return hmac.new(secret.encode(), signing_input.encode(), hashlib.sha256).digest()
 
 
-def issue_token(secret: str, ttl: int = DEFAULT_TTL, issued_at: float | None = None) -> str:
+def issue_token(secret: str, ttl: int = DEFAULT_TTL, issued_at: float | None = None, jti: str | None = None) -> str:
     if not secret:
         raise ValueError("JWT secret is not configured.")
     now = int(issued_at or time.time())
+    payload = {"sub": "admin", "iat": now, "exp": now + ttl}
+    if jti:
+        payload["jti"] = jti
     body = ".".join(
-        _b64(json.dumps(part, separators=(",", ":")).encode())
-        for part in (_HEADER, {"sub": "admin", "iat": now, "exp": now + ttl})
+        _b64(json.dumps(part, separators=(",", ":")).encode()) for part in (_HEADER, payload)
     )
     return f"{body}.{_b64(_sign(body, secret))}"
 
 
-def verify_token(token: str, secret: str) -> bool:
+def decode_token(token: str, secret: str) -> dict | None:
+    """Return the token's claims if its signature is valid and it has not
+    expired, else None."""
     if not token or not secret:
-        return False
+        return None
     try:
         header_b64, payload_b64, signature_b64 = token.split(".")
         if not hmac.compare_digest(_unb64(signature_b64), _sign(f"{header_b64}.{payload_b64}", secret)):
-            return False
-        exp = json.loads(_unb64(payload_b64)).get("exp")
+            return None
+        payload = json.loads(_unb64(payload_b64))
     except (ValueError, json.JSONDecodeError):
-        return False
-    return isinstance(exp, int) and time.time() < exp
+        return None
+    exp = payload.get("exp")
+    return payload if isinstance(exp, int) and time.time() < exp else None
+
+
+def verify_token(token: str, secret: str) -> bool:
+    return decode_token(token, secret) is not None
+
+
+def issue_login_token(secret: str) -> str:
+    """A short-lived, single-use token for the ?sid= sign-in link."""
+    return issue_token(secret, ttl=LOGIN_TTL, jti=secrets.token_urlsafe(8))
 
 
 def ensure_jwt_secret(toml_path) -> str:
@@ -71,7 +86,7 @@ def ensure_jwt_secret(toml_path) -> str:
 
 class GenerateSessionCommand(Command):
     name = "generate-session"
-    help = "Issue a 1-day admin session token (use --full-path for a sign-in URL)."
+    help = "Issue a 5-minute one-time sign-in token (use --full-path for a sign-in URL)."
 
     @classmethod
     def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
@@ -91,7 +106,7 @@ class GenerateSessionCommand(Command):
 
         if not self.bench.config.admin.password:
             raise BenchError("Admin has no password set; configure [admin].password in bench.toml first.")
-        token = issue_token(self._jwt_secret())
+        token = issue_login_token(self._jwt_secret())
         if self.full_path:
             print(f"{admin_url(self.bench.config)}/?sid={urllib.parse.quote(token, safe='')}")
         else:

--- a/bench_cli/commands/generate_session.py
+++ b/bench_cli/commands/generate_session.py
@@ -58,6 +58,17 @@ def verify_token(token: str, secret: str) -> bool:
     return isinstance(exp, int) and time.time() < exp
 
 
+def ensure_jwt_secret(toml_path) -> str:
+    data = tomllib.loads(toml_path.read_text())
+    secret = data.get("admin", {}).get("jwt_secret")
+    if secret:
+        return secret
+    secret = secrets.token_urlsafe(32)
+    data.setdefault("admin", {})["jwt_secret"] = secret
+    write_toml(toml_path, data)
+    return secret
+
+
 class GenerateSessionCommand(Command):
     name = "generate-session"
     help = "Issue a 1-day admin session token (use --full-path for a sign-in URL)."
@@ -87,13 +98,6 @@ class GenerateSessionCommand(Command):
             print(token)
 
     def _jwt_secret(self) -> str:
-        secret = self.bench.config.admin.jwt_secret
-        if secret:
-            return secret
-        secret = secrets.token_urlsafe(32)
-        toml_path = self.bench.path / "bench.toml"
-        data = tomllib.loads(toml_path.read_text())
-        data.setdefault("admin", {})["jwt_secret"] = secret
-        write_toml(toml_path, data)
+        secret = ensure_jwt_secret(self.bench.path / "bench.toml")
         self.bench.config.admin.jwt_secret = secret
         return secret

--- a/bench_cli/commands/generate_session.py
+++ b/bench_cli/commands/generate_session.py
@@ -85,7 +85,7 @@ def ensure_jwt_secret(toml_path) -> str:
 
 
 class GenerateSessionCommand(Command):
-    name = "generate-session"
+    name = "generate-admin-session"
     help = "Issue a 5-minute one-time sign-in token (use --full-path for a sign-in URL)."
 
     @classmethod

--- a/bench_cli/config/admin_config.py
+++ b/bench_cli/config/admin_config.py
@@ -7,6 +7,7 @@ class AdminConfig:
     timeout: int = 180  # seconds
     enabled: bool = False
     password: str = ""
+    jwt_secret: str = ""
     domain: str = ""
     # Bench-wide TLS termination, opt-in. False (default): nginx serves sites and
     # the admin over plain HTTP on the http port and obtains no certs — the bench

--- a/bench_cli/config/bench_config.py
+++ b/bench_cli/config/bench_config.py
@@ -177,6 +177,7 @@ class BenchConfig:
             timeout=data.get("timeout", 180),
             enabled=data.get("enabled", False),
             password=data.get("password", ""),
+            jwt_secret=data.get("jwt_secret", ""),
             domain=data.get("domain", ""),
             tls=data.get("tls", False),
         )

--- a/bench_cli/config/toml_writer.py
+++ b/bench_cli/config/toml_writer.py
@@ -87,6 +87,8 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append(f"timeout = {a.timeout}")
     parts.append(f"enabled = {'true' if a.enabled else 'false'}")
     parts.append(f'password = "{a.password}"')
+    if a.jwt_secret:
+        parts.append(f'jwt_secret = "{a.jwt_secret}"')
     parts.append(f'domain = "{a.domain}"')
     parts.append(f"tls = {'true' if a.tls else 'false'}")
     parts.append("")

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -518,6 +518,7 @@ Views catch `ConfigError`, `FileNotFoundError`, and database connection errors a
 - Bind to `127.0.0.1` by default.
 - **Password is mandatory.** The admin refuses all requests with HTTP 503 if `[admin] password` is not set in `bench.toml`. There is no way to bypass authentication.
 - Sessions are Flask cookie-based. The session key is a random 32-byte hex string generated at startup — sessions are invalidated on process restart.
+- `bench generate-session` issues a 7-day signed token (the `sid` cookie) as an alternative to password login, signed with `admin.jwt_secret` in `bench.toml`. See [docs/commands.md](commands.md#bench-generate-session).
 - `LogReader.read_tail` and `stream_tail` validate that the requested filename contains no path separators and resolves to a file inside `logs/`. Any traversal attempt returns HTTP 400.
 - Command execution uses `TaskRunner._build_argv`, which only accepts whitelisted commands. No user-supplied string is passed to a shell.
 - `task_id` values are validated against `^\d{8}-\d{6}-[0-9a-f]{6}$` before being used as directory names.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -518,7 +518,7 @@ Views catch `ConfigError`, `FileNotFoundError`, and database connection errors a
 - Bind to `127.0.0.1` by default.
 - **Password is mandatory.** The admin refuses all requests with HTTP 503 if `[admin] password` is not set in `bench.toml`. There is no way to bypass authentication.
 - Sessions are Flask cookie-based. The session key is a random 32-byte hex string generated at startup — sessions are invalidated on process restart.
-- `bench generate-session` issues a 7-day signed token (the `sid` cookie) as an alternative to password login, signed with `admin.jwt_secret` in `bench.toml`. See [docs/commands.md](commands.md#bench-generate-session).
+- `bench generate-session` issues a 1-day signed token (the `sid` cookie) as an alternative to password login, signed with `admin.jwt_secret` in `bench.toml`. See [docs/commands.md](commands.md#bench-generate-session).
 - `LogReader.read_tail` and `stream_tail` validate that the requested filename contains no path separators and resolves to a file inside `logs/`. Any traversal attempt returns HTTP 400.
 - Command execution uses `TaskRunner._build_argv`, which only accepts whitelisted commands. No user-supplied string is passed to a shell.
 - `task_id` values are validated against `^\d{8}-\d{6}-[0-9a-f]{6}$` before being used as directory names.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -518,7 +518,7 @@ Views catch `ConfigError`, `FileNotFoundError`, and database connection errors a
 - Bind to `127.0.0.1` by default.
 - **Password is mandatory.** The admin refuses all requests with HTTP 503 if `[admin] password` is not set in `bench.toml`. There is no way to bypass authentication.
 - Sessions are Flask cookie-based. The session key is a random 32-byte hex string generated at startup — sessions are invalidated on process restart.
-- `bench generate-session` issues a 1-day signed token (the `sid` cookie) as an alternative to password login, signed with `admin.jwt_secret` in `bench.toml`. See [docs/commands.md](commands.md#bench-generate-session).
+- `bench generate-session` issues a 5-minute, single-use `?sid=` token that the frontend exchanges for a 1-day `HttpOnly` session cookie — an alternative to password login, signed with `admin.jwt_secret` in `bench.toml`. See [docs/commands.md](commands.md#bench-generate-session).
 - `LogReader.read_tail` and `stream_tail` validate that the requested filename contains no path separators and resolves to a file inside `logs/`. Any traversal attempt returns HTTP 400.
 - Command execution uses `TaskRunner._build_argv`, which only accepts whitelisted commands. No user-supplied string is passed to a shell.
 - `task_id` values are validated against `^\d{8}-\d{6}-[0-9a-f]{6}$` before being used as directory names.

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -518,7 +518,7 @@ Views catch `ConfigError`, `FileNotFoundError`, and database connection errors a
 - Bind to `127.0.0.1` by default.
 - **Password is mandatory.** The admin refuses all requests with HTTP 503 if `[admin] password` is not set in `bench.toml`. There is no way to bypass authentication.
 - Sessions are Flask cookie-based. The session key is a random 32-byte hex string generated at startup — sessions are invalidated on process restart.
-- `bench generate-session` issues a 5-minute, single-use `?sid=` token that the frontend exchanges for a 1-day `HttpOnly` session cookie — an alternative to password login, signed with `admin.jwt_secret` in `bench.toml`. See [docs/commands.md](commands.md#bench-generate-session).
+- `bench generate-admin-session` issues a 5-minute, single-use `?sid=` token that the frontend exchanges for a 1-day `HttpOnly` session cookie — an alternative to password login, signed with `admin.jwt_secret` in `bench.toml`. See [docs/commands.md](commands.md#bench-generate-admin-session).
 - `LogReader.read_tail` and `stream_tail` validate that the requested filename contains no path separators and resolves to a file inside `logs/`. Any traversal attempt returns HTTP 400.
 - Command execution uses `TaskRunner._build_argv`, which only accepts whitelisted commands. No user-supplied string is passed to a shell.
 - `task_id` values are validated against `^\d{8}-\d{6}-[0-9a-f]{6}$` before being used as directory names.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -491,7 +491,7 @@ See [docs/admin.md](admin.md) for the full interface specification.
 
 ## `bench generate-session`
 
-Issues a 7-day signed token that signs you into the admin UI without typing the password — handy for opening the panel from a server shell.
+Issues a 1-day signed token that signs you into the admin UI without typing the password — handy for opening the panel from a server shell.
 
 ```bash
 bench generate-session              # prints the token

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -489,6 +489,19 @@ See [docs/admin.md](admin.md) for the full interface specification.
 
 ---
 
+## `bench generate-session`
+
+Issues a 7-day signed token that signs you into the admin UI without typing the password — handy for opening the panel from a server shell.
+
+```bash
+bench generate-session              # prints the token
+bench generate-session --full-path  # prints the full admin URL with ?sid=<token>
+```
+
+Open the `--full-path` URL in a browser: the frontend stores the token in the `sid` cookie and sends it with every request. The token is an HS256 JWT signed with `admin.jwt_secret` in `bench.toml` (generated on first run). Requires `admin.password` to be set. Treat the URL as a credential — anyone with it has admin access until the token expires.
+
+---
+
 ## `bench setup nginx`
 
 See [docs/production.md](production.md) for the full step-by-step.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -489,13 +489,13 @@ See [docs/admin.md](admin.md) for the full interface specification.
 
 ---
 
-## `bench generate-session`
+## `bench generate-admin-session`
 
 Issues a short-lived, single-use sign-in token so you can open the admin UI without typing the password — handy from a server shell.
 
 ```bash
-bench generate-session              # prints the token
-bench generate-session --full-path  # prints the full admin URL with ?sid=<token>
+bench generate-admin-session              # prints the token
+bench generate-admin-session --full-path  # prints the full admin URL with ?sid=<token>
 ```
 
 Open the `--full-path` URL in a browser within **5 minutes**: the frontend exchanges the `?sid=` token for a 1-day `HttpOnly` session cookie, and the sign-in token is consumed (single-use). Both are HS256 JWTs signed with `admin.jwt_secret` in `bench.toml` (generated on first run). Requires `admin.password` to be set.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -491,14 +491,14 @@ See [docs/admin.md](admin.md) for the full interface specification.
 
 ## `bench generate-session`
 
-Issues a 1-day signed token that signs you into the admin UI without typing the password — handy for opening the panel from a server shell.
+Issues a short-lived, single-use sign-in token so you can open the admin UI without typing the password — handy from a server shell.
 
 ```bash
 bench generate-session              # prints the token
 bench generate-session --full-path  # prints the full admin URL with ?sid=<token>
 ```
 
-Open the `--full-path` URL in a browser: the frontend stores the token in the `sid` cookie and sends it with every request. The token is an HS256 JWT signed with `admin.jwt_secret` in `bench.toml` (generated on first run). Requires `admin.password` to be set. Treat the URL as a credential — anyone with it has admin access until the token expires.
+Open the `--full-path` URL in a browser within **5 minutes**: the frontend exchanges the `?sid=` token for a 1-day `HttpOnly` session cookie, and the sign-in token is consumed (single-use). Both are HS256 JWTs signed with `admin.jwt_secret` in `bench.toml` (generated on first run). Requires `admin.password` to be set.
 
 ---
 

--- a/tests/test_admin_app.py
+++ b/tests/test_admin_app.py
@@ -24,13 +24,14 @@ def _write_raw_bench_toml(bench_dir: Path, name: str, admin_port: int) -> None:
 
 def _client(bench_root: Path, password: str = "secret"):
     from admin.backend.app import create_app
+    from bench_cli.commands.generate_session import ensure_jwt_secret, issue_token
 
     _write_bench_toml(bench_root, bench_root.name, admin_enabled=True, admin_password=password)
+    secret = ensure_jwt_secret(bench_root / "bench.toml")
     app = create_app(bench_root)
     app.config["TESTING"] = True
     client = app.test_client()
-    with client.session_transaction() as sess:
-        sess["authenticated"] = True
+    client.set_cookie("sid", issue_token(secret))
     return client
 
 
@@ -175,11 +176,12 @@ def test_api_benches_new_routes_wizard_at_domain_when_production(tmp_path: Path)
         toml.replace("enabled = false\nuse_companion_manager",
                      'enabled = true\nprocess_manager = "systemd"\nuse_companion_manager')
     )
+    from bench_cli.commands.generate_session import ensure_jwt_secret, issue_token
+    secret = ensure_jwt_secret(current / "bench.toml")
     app = create_app(current)
     app.config["TESTING"] = True
     client = app.test_client()
-    with client.session_transaction() as sess:
-        sess["authenticated"] = True
+    client.set_cookie("sid", issue_token(secret))
 
     with patch("bench_cli.managers.systemd_process_manager.SystemdProcessManager.setup_admin") as mock_admin, \
          patch("bench_cli.managers.nginx_manager.NginxManager.generate_config") as mock_gen, \

--- a/tests/test_admin_session.py
+++ b/tests/test_admin_session.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import time
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from bench_cli.commands.generate_session import issue_token, verify_token
+from bench_cli.config.bench_config import BenchConfig
+from bench_cli.config.bench_toml_builder import BenchTomlBuilder
+from bench_cli.core.bench import Bench
+from bench_cli.exceptions import BenchError
+
+
+# ── JWT module ────────────────────────────────────────────────────────────────
+
+
+def test_round_trip_is_valid() -> None:
+    assert verify_token(issue_token("k3y"), "k3y")
+
+
+def test_wrong_secret_rejected() -> None:
+    assert not verify_token(issue_token("k3y"), "other")
+
+
+def test_tampered_token_rejected() -> None:
+    assert not verify_token(issue_token("k3y") + "x", "k3y")
+
+
+def test_expired_token_rejected() -> None:
+    assert not verify_token(issue_token("k3y", ttl=10, issued_at=time.time() - 100), "k3y")
+
+
+def test_empty_inputs_rejected() -> None:
+    assert not verify_token("", "k3y")
+    assert not verify_token(issue_token("k3y"), "")
+
+
+def test_issue_requires_secret() -> None:
+    with pytest.raises(ValueError):
+        issue_token("")
+
+
+# ── CLI command ───────────────────────────────────────────────────────────────
+
+
+def _bench(tmp_path: Path, password: str = "secret") -> Bench:
+    toml_path = tmp_path / "bench.toml"
+    toml_path.write_text(BenchTomlBuilder(tmp_path.name, {"admin_password": password}).render())
+    return _load_bench(tmp_path)
+
+
+def _load_bench(tmp_path: Path) -> Bench:
+    return Bench(BenchConfig.from_file(tmp_path / "bench.toml"), tmp_path)
+
+
+def test_command_issues_verifiable_token_and_persists_secret(tmp_path, capsys) -> None:
+    from bench_cli.commands.generate_session import GenerateSessionCommand
+
+    GenerateSessionCommand(_bench(tmp_path)).run()
+    token = capsys.readouterr().out.strip()
+    secret = tomllib.loads((tmp_path / "bench.toml").read_text())["admin"]["jwt_secret"]
+    assert secret and verify_token(token, secret)
+
+
+def test_command_reuses_existing_secret(tmp_path) -> None:
+    from bench_cli.commands.generate_session import GenerateSessionCommand
+
+    GenerateSessionCommand(_bench(tmp_path)).run()
+    first = tomllib.loads((tmp_path / "bench.toml").read_text())["admin"]["jwt_secret"]
+    GenerateSessionCommand(_load_bench(tmp_path)).run()
+    assert tomllib.loads((tmp_path / "bench.toml").read_text())["admin"]["jwt_secret"] == first
+
+
+def test_command_full_path_builds_url(tmp_path, capsys) -> None:
+    from bench_cli.commands.generate_session import GenerateSessionCommand
+
+    GenerateSessionCommand(_bench(tmp_path), full_path=True).run()
+    assert capsys.readouterr().out.strip().startswith("http://")
+
+
+def test_command_requires_password(tmp_path) -> None:
+    from bench_cli.commands.generate_session import GenerateSessionCommand
+
+    with pytest.raises(BenchError):
+        GenerateSessionCommand(_bench(tmp_path, password="")).run()
+
+
+# ── backend cookie auth ───────────────────────────────────────────────────────
+
+
+def _initialized_bench(bench_dir: Path, password: str, jwt_secret: str) -> None:
+    from bench_cli.config.toml_writer import bench_config_to_toml
+
+    bench_dir.mkdir(parents=True, exist_ok=True)
+    toml_path = bench_dir / "bench.toml"
+    toml_path.write_text(BenchTomlBuilder(bench_dir.name, {"admin_enabled": True, "admin_password": password}).render())
+    config = BenchConfig.from_file(toml_path)
+    config.admin.jwt_secret = jwt_secret
+    toml_path.write_text(bench_config_to_toml(config))
+    python = bench_dir / "env" / "bin" / "python"
+    python.parent.mkdir(parents=True, exist_ok=True)
+    python.touch()
+
+
+def _client(tmp_path: Path, jwt_secret: str = "k3y"):
+    from admin.backend.app import create_app
+
+    bench_root = tmp_path / "benches" / "current"
+    _initialized_bench(bench_root, "secret", jwt_secret)
+    app = create_app(bench_root)
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def test_valid_jwt_cookie_authenticates(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    client.set_cookie("sid", issue_token("k3y"))
+    assert client.get("/api/status").get_json()["authenticated"] is True
+    assert client.get("/api/benches/").status_code != 401
+
+
+def test_invalid_jwt_cookie_stays_unauthenticated(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    client.set_cookie("sid", issue_token("wrong-secret"))
+    assert client.get("/api/status").get_json()["authenticated"] is False
+    assert client.get("/api/benches/").status_code == 401
+
+
+def test_setup_endpoint_requires_auth_once_password_set(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    assert client.post("/api/setup/validate-mariadb", json={}).status_code == 401
+    client.set_cookie("sid", issue_token("k3y"))
+    assert client.post("/api/setup/validate-mariadb", json={}).status_code != 401
+
+
+def test_setup_endpoint_open_before_password_set(tmp_path: Path) -> None:
+    from admin.backend.app import create_app
+
+    app = create_app(tmp_path)  # no bench.toml → first-time setup
+    app.config["TESTING"] = True
+    assert app.test_client().post("/api/setup/validate-mariadb", json={}).status_code != 401

--- a/tests/test_admin_session.py
+++ b/tests/test_admin_session.py
@@ -157,7 +157,7 @@ def test_sid_is_single_use(tmp_path: Path) -> None:
 
 def test_login_rate_limited_after_limit(tmp_path: Path) -> None:
     client = _client(tmp_path)
-    for _ in range(10):
+    for _ in range(5):
         assert client.post("/api/login", json={"password": "wrong"}).status_code == 401
     assert client.post("/api/login", json={"password": "wrong"}).status_code == 429
 

--- a/tests/test_admin_session.py
+++ b/tests/test_admin_session.py
@@ -128,6 +128,22 @@ def test_invalid_jwt_cookie_stays_unauthenticated(tmp_path: Path) -> None:
     assert client.get("/api/benches/").status_code == 401
 
 
+def test_login_with_sid_sets_httponly_cookie(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    resp = client.post("/api/login", json={"sid": issue_token("k3y")})
+    assert resp.status_code == 200
+    cookie = next(h for k, h in resp.headers if k == "Set-Cookie" and h.startswith("sid="))
+    assert "HttpOnly" in cookie
+    assert client.get("/api/benches/").status_code != 401
+
+
+def test_login_with_invalid_sid_rejected(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    resp = client.post("/api/login", json={"sid": issue_token("wrong-secret")})
+    assert resp.status_code == 401
+    assert client.get("/api/benches/").status_code == 401
+
+
 def test_setup_endpoint_requires_auth_once_password_set(tmp_path: Path) -> None:
     client = _client(tmp_path)
     assert client.post("/api/setup/validate-mariadb", json={}).status_code == 401

--- a/tests/test_admin_session.py
+++ b/tests/test_admin_session.py
@@ -144,6 +144,13 @@ def test_login_with_invalid_sid_rejected(tmp_path: Path) -> None:
     assert client.get("/api/benches/").status_code == 401
 
 
+def test_login_rate_limited_after_limit(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    for _ in range(10):
+        assert client.post("/api/login", json={"password": "wrong"}).status_code == 401
+    assert client.post("/api/login", json={"password": "wrong"}).status_code == 429
+
+
 def test_setup_endpoint_requires_auth_once_password_set(tmp_path: Path) -> None:
     client = _client(tmp_path)
     assert client.post("/api/setup/validate-mariadb", json={}).status_code == 401

--- a/tests/test_admin_session.py
+++ b/tests/test_admin_session.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from bench_cli.commands.generate_session import issue_token, verify_token
+from bench_cli.commands.generate_session import decode_token, issue_login_token, issue_token, verify_token
 from bench_cli.config.bench_config import BenchConfig
 from bench_cli.config.bench_toml_builder import BenchTomlBuilder
 from bench_cli.core.bench import Bench
@@ -40,6 +40,10 @@ def test_empty_inputs_rejected() -> None:
 def test_issue_requires_secret() -> None:
     with pytest.raises(ValueError):
         issue_token("")
+
+
+def test_login_token_carries_jti() -> None:
+    assert decode_token(issue_login_token("k3y"), "k3y").get("jti")
 
 
 # ── CLI command ───────────────────────────────────────────────────────────────
@@ -130,7 +134,7 @@ def test_invalid_jwt_cookie_stays_unauthenticated(tmp_path: Path) -> None:
 
 def test_login_with_sid_sets_httponly_cookie(tmp_path: Path) -> None:
     client = _client(tmp_path)
-    resp = client.post("/api/login", json={"sid": issue_token("k3y")})
+    resp = client.post("/api/login", json={"sid": issue_login_token("k3y")})
     assert resp.status_code == 200
     cookie = next(h for k, h in resp.headers if k == "Set-Cookie" and h.startswith("sid="))
     assert "HttpOnly" in cookie
@@ -139,9 +143,16 @@ def test_login_with_sid_sets_httponly_cookie(tmp_path: Path) -> None:
 
 def test_login_with_invalid_sid_rejected(tmp_path: Path) -> None:
     client = _client(tmp_path)
-    resp = client.post("/api/login", json={"sid": issue_token("wrong-secret")})
+    resp = client.post("/api/login", json={"sid": issue_login_token("wrong-secret")})
     assert resp.status_code == 401
     assert client.get("/api/benches/").status_code == 401
+
+
+def test_sid_is_single_use(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    sid = issue_login_token("k3y")
+    assert client.post("/api/login", json={"sid": sid}).status_code == 200
+    assert client.post("/api/login", json={"sid": sid}).status_code == 401
 
 
 def test_login_rate_limited_after_limit(tmp_path: Path) -> None:


### PR DESCRIPTION
- Added `bench -b bench1 generate-admin-session --full-path` for passwordless login by atlas.
- Use jwt as sid token to validate session else it resets on every restart (bench admin goes to sleep if not request coming usually). Also prerequisites for above one.
- Mark the `sid` cookie as httponly, so that js cant access it.
- Add rate limiter to `/login` method.