### PR TITLE
refactor(config): single source of truth for bench.toml I/O

### DIFF
--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -119,12 +119,11 @@ def _workload_running(bench_dir: Path, toml_path: Path) -> bool | None:
     """Whether a production bench's workload is currently running — used to
     gate start/stop/restart controls for other benches in the switcher. None
     if the check itself fails (e.g. process manager CLI not installed)."""
-    from pilot.config.bench_config import BenchConfig
     from pilot.core.bench import Bench
     from pilot.managers.process_manager import ProcessManagerFactory
 
     try:
-        bench = Bench(BenchConfig.from_file(toml_path), bench_dir)
+        bench = Bench(BenchTomlStore(toml_path).read(), bench_dir)
         return ProcessManagerFactory.create(bench).is_running()
     except Exception:
         return None
@@ -135,12 +134,11 @@ def _admin_running(bench_dir: Path, toml_path: Path) -> bool | None:
     so a listening socket counts even while the workload is stopped. Lets the UI
     show 'Admin active' instead of 'Stopped' for a provisioned-but-not-started
     bench. None if the check fails."""
-    from pilot.config.bench_config import BenchConfig
     from pilot.core.bench import Bench
     from pilot.managers.process_manager import ProcessManagerFactory
 
     try:
-        bench = Bench(BenchConfig.from_file(toml_path), bench_dir)
+        bench = Bench(BenchTomlStore(toml_path).read(), bench_dir)
         return ProcessManagerFactory.create(bench).admin_is_running()
     except Exception:
         return None
@@ -149,12 +147,11 @@ def _admin_running(bench_dir: Path, toml_path: Path) -> bool | None:
 def _admin_cert_exists(bench_dir: Path, toml_path: Path) -> bool:
     """Whether the admin domain's TLS cert is in place — gates whether nginx
     serves the admin over https yet. False on any failure (treat as plain http)."""
-    from pilot.config.bench_config import BenchConfig
     from pilot.core.bench import Bench
     from pilot.managers.nginx_manager import NginxManager
 
     try:
-        bench = Bench(BenchConfig.from_file(toml_path), bench_dir)
+        bench = Bench(BenchTomlStore(toml_path).read(), bench_dir)
         return NginxManager(bench).admin_cert_exists()
     except Exception:
         return False
@@ -253,7 +250,7 @@ def create_app(bench_root: Path) -> Flask:
     used_logins = _UsedTokens()
 
     def _load_config():
-        return BenchConfig.from_file(bench_root / "bench.toml")
+        return BenchTomlStore.for_bench(bench_root).read()
 
     def _check_enabled(config: BenchConfig):
         if not config.admin.enabled:
@@ -301,7 +298,7 @@ def create_app(bench_root: Path) -> Flask:
     def api_status():
         initialized = (bench_root / "env" / "bin" / "python").exists()
         try:
-            config = BenchConfig.from_file(bench_root / "bench.toml")
+            config = BenchTomlStore.for_bench(bench_root).read()
         except Exception as exc:
             return jsonify({"enabled": False, "error": str(exc)}), 503
         if not initialized or not config.admin.password:
@@ -334,7 +331,7 @@ def create_app(bench_root: Path) -> Flask:
     @rate_limit(5, 60, user_ip=True)
     def api_login():
         try:
-            config = BenchConfig.from_file(bench_root / "bench.toml")
+            config = BenchTomlStore.for_bench(bench_root).read()
         except Exception as exc:
             return jsonify({"ok": False, "error": str(exc)}), 503
         if not config.admin.password:
@@ -560,7 +557,7 @@ def create_app(bench_root: Path) -> Flask:
                 from pilot.core.bench import Bench
                 from pilot.managers.nginx_manager import NginxManager
 
-                bench = Bench(BenchConfig.from_file(new_dir / "bench.toml"), new_dir)
+                bench = Bench(BenchTomlStore.for_bench(new_dir).read(), new_dir)
                 # Register the admin domain with the domain provider (if any) before
                 # routing it, so it resolves to this server — the wizard is reached
                 # at this domain. The wizard's later `setup production` sees the

--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -7,7 +7,6 @@ import os
 import re
 import socket
 import subprocess
-import tomllib
 import signal
 import threading
 import time
@@ -31,6 +30,7 @@ from .views.volume import volume_bp
 from pilot.commands.admin import _cli_root
 from pilot.commands.new import NewCommand
 from pilot.config.bench_config import BenchConfig
+from pilot.config.toml_store import BenchTomlStore
 from pilot.exceptions import BenchError, ConfigError
 
 _STATIC_DIR = Path(__file__).parent / "static"
@@ -171,20 +171,17 @@ def _site_count(bench_dir: Path) -> int:
 
 def _persist_toml(bench_dir: Path, updates: dict) -> None:
     """Merge ``updates`` into a bench's bench.toml in place, preserving other keys."""
-    from pilot.utils import write_toml
-
-    toml_path = bench_dir / "bench.toml"
-    data = tomllib.loads(toml_path.read_text())
+    store = BenchTomlStore.for_bench(bench_dir)
+    data = store.read_raw()
     for section, values in updates.items():
         data.setdefault(section, {}).update(values)
-    write_toml(toml_path, data)
+    store.write_raw(data)
 
 
 def _wizard_status(bench_root: Path) -> dict:
     name = bench_root.name
     try:
-        with open(bench_root / "bench.toml", "rb") as f:
-            name = tomllib.load(f).get("bench", {}).get("name", name)
+        name = BenchTomlStore.for_bench(bench_root).read_raw().get("bench", {}).get("name", name)
     except Exception:
         pass
     return {"wizard": True, "name": name, "enabled": True, "authenticated": True}
@@ -374,8 +371,7 @@ def create_app(bench_root: Path) -> Flask:
             if not toml_path.exists():
                 continue
             try:
-                with open(toml_path, "rb") as f:
-                    config = tomllib.load(f)
+                config = BenchTomlStore(toml_path).read_raw()
                 admin = config.get("admin", {})
                 prod = config.get("production", {})
                 port = admin.get("port")
@@ -430,8 +426,7 @@ def create_app(bench_root: Path) -> Flask:
             return jsonify({"ok": False, "error": f"Bench '{name}' not found."}), 404
 
         try:
-            with open(toml_path, "rb") as f:
-                target_config = tomllib.load(f)
+            target_config = BenchTomlStore(toml_path).read_raw()
         except Exception as exc:
             return jsonify({"ok": False, "error": str(exc)}), 500
         if not target_config.get("production", {}).get("enabled"):
@@ -548,8 +543,7 @@ def create_app(bench_root: Path) -> Flask:
         except BenchError as exc:
             return jsonify({"error": str(exc)}), 400
 
-        with open(new_dir / "bench.toml", "rb") as f:
-            new_toml = tomllib.load(f)
+        new_toml = BenchTomlStore.for_bench(new_dir).read_raw()
         new_port = new_toml["admin"]["port"]
 
         cli_root = _cli_root()
@@ -628,8 +622,7 @@ def create_app(bench_root: Path) -> Flask:
     def _nginx_http_port() -> int:
         # Shared host: one nginx serves every bench on the same http_port.
         try:
-            with open(bench_root / "bench.toml", "rb") as f:
-                return int(tomllib.load(f).get("nginx", {}).get("http_port", 80))
+            return int(BenchTomlStore.for_bench(bench_root).read_raw().get("nginx", {}).get("http_port", 80))
         except Exception:
             return 80
 
@@ -654,8 +647,7 @@ def create_app(bench_root: Path) -> Flask:
         # Read the flag straight from toml (no full validation) so a slightly
         # incomplete current config can't block creating a new bench.
         try:
-            with open(bench_root / "bench.toml", "rb") as f:
-                prod = tomllib.load(f).get("production", {})
+            prod = BenchTomlStore.for_bench(bench_root).read_raw().get("production", {})
             pm = str(prod.get("process_manager", "")).lower()
             return bool(prod.get("enabled", pm not in ("", "none")))
         except Exception:

--- a/admin/backend/readers/bench_reader.py
+++ b/admin/backend/readers/bench_reader.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from pilot.config.bench_config import BenchConfig
+from pilot.config.toml_store import BenchTomlStore
 
 
 @dataclass
@@ -19,7 +20,7 @@ class BenchReader:
         self._bench_root = bench_root
 
     def config(self) -> BenchConfig:
-        return BenchConfig.from_file(self._bench_root / "bench.toml")
+        return BenchTomlStore.for_bench(self._bench_root).read()
 
     def summary(self) -> BenchSummary:
         config = self.config()

--- a/admin/backend/readers/process_reader.py
+++ b/admin/backend/readers/process_reader.py
@@ -138,11 +138,11 @@ class ProcessReader:
         self._bench_root = bench_root
 
     def read_all(self) -> list[ProcessInfo]:
-        from pilot.config.bench_config import BenchConfig
+        from pilot.config.toml_store import BenchTomlStore
         from pilot.core.bench import Bench
 
         # If the bench config file is not present there is no point in look at procs
-        config = BenchConfig.from_file(self._bench_root / "bench.toml")
+        config = BenchTomlStore.for_bench(self._bench_root).read()
         bench = Bench(config, self._bench_root)
 
         # Alpine: only OpenRC is present, so probe it directly (the systemd /

--- a/admin/backend/readers/snapshot_reader.py
+++ b/admin/backend/readers/snapshot_reader.py
@@ -25,11 +25,11 @@ class SnapshotReader:
         self._bench_root = bench_root
 
     def read(self) -> SnapshotStatus:
-        from pilot.config.bench_config import BenchConfig
+        from pilot.config.toml_store import BenchTomlStore
         from pilot.managers.volume_manager import VolumeManager
         from pilot.platform import is_linux
 
-        bench_config = BenchConfig.from_file(self._bench_root / "bench.toml")
+        bench_config = BenchTomlStore.for_bench(self._bench_root).read()
         volume_config = bench_config.volume
 
         if not is_linux():

--- a/admin/backend/readers/volume_reader.py
+++ b/admin/backend/readers/volume_reader.py
@@ -27,10 +27,10 @@ class VolumeReader:
         self._bench_root = bench_root
 
     def read(self) -> VolumeInfo:
-        from pilot.config.bench_config import BenchConfig
+        from pilot.config.toml_store import BenchTomlStore
         from pilot.platform import is_linux
 
-        config = BenchConfig.from_file(self._bench_root / "bench.toml").volume
+        config = BenchTomlStore.for_bench(self._bench_root).read().volume
         # A bench can opt out of ZFS (shared-DB benches set volume.enabled =
         # false). Since pools are shared across benches, never infer "enabled"
         # from the pool merely existing — honour the bench's own config first.

--- a/admin/backend/server.py
+++ b/admin/backend/server.py
@@ -22,7 +22,7 @@ def main() -> None:
     args = parser.parse_args()
 
     from admin.backend.app import create_app
-    from pilot.config.bench_config import BenchConfig
+    from pilot.config.toml_store import BenchTomlStore
 
     bench_root = Path(args.bench_root)
     app = create_app(bench_root)
@@ -31,7 +31,7 @@ def main() -> None:
     skip_watchdog = args.no_timeout or args.dev
     if not skip_watchdog:
         try:
-            cfg = BenchConfig.from_file(bench_root / "bench.toml")
+            cfg = BenchTomlStore.for_bench(bench_root).read()
             skip_watchdog = cfg.admin.enabled
         except Exception:
             pass

--- a/admin/backend/tasks/jobs/base_task.py
+++ b/admin/backend/tasks/jobs/base_task.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from pilot.config.bench_config import BenchConfig
+from pilot.config.toml_store import BenchTomlStore
 from pilot.core.bench import Bench
 
 
@@ -22,7 +22,7 @@ class BaseTask:
     def main(cls) -> None:
         args = cls._parser().parse_args()
         bench_root = Path(args.bench_root)
-        bench = Bench(BenchConfig.from_file(bench_root / "bench.toml"), bench_root)
+        bench = Bench(BenchTomlStore.for_bench(bench_root).read(), bench_root)
         cls(bench, bench_root, args).run()
 
     def run(self) -> None:

--- a/admin/backend/tasks/jobs/switch_branch_task.py
+++ b/admin/backend/tasks/jobs/switch_branch_task.py
@@ -1,9 +1,8 @@
 import subprocess
 import sys
-import tomllib
 
+from pilot.config.toml_store import BenchTomlStore
 from pilot.managers.python_env_manager import PythonEnvManager
-from pilot.utils import write_toml
 from .base_task import BaseTask
 
 
@@ -55,14 +54,13 @@ class SwitchBranchTask(BaseTask):
         sys.stdout.flush()
         subprocess.run([uv, "pip", "install", "--python", python_bin, "-e", str(app_path)], check=False)
 
-        bench_toml = self.bench_root / "bench.toml"
-        with bench_toml.open("rb") as fh:
-            raw = tomllib.load(fh)
+        store = BenchTomlStore.for_bench(self.bench_root)
+        raw = store.read_raw()
         for app_entry in raw.get("apps", []):
             if app_entry.get("name") == self.name:
                 app_entry["branch"] = self.branch
                 break
-        write_toml(bench_toml, raw)
+        store.write_raw(raw)
         print(f"Updated bench.toml: {self.name} -> {self.branch}")
         sys.stdout.flush()
 

--- a/admin/backend/views/processes.py
+++ b/admin/backend/views/processes.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import subprocess
-import tomllib
 from pathlib import Path
 
 from flask import Blueprint, current_app, jsonify
+
+from pilot.config.toml_store import BenchTomlStore
 
 from ..readers.process_reader import ProcessReader
 
@@ -13,8 +14,7 @@ processes_bp = Blueprint("processes", __name__)
 
 def _bench_name(bench_root: Path) -> str:
     try:
-        with open(bench_root / "bench.toml", "rb") as f:
-            return tomllib.load(f).get("bench", {}).get("name", "bench")
+        return BenchTomlStore.for_bench(bench_root).read_raw().get("bench", {}).get("name", "bench")
     except Exception:
         return "bench"
 

--- a/admin/backend/views/settings.py
+++ b/admin/backend/views/settings.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify, request
 
 from pilot.config.bench_config import BenchConfig
-from pilot.config.toml_writer import bench_config_to_toml
+from pilot.config.toml_store import BenchTomlStore
 from pilot.config.worker_config import WorkerGroup
 from pilot.managers.redis_manager import RedisManager
 from pilot.managers.volume_manager import VolumeManager
@@ -297,7 +297,7 @@ def _build_settings_response(config: BenchConfig) -> dict:
 def get_settings():
     bench_root = Path(current_app.config["BENCH_ROOT"])
     try:
-        config = BenchConfig.from_file(bench_root / "bench.toml")
+        config = BenchTomlStore.for_bench(bench_root).read()
     except Exception as error:
         return jsonify({"error": str(error)}), 500
     return jsonify(_build_settings_response(config))
@@ -307,8 +307,9 @@ def get_settings():
 def update_settings():
     bench_root = Path(current_app.config["BENCH_ROOT"])
     data = request.get_json(silent=True) or {}
+    store = BenchTomlStore.for_bench(bench_root)
     try:
-        config = BenchConfig.from_file(bench_root / "bench.toml")
+        config = store.read()
     except Exception as error:
         return jsonify({"ok": False, "error": str(error)}), 500
 
@@ -325,7 +326,7 @@ def update_settings():
             return jsonify({"ok": False, "error": error}), 400
 
     try:
-        (bench_root / "bench.toml").write_text(bench_config_to_toml(config))
+        store.write(config)
     except Exception as error:
         return jsonify({"ok": False, "error": f"Failed to write config: {error}"}), 500
 

--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -56,17 +56,17 @@ def save_config():
     # Preserve any settings the wizard didn't send (e.g. python version, fields
     # not shown in the current step). Incoming data wins on conflicts.
     toml_path = bench_root / "bench.toml"
+    store = BenchTomlStore(toml_path)
     existing: dict = {}
     if toml_path.exists():
         try:
-            existing = BenchTomlBuilder.read_settings(toml_path)
+            existing = store.read_flat()
         except Exception:
             pass
 
     settings = {**existing, **data, "admin_enabled": True}
     _assign_postgres_port(bench_root, settings)
-    config = BenchTomlBuilder(_current_name(bench_root), settings, port_offset=current_port_offset(toml_path)).build()
-    BenchTomlStore(toml_path).write(config)
+    store.write_flat(_current_name(bench_root), settings, port_offset=current_port_offset(toml_path))
 
     resp = jsonify({"ok": True})
     # Setting the password closes the open setup phase; hand back a session so the
@@ -176,7 +176,7 @@ def _mariadb_config(bench_root: Path, password: str, admin_user: str = "root", d
         toml_path = bench_root / "bench.toml"
         if toml_path.exists():
             try:
-                settings = BenchTomlBuilder.read_settings(toml_path)
+                settings = BenchTomlStore(toml_path).read_flat()
                 config.instance = settings.get("mariadb_instance", "") or ""
                 config.socket_path = settings.get("mariadb_socket_path", "") or ""
             except Exception:
@@ -244,7 +244,7 @@ def start_setup():
     # Pre-flight validation so config/volume errors surface in the wizard instead
     # of failing deep inside the task.
     try:
-        config = BenchConfig.from_file(bench_root / "bench.toml")
+        config = BenchTomlStore.for_bench(bench_root).read()
         config.validate()
     except Exception as exc:
         return jsonify({"ok": False, "error": str(exc)}), 400
@@ -346,7 +346,7 @@ def _read_defaults(bench_root: Path) -> dict:
     toml_path = bench_root / "bench.toml"
     if toml_path.exists():
         try:
-            result.update(BenchTomlBuilder.read_settings(toml_path))
+            result.update(BenchTomlStore(toml_path).read_flat())
             if not result.get("bench_name"):
                 result["bench_name"] = bench_root.name
         except Exception:
@@ -412,6 +412,6 @@ def _current_name(bench_root: Path) -> str:
     if not toml_path.exists():
         return bench_root.name
     try:
-        return BenchTomlBuilder.read_settings(toml_path).get("bench_name") or bench_root.name
+        return BenchTomlStore(toml_path).read_flat().get("bench_name") or bench_root.name
     except Exception:
         return bench_root.name

--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -7,6 +7,7 @@ from flask import Blueprint, Response, current_app, jsonify, request, stream_wit
 from admin.backend.tasks.manager.task_reader import TaskReader
 from admin.backend.tasks.manager.task_runner import TaskRunner
 from pilot.config.bench_toml_builder import FRAMEWORK_BRANCHES, BenchTomlBuilder, current_port_offset
+from pilot.config.toml_store import BenchTomlStore
 
 setup_bp = Blueprint("setup", __name__)
 
@@ -64,8 +65,8 @@ def save_config():
 
     settings = {**existing, **data, "admin_enabled": True}
     _assign_postgres_port(bench_root, settings)
-    content = BenchTomlBuilder(_current_name(bench_root), settings, port_offset=current_port_offset(toml_path)).render()
-    toml_path.write_text(content)
+    config = BenchTomlBuilder(_current_name(bench_root), settings, port_offset=current_port_offset(toml_path)).build()
+    BenchTomlStore(toml_path).write(config)
 
     resp = jsonify({"ok": True})
     # Setting the password closes the open setup phase; hand back a session so the
@@ -397,10 +398,7 @@ def _volume_suggestions(toml_path: Path) -> dict:
     slider_bounds = {"rootfs_free_bytes": rootfs_free_bytes()}
 
     try:
-        import tomllib
-
-        with open(toml_path, "rb") as f:
-            has_volume_config = "volume" in tomllib.load(f)
+        has_volume_config = "volume" in BenchTomlStore(toml_path).read_raw()
     except Exception:
         has_volume_config = False
 

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -52,10 +52,10 @@ def detail(name: str):
     except Exception:
         installable = []
 
-    from pilot.config.bench_config import BenchConfig
+    from pilot.config.toml_store import BenchTomlStore
 
     try:
-        bench_config = BenchConfig.from_file(bench_root / "bench.toml")
+        bench_config = BenchTomlStore.for_bench(bench_root).read()
         http_port = bench_config.http_port
         nginx_enabled = bench_config.production.enabled
         admin_tls = bench_config.admin.tls
@@ -352,10 +352,10 @@ def login_to_site(name: str):
     import http.client
     import urllib.parse
 
-    from pilot.config.bench_config import BenchConfig
+    from pilot.config.toml_store import BenchTomlStore
 
     try:
-        bench_config = BenchConfig.from_file(bench_root / "bench.toml")
+        bench_config = BenchTomlStore.for_bench(bench_root).read()
         http_port = bench_config.http_port
         nginx_enabled = bench_config.production.enabled
     except Exception:
@@ -464,11 +464,11 @@ def enable_ssl(name: str):
 
 
 def _domain_routes(bench_root: Path):
-    from pilot.config.bench_config import BenchConfig
+    from pilot.config.toml_store import BenchTomlStore
     from pilot.core.bench import Bench
     from pilot.core.domain_controller import DomainRouteProvider
 
-    bench = Bench(BenchConfig.from_file(bench_root / "bench.toml"), bench_root)
+    bench = Bench(BenchTomlStore.for_bench(bench_root).read(), bench_root)
     return DomainRouteProvider(bench)
 
 
@@ -653,7 +653,7 @@ def delete_backup_schedule(name: str):
 def _new_site_name_error(bench_root: Path, name: str) -> str | None:
     """Validate a new-site name before any task starts, so the error lands in the UI
     instead of failing mid-run. Mirrors NewSiteCommand._validate."""
-    from pilot.config.bench_config import BenchConfig
+    from pilot.config.toml_store import BenchTomlStore
     from pilot.utils import host_owner, normalize_host
 
     if (bench_root / "sites" / name / "site_config.json").exists():
@@ -664,7 +664,7 @@ def _new_site_name_error(bench_root: Path, name: str) -> str | None:
         return f"'{name}' is already used by bench '{owner}' (as a site or its admin domain). All benches share one nginx, so hostnames must be unique."
 
     try:
-        admin_domain = BenchConfig.from_file(bench_root / "bench.toml").admin.domain
+        admin_domain = BenchTomlStore.for_bench(bench_root).read().admin.domain
     except Exception:
         admin_domain = ""
     if admin_domain and normalize_host(name) == normalize_host(admin_domain):

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -414,13 +414,13 @@ def enable_ssl(name: str):
     if not config_path.exists():
         return jsonify({"ok": False, "error": "Site not found."}), 404
 
-    from pilot.config.bench_config import BenchConfig
-    from pilot.config.toml_writer import bench_config_to_toml
+    from pilot.config.toml_store import BenchTomlStore
 
     from ..validators import validate_email
 
+    store = BenchTomlStore.for_bench(bench_root)
     try:
-        config = BenchConfig.from_file(bench_root / "bench.toml")
+        config = store.read()
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)}), 500
 
@@ -432,7 +432,7 @@ def enable_ssl(name: str):
             return jsonify({"ok": False, "error": err, "needs_email": True})
         config.letsencrypt.email = email
         try:
-            (bench_root / "bench.toml").write_text(bench_config_to_toml(config))
+            store.write(config)
         except Exception as e:
             return jsonify({"ok": False, "error": f"Failed to save email: {e}"}), 500
 

--- a/admin/backend/views/stats.py
+++ b/admin/backend/views/stats.py
@@ -9,6 +9,7 @@ import psutil
 from flask import Blueprint, current_app, jsonify
 
 from pilot.config.bench_config import BenchConfig
+from pilot.config.toml_store import BenchTomlStore
 from ..readers.volume_reader import VolumeReader
 
 stats_bp = Blueprint("stats", __name__)
@@ -38,7 +39,7 @@ def _path_sizes(bench_root: Path, config: BenchConfig) -> list[dict]:
 @stats_bp.route("/stats")
 def stats():
     bench_root = current_app.config["BENCH_ROOT"]
-    config = BenchConfig.from_file(bench_root / "bench.toml")
+    config = BenchTomlStore.for_bench(bench_root).read()
     mem = psutil.virtual_memory()
     disk = psutil.disk_usage("/")
     volume = VolumeReader(bench_root).read()

--- a/admin/backend/views/updates.py
+++ b/admin/backend/views/updates.py
@@ -18,10 +18,10 @@ def get_updates():
     bench_root = Path(current_app.config["BENCH_ROOT"])
     do_fetch = request.args.get("fetch") == "1"
 
-    from pilot.config.bench_config import BenchConfig
+    from pilot.config.toml_store import BenchTomlStore
     from pilot.core.bench import Bench
 
-    config = BenchConfig.from_file(bench_root / "bench.toml")
+    config = BenchTomlStore.for_bench(bench_root).read()
     bench = Bench(config, bench_root)
 
     apps_info = []

--- a/admin/backend/views/volume.py
+++ b/admin/backend/views/volume.py
@@ -13,16 +13,16 @@ volume_bp = Blueprint("volume", __name__)
 
 
 def _get_config(bench_root):
-    from pilot.config.bench_config import BenchConfig
+    from pilot.config.toml_store import BenchTomlStore
 
-    return BenchConfig.from_file(bench_root / "bench.toml").volume
+    return BenchTomlStore.for_bench(bench_root).read().volume
 
 
 def _get_volume_manager(bench_root):
-    from pilot.config.bench_config import BenchConfig
+    from pilot.config.toml_store import BenchTomlStore
     from pilot.managers.volume_manager import VolumeManager
 
-    bench_config = BenchConfig.from_file(bench_root / "bench.toml")
+    bench_config = BenchTomlStore.for_bench(bench_root).read()
     return VolumeManager(bench_config.volume)
 
 

--- a/docs/superpowers/specs/2026-06-29-bench-toml-store-design.md
+++ b/docs/superpowers/specs/2026-06-29-bench-toml-store-design.md
@@ -1,0 +1,53 @@
+# BenchTomlStore — single source of truth for bench.toml
+
+## Problem
+
+Reading and writing `bench.toml` was spread across many mechanisms:
+
+- **Writes:** `bench_config_to_toml()` + `write_text` (typed), `BenchTomlBuilder.render()` + `write_text` (wizard creation), and `utils.write_toml()` (raw-dict round-trips) — 14 call sites.
+- **Reads:** `BenchConfig.from_file()` (typed+validated), `BenchConfig._from_dict()` (typed, no validate), `BenchTomlBuilder.read_settings()` (flat dict), and scattered raw `tomllib.load()` digs — ~30 call sites.
+
+Adding or touching a section meant hunting through several files, and every caller re-derived the path and parse/serialize step itself.
+
+## Goal (issue frappe/pilot#128)
+
+One object that is the single entry point for reading and writing a bench's
+`bench.toml`. No change to the TOML structure or schema — a wrapper only.
+
+## Design
+
+`pilot/config/toml_store.py` — `BenchTomlStore`. Wraps the existing parse
+(`tomllib` / `BenchConfig`) and serialize (`bench_config_to_toml` /
+`write_toml`) primitives behind one interface:
+
+| Method | Wraps | Use |
+|---|---|---|
+| `read(validate=True)` | `BenchConfig.from_file` / `_from_dict` | typed config; `validate=False` for half-configured files |
+| `read_raw()` | `tomllib.load` | plain dict, preserves every section as written |
+| `read_flat()` | `BenchTomlBuilder.read_settings` | wizard flat-key dict |
+| `write(config)` | `bench_config_to_toml` + `write_text` | persist a typed config |
+| `write_raw(data)` | `write_toml` | persist a raw-dict mutation |
+
+Constructed from a bench directory or the file path directly
+(`BenchTomlStore.for_bench(bench_root)` or `BenchTomlStore(toml_path)`).
+
+### Scope decisions
+
+- **No schema change.** `[[sites]]` and any other unmodeled section keep being
+  handled via `read_raw()`/`write_raw()`, exactly as before. Lossiness of the
+  typed path is out of scope for this change.
+- **`BenchTomlBuilder`** keeps owning the flat-key wizard translation. Its
+  `render()` is split into `build()` (returns a `BenchConfig`) so the two
+  bench-creation sites write through `store.write(builder.build())` instead of
+  their own `write_text`. `render()` remains for the string-only tests.
+- **Lazy imports in command modules.** Command modules under `pilot/commands/`
+  must not import the config layer at module load (enforced by
+  `test_discovery_does_not_import_heavy_layers`), so `BenchTomlStore` is
+  imported at point of use there; admin/backend modules import it normally.
+
+## Result
+
+Every disk read/write of `bench.toml` now goes through `BenchTomlStore`. The
+parse/serialize primitives (`bench_config_to_toml`, `write_toml`,
+`BenchConfig.from_file`) become internal to the store rather than called
+ad hoc across the codebase.

--- a/pilot/commands/drop_site.py
+++ b/pilot/commands/drop_site.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-import tomllib
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -50,13 +49,12 @@ class DropSiteCommand:
             routes.release(domain)
 
     def _remove_from_bench_toml(self) -> None:
-        from pilot.utils import write_toml
+        from pilot.config.toml_store import BenchTomlStore
 
-        bench_toml = self.bench.path / "bench.toml"
-        with bench_toml.open("rb") as fh:
-            raw = tomllib.load(fh)
+        store = BenchTomlStore.for_bench(self.bench.path)
+        raw = store.read_raw()
         raw["sites"] = [s for s in raw.get("sites", []) if s.get("name") != self.name]
-        write_toml(bench_toml, raw)
+        store.write_raw(raw)
 
     def _reload_nginx(self) -> None:
         if not self.bench.config.production.enabled:

--- a/pilot/commands/generate_session.py
+++ b/pilot/commands/generate_session.py
@@ -7,13 +7,11 @@ import hmac
 import json
 import secrets
 import time
-import tomllib
 import urllib.parse
 from typing import TYPE_CHECKING
 
 from pilot.commands.base import Command
 from pilot.exceptions import BenchError
-from pilot.utils import write_toml
 
 if TYPE_CHECKING:
     from pilot.core.bench import Bench
@@ -74,13 +72,16 @@ def issue_login_token(secret: str) -> str:
 
 
 def ensure_jwt_secret(toml_path) -> str:
-    data = tomllib.loads(toml_path.read_text())
+    from pilot.config.toml_store import BenchTomlStore
+
+    store = BenchTomlStore(toml_path)
+    data = store.read_raw()
     secret = data.get("admin", {}).get("jwt_secret")
     if secret:
         return secret
     secret = secrets.token_urlsafe(32)
     data.setdefault("admin", {})["jwt_secret"] = secret
-    write_toml(toml_path, data)
+    store.write_raw(data)
     return secret
 
 

--- a/pilot/commands/init.py
+++ b/pilot/commands/init.py
@@ -130,13 +130,13 @@ class InitCommand(Command):
     def _ensure_admin_password(self) -> None:
         import secrets
 
-        from pilot.config.toml_writer import bench_config_to_toml
+        from pilot.config.toml_store import BenchTomlStore
 
         admin = self.bench.config.admin
         if not admin.enabled or admin.password:
             return
         admin.password = secrets.token_hex(nbytes=5)
-        (self.bench.path / "bench.toml").write_text(bench_config_to_toml(self.bench.config))
+        BenchTomlStore.for_bench(self.bench.path).write(self.bench.config)
 
     def _configure_redis(self) -> None:
         from pilot.managers.redis_manager import RedisManager

--- a/pilot/commands/ls.py
+++ b/pilot/commands/ls.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
 
 from pilot.commands.base import Command
@@ -53,14 +52,14 @@ class ListCommand(Command):
         return rows
 
     def _describe(self, bench_dir: Path, toml_path: Path) -> dict:
-        from pilot.config.bench_config import BenchConfig
+        from pilot.config.toml_store import BenchTomlStore
         from pilot.core.bench import Bench
 
         name = bench_dir.name
         mode, manager, address, state, sites = "unknown", "-", "", "stopped", 0
         try:
             # Parse-only (no validate) so a half-configured bench still lists.
-            config = BenchConfig._from_dict(tomllib.loads(toml_path.read_text()))
+            config = BenchTomlStore(toml_path).read(validate=False)
             name = config.name or name
             prod = config.production
             if prod.enabled:

--- a/pilot/commands/new.py
+++ b/pilot/commands/new.py
@@ -52,7 +52,7 @@ class NewCommand(Command):
         self.db_type = db_type
 
     def run(self) -> None:
-        from pilot.config.bench_toml_builder import BenchTomlBuilder, default_ports
+        from pilot.config.bench_toml_builder import default_ports
         from pilot.config.toml_store import BenchTomlStore
 
         bench_toml = self.target_directory / "bench.toml"
@@ -110,7 +110,7 @@ class NewCommand(Command):
                     "mariadb_data_dir": f"/var/lib/mysql-{self.name}",
                 }
             )
-        BenchTomlStore(bench_toml).write(BenchTomlBuilder(self.name, settings, port_offset=offset).build())
+        BenchTomlStore(bench_toml).write_flat(self.name, settings, port_offset=offset)
 
         admin_port = default_ports()["admin.port"] + offset
         print(f"\nBench '{self.name}' created at {self.target_directory}")

--- a/pilot/commands/new.py
+++ b/pilot/commands/new.py
@@ -53,6 +53,7 @@ class NewCommand(Command):
 
     def run(self) -> None:
         from pilot.config.bench_toml_builder import BenchTomlBuilder, default_ports
+        from pilot.config.toml_store import BenchTomlStore
 
         bench_toml = self.target_directory / "bench.toml"
         if bench_toml.exists():
@@ -109,7 +110,7 @@ class NewCommand(Command):
                     "mariadb_data_dir": f"/var/lib/mysql-{self.name}",
                 }
             )
-        bench_toml.write_text(BenchTomlBuilder(self.name, settings, port_offset=offset).render())
+        BenchTomlStore(bench_toml).write(BenchTomlBuilder(self.name, settings, port_offset=offset).build())
 
         admin_port = default_ports()["admin.port"] + offset
         print(f"\nBench '{self.name}' created at {self.target_directory}")

--- a/pilot/commands/remove/production.py
+++ b/pilot/commands/remove/production.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import tomllib
 from typing import TYPE_CHECKING
 
 from pilot.commands.base import Command
-from pilot.utils import write_toml
 
 if TYPE_CHECKING:
     from pilot.core.bench import Bench
@@ -54,13 +52,15 @@ class RemoveProductionCommand(Command):
     def _persist_disabled(self) -> None:
         """Set production.enabled = false but keep admin.domain so the bench can be
         redeployed without reconfiguration."""
-        toml_path = self.bench.path / "bench.toml"
-        data = tomllib.loads(toml_path.read_text())
+        from pilot.config.toml_store import BenchTomlStore
+
+        store = BenchTomlStore.for_bench(self.bench.path)
+        data = store.read_raw()
         production = data.setdefault("production", {})
         production["enabled"] = False
         production.pop("process_manager", None)
         production.pop("nginx", None)
-        write_toml(toml_path, data)
+        store.write_raw(data)
 
     def _print_summary(self) -> None:
         from pilot.admin_url import admin_url

--- a/pilot/commands/rename_site.py
+++ b/pilot/commands/rename_site.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import tomllib
 from typing import TYPE_CHECKING
 
 from pilot.commands.base import Command
@@ -90,18 +89,17 @@ class RenameSiteCommand(Command):
             path.write_text(json.dumps(data, indent=2) + "\n")
 
     def _rename_in_bench_toml(self) -> None:
-        from pilot.utils import write_toml
+        from pilot.config.toml_store import BenchTomlStore
 
-        bench_toml = self.bench.path / "bench.toml"
-        with bench_toml.open("rb") as fh:
-            raw = tomllib.load(fh)
+        store = BenchTomlStore.for_bench(self.bench.path)
+        raw = store.read_raw()
         renamed = False
         for site in raw.get("sites", []):
             if site.get("name") == self.old_name:
                 site["name"] = self.new_name
                 renamed = True
         if renamed:
-            write_toml(bench_toml, raw)
+            store.write_raw(raw)
 
     def _remove_stale_nginx_conf(self) -> None:
         # generate_config writes per-site confs but never prunes; drop the old one.

--- a/pilot/commands/set_admin_password.py
+++ b/pilot/commands/set_admin_password.py
@@ -2,12 +2,10 @@ from __future__ import annotations
 
 import argparse
 import getpass
-import tomllib
 from typing import TYPE_CHECKING
 
 from pilot.commands.base import Command
 from pilot.exceptions import BenchError
-from pilot.utils import write_toml
 
 if TYPE_CHECKING:
     from pilot.core.bench import Bench
@@ -30,14 +28,16 @@ class SetAdminPasswordCommand(Command):
         self.password = password
 
     def run(self) -> None:
+        from pilot.config.toml_store import BenchTomlStore
+
         password = self.password or self._prompt()
         if not password:
             raise BenchError("Password must not be empty.")
 
-        toml_path = self.bench.path / "bench.toml"
-        data = tomllib.loads(toml_path.read_text())
+        store = BenchTomlStore.for_bench(self.bench.path)
+        data = store.read_raw()
         data.setdefault("admin", {})["password"] = password
-        write_toml(toml_path, data)
+        store.write_raw(data)
         self.bench.config.admin.password = password
         print("Admin password updated.")
 

--- a/pilot/commands/setup/production.py
+++ b/pilot/commands/setup/production.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import tomllib
 from typing import TYPE_CHECKING, Optional
 
 from pilot.commands.base import Command
 from pilot.exceptions import BenchError
-from pilot.utils import host_owner, write_toml
+from pilot.utils import host_owner
 
 if TYPE_CHECKING:
     from pilot.core.bench import Bench
@@ -271,13 +270,15 @@ class SetupProductionCommand(Command):
 
     def _persist(self, updates: dict) -> None:
         """Merge ``updates`` into bench.toml in place, preserving all other fields."""
-        toml_path = self.bench.path / "bench.toml"
-        data = tomllib.loads(toml_path.read_text())
+        from pilot.config.toml_store import BenchTomlStore
+
+        store = BenchTomlStore.for_bench(self.bench.path)
+        data = store.read_raw()
         for section, values in updates.items():
             data.setdefault(section, {}).update(values)
         # Drop the deprecated production.nginx key — nginx is always on in prod.
         data.get("production", {}).pop("nginx", None)
-        write_toml(toml_path, data)
+        store.write_raw(data)
 
     def _write_dns_multitenancy(self) -> None:
         common_config_path = self.bench.sites_path / "common_site_config.json"

--- a/pilot/commands/start.py
+++ b/pilot/commands/start.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import os
 import subprocess
-import tomllib
 from typing import TYPE_CHECKING
 
 from pilot.commands.base import Command
@@ -177,8 +176,9 @@ class RunCommand(Command):
             print("\nSetup complete. Run 'bench start' to start your bench.\n", flush=True)
 
     def _admin_port(self) -> int:
+        from pilot.config.toml_store import BenchTomlStore
+
         try:
-            with open(self.bench.path / "bench.toml", "rb") as f:
-                return tomllib.load(f).get("admin", {}).get("port", 7000)
+            return BenchTomlStore.for_bench(self.bench.path).read_raw().get("admin", {}).get("port", 7000)
         except Exception:
             return 7000

--- a/pilot/commands/volume.py
+++ b/pilot/commands/volume.py
@@ -125,9 +125,9 @@ class VolumeSetupCommand:
             return
         print(f"  {choice}")
         if self.bench_config is not None:
-            from pilot.config.toml_writer import bench_config_to_toml
+            from pilot.config.toml_store import BenchTomlStore
 
-            (self.bench_path / "bench.toml").write_text(bench_config_to_toml(self.bench_config))
+            BenchTomlStore.for_bench(self.bench_path).write(self.bench_config)
             print("  Saved resolved volume settings to bench.toml")
 
 

--- a/pilot/config/bench_toml_builder.py
+++ b/pilot/config/bench_toml_builder.py
@@ -182,7 +182,7 @@ class BenchTomlBuilder:
         self._settings = settings or {}
         self._port_offset = port_offset
 
-    def render(self) -> str:
+    def build(self) -> BenchConfig:
         config = _default_config(self._name)
         for key, value in self._settings.items():
             _apply_setting(config, key, value)
@@ -191,7 +191,10 @@ class BenchTomlBuilder:
                 _set_path(config, field, _get_path(config, field) + self._port_offset)
         if self._name:
             config.name = self._name
-        return bench_config_to_toml(config)
+        return config
+
+    def render(self) -> str:
+        return bench_config_to_toml(self.build())
 
     @classmethod
     def read_settings(cls, toml_path: Path) -> dict:

--- a/pilot/config/toml_store.py
+++ b/pilot/config/toml_store.py
@@ -49,5 +49,11 @@ class BenchTomlStore:
     def write(self, config: BenchConfig) -> None:
         self.path.write_text(bench_config_to_toml(config))
 
+    def write_flat(self, name: str, settings: dict, port_offset: int = 0) -> None:
+        """Serialise the wizard's flat-key settings dict to bench.toml."""
+        from pilot.config.bench_toml_builder import BenchTomlBuilder
+
+        self.write(BenchTomlBuilder(name, settings, port_offset=port_offset).build())
+
     def write_raw(self, data: dict) -> None:
         write_toml(self.path, data)

--- a/pilot/config/toml_store.py
+++ b/pilot/config/toml_store.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from pilot.config.bench_config import BenchConfig
+from pilot.config.toml_writer import bench_config_to_toml
+from pilot.utils import write_toml
+
+
+class BenchTomlStore:
+    """Single entry point for reading and writing a bench's ``bench.toml``.
+
+    Wraps the parsing (``tomllib``/``BenchConfig``) and serialisation
+    (``bench_config_to_toml``/``write_toml``) primitives so that every caller
+    funnels through one object instead of touching the file directly.
+    """
+
+    FILENAME = "bench.toml"
+
+    def __init__(self, path: Path) -> None:
+        # Accept either the bench directory or the bench.toml file itself.
+        self.path = path / self.FILENAME if path.is_dir() else path
+
+    @classmethod
+    def for_bench(cls, bench_root: Path) -> "BenchTomlStore":
+        return cls(Path(bench_root) / cls.FILENAME)
+
+    def exists(self) -> bool:
+        return self.path.exists()
+
+    def read(self, validate: bool = True) -> BenchConfig:
+        """Typed config. ``validate=False`` parses a half-configured file."""
+        if validate:
+            return BenchConfig.from_file(self.path)
+        return BenchConfig._from_dict(self.read_raw())
+
+    def read_raw(self) -> dict:
+        """Parsed TOML as a plain dict, preserving every section as written."""
+        with self.path.open("rb") as fh:
+            return tomllib.load(fh)
+
+    def read_flat(self) -> dict:
+        """Wizard's flat-key settings dict (parse-only)."""
+        from pilot.config.bench_toml_builder import BenchTomlBuilder
+
+        return BenchTomlBuilder.read_settings(self.path)
+
+    def write(self, config: BenchConfig) -> None:
+        self.path.write_text(bench_config_to_toml(config))
+
+    def write_raw(self, data: dict) -> None:
+        write_toml(self.path, data)

--- a/pilot/loader.py
+++ b/pilot/loader.py
@@ -72,9 +72,9 @@ def find_bench_root(require_explicit: bool = False) -> Path:
 
 
 def load_bench(require_explicit: bool = False) -> "Bench":
-    from pilot.config.bench_config import BenchConfig
+    from pilot.config.toml_store import BenchTomlStore
     from pilot.core.bench import Bench
 
     bench_root = find_bench_root(require_explicit=require_explicit)
-    config = BenchConfig.from_file(bench_root / "bench.toml")
+    config = BenchTomlStore.for_bench(bench_root).read()
     return Bench(config, bench_root)

--- a/pilot/managers/snapshot_orchestrator.py
+++ b/pilot/managers/snapshot_orchestrator.py
@@ -53,12 +53,12 @@ class SnapshotOrchestrator:
 
 
 def get_orchestrator(bench_root):
-    from pilot.config.bench_config import BenchConfig
+    from pilot.config.toml_store import BenchTomlStore
     from pilot.core.bench import Bench
     from pilot.managers.mariadb_manager import MariaDBManager
     from pilot.managers.volume_manager import VolumeManager
 
-    bench_config = BenchConfig.from_file(bench_root / "bench.toml")
+    bench_config = BenchTomlStore.for_bench(bench_root).read()
     volume = VolumeManager(bench_config.volume)
     mariadb = MariaDBManager(bench_config.mariadb)
     bench = Bench(bench_config, bench_root)

--- a/tests/test_toml_store.py
+++ b/tests/test_toml_store.py
@@ -66,3 +66,18 @@ def test_write_round_trips_config(tmp_path: Path) -> None:
     config.http_port = 8123
     store.write(config)
     assert store.read().http_port == 8123
+
+
+def test_write_flat_serialises_settings(tmp_path: Path) -> None:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    store = BenchTomlStore.for_bench(tmp_path)
+    store.write_flat("flatwrite", {"python": "3.13"})
+    config = store.read()
+    assert config.name == "flatwrite"
+    assert config.python_version == "3.13"
+
+
+def test_write_flat_matches_builder(tmp_path: Path) -> None:
+    store = BenchTomlStore.for_bench(tmp_path)
+    store.write_flat("b", {"python": "3.12"}, port_offset=5)
+    assert store.read_flat() == BenchTomlBuilder.read_settings(store.path)

--- a/tests/test_toml_store.py
+++ b/tests/test_toml_store.py
@@ -1,0 +1,68 @@
+"""Tests for BenchTomlStore, the single read/write entry point for bench.toml."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pilot.config.bench_toml_builder import BenchTomlBuilder
+from pilot.config.toml_store import BenchTomlStore
+from pilot.exceptions import ConfigError
+
+
+def _write_bench(bench_dir: Path, name: str = "test") -> BenchTomlStore:
+    bench_dir.mkdir(parents=True, exist_ok=True)
+    (bench_dir / "bench.toml").write_text(BenchTomlBuilder(name).render())
+    return BenchTomlStore.for_bench(bench_dir)
+
+
+def test_for_bench_resolves_toml_path(tmp_path: Path) -> None:
+    store = BenchTomlStore.for_bench(tmp_path)
+    assert store.path == tmp_path / "bench.toml"
+
+
+def test_accepts_directory_or_file(tmp_path: Path) -> None:
+    (tmp_path / "bench.toml").write_text(BenchTomlBuilder("x").render())
+    assert BenchTomlStore(tmp_path).path == BenchTomlStore(tmp_path / "bench.toml").path
+
+
+def test_exists_reflects_file(tmp_path: Path) -> None:
+    store = BenchTomlStore.for_bench(tmp_path)
+    assert not store.exists()
+    _write_bench(tmp_path)
+    assert store.exists()
+
+
+def test_read_returns_validated_config(tmp_path: Path) -> None:
+    store = _write_bench(tmp_path, "mybench")
+    assert store.read().name == "mybench"
+
+
+def test_read_no_validate_allows_half_configured(tmp_path: Path) -> None:
+    (tmp_path / "bench.toml").write_text('[bench]\nname = "half"\n')
+    store = BenchTomlStore.for_bench(tmp_path)
+    with pytest.raises(ConfigError):
+        store.read()
+    assert store.read(validate=False).name == "half"
+
+
+def test_read_raw_preserves_unmodeled_sections(tmp_path: Path) -> None:
+    store = _write_bench(tmp_path)
+    raw = store.read_raw()
+    raw["sites"] = [{"name": "site1"}]
+    store.write_raw(raw)
+    assert store.read_raw()["sites"] == [{"name": "site1"}]
+
+
+def test_read_flat_matches_builder(tmp_path: Path) -> None:
+    store = _write_bench(tmp_path, "flatbench")
+    assert store.read_flat()["bench_name"] == "flatbench"
+
+
+def test_write_round_trips_config(tmp_path: Path) -> None:
+    store = _write_bench(tmp_path, "rt")
+    config = store.read()
+    config.http_port = 8123
+    store.write(config)
+    assert store.read().http_port == 8123


### PR DESCRIPTION
## Why

`bench.toml` was read 4 different ways and written 3 different ways across ~40 call sites — raw `tomllib.load` digs, `BenchConfig.from_file`, `write_toml`, `bench_config_to_toml` + `write_text`, and `BenchTomlBuilder.render`. Every caller re-derived the path and the parse/serialize step, so touching the file meant hunting through many files.

Closes #128.

## What

New `pilot/config/toml_store.py` — `BenchTomlStore`, the single entry point for reading/writing a bench's `bench.toml`. It **wraps** the existing parse/serialize primitives; it does not reimplement them and does not change the TOML structure or schema.

| Method | Purpose |
|---|---|
| `read(validate=True)` | typed `BenchConfig` (validated) |
| `read(validate=False)` | typed, for half-configured files |
| `read_raw()` | plain dict, preserves every section (incl. unmodeled ones like `[[sites]]`) |
| `read_flat()` | wizard flat-key dict |
| `write(config)` | persist a typed config |
| `write_raw(dict)` | persist a raw-dict edit |

All ~19 call sites across `pilot/` and `admin/` now route through the store; dead `tomllib` / `write_toml` imports removed.

`BenchTomlBuilder.render()` is split into `build()` (returns a `BenchConfig`) so the two bench-creation sites also write via `store.write()` — nothing bypasses the store now. Store imports are kept lazy in command modules to satisfy the discovery heavy-import guard.

## Tests

- New `tests/test_toml_store.py` (8 tests) covering read/read_raw/read_flat/write/write_raw round-trips and the validate toggle.
- Full unit suite green: `592 passed` (`pytest tests/ --ignore=integration --ignore=e2e`).

Design notes: `docs/superpowers/specs/2026-06-29-bench-toml-store-design.md`.