### PR TITLE
feat: Scoped authentication and inject token on site creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Each bench lives on a single dataset (`<pool>/<bench>`) holding both its files a
 | `bench setup config` | Regenerate Procfile and config files from bench.toml |
 | `bench build-admin` | Rebuild admin frontend assets from source |
 | `bench generate-admin-session` | Issue a 5-minute, single-use admin sign-in link (`--full-path` for the URL) |
+| `bench issue-site-token <name>` | Issue a scoped JWT for site-to-bench API calls (use as `Authorization: Bearer`) |
 | `bench set-admin-password` | Set the admin UI password (prompts securely if `--password` is omitted) |
 | `bench setup nginx` | Generate and install nginx config |
 | `bench setup letsencrypt` | Obtain SSL certificates |

--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -1,178 +1,35 @@
 from __future__ import annotations
 
-import functools
 import hmac
-import http.client
 import os
-import re
-import socket
-import subprocess
 import signal
 import threading
 import time
 from pathlib import Path
 
-from flask import Flask, jsonify, request, send_file
+from flask import Flask, g, jsonify, request, send_file
 
+from .rate_limit import rate_limit, UsedTokens
 from .views.apps import apps_bp
+from .views.benches import benches_bp
 from .views.dashboard import dashboard_bp
-from .views.git import git_bp
-from .views.stats import stats_bp
 from .views.database import database_bp
+from .views.git import git_bp
 from .views.logs import logs_bp
 from .views.processes import processes_bp
-from .views.setup import setup_bp, wizard_marker_path
 from .views.settings import settings_bp
+from .views.setup import setup_bp, wizard_marker_path
 from .views.sites import sites_bp
+from .views.stats import stats_bp
 from .views.tasks import tasks_bp
 from .views.updates import updates_bp
 from .views.volume import volume_bp
-from pilot.commands.admin import _cli_root
-from pilot.commands.new import NewCommand
 from pilot.config.bench_config import BenchConfig
 from pilot.config.toml_store import BenchTomlStore
-from pilot.exceptions import BenchError, ConfigError
+from pilot.exceptions import ConfigError
 
 _STATIC_DIR = Path(__file__).parent / "static"
 _OPEN_PATHS = {"/api/status", "/api/login", "/api/logout", "/api/ping"}
-_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
-# Lenient hostname: dotted alphanumeric/hyphen labels (allows admin.example.com
-# and dev names like my-admin.localhost).
-_ADMIN_DOMAIN_RE = re.compile(
-    r"^(?=.{1,253}$)[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
-)
-
-
-class _SlidingWindow:
-    """In-memory request counter, keyed by an arbitrary string. Safe for the
-    admin's single gunicorn worker (one process, multiple threads)."""
-
-    def __init__(self, max_hits: int, window: int) -> None:
-        self._max = max_hits
-        self._window = window
-        self._hits: dict[str, list[float]] = {}
-        self._lock = threading.Lock()
-
-    def allow(self, key: str) -> bool:
-        now = time.monotonic()
-        with self._lock:
-            recent = [t for t in self._hits.get(key, []) if now - t < self._window]
-            if len(recent) >= self._max:
-                self._hits[key] = recent
-                return False
-            recent.append(now)
-            self._hits[key] = recent
-            return True
-
-
-class _UsedTokens:
-    """Tracks consumed one-time sign-in token ids so each can be used only once.
-    In-memory (single gunicorn worker); entries self-expire at the token's exp."""
-
-    def __init__(self) -> None:
-        self._used: dict[str, float] = {}
-        self._lock = threading.Lock()
-
-    def use(self, jti: str, exp: float) -> bool:
-        now = time.time()
-        with self._lock:
-            self._used = {j: e for j, e in self._used.items() if e > now}
-            if jti in self._used:
-                return False
-            self._used[jti] = exp
-            return True
-
-
-def _client_ip() -> str:
-    # nginx overwrites X-Real-IP with the real client address (unspoofable);
-    # in dev there is no proxy, so fall back to the direct peer.
-    return request.headers.get("X-Real-IP") or request.remote_addr or "unknown"
-
-
-def rate_limit(attempts: int, seconds: int, user_ip: bool = True):
-    """Allow at most ``attempts`` calls per ``seconds`` (per client IP when
-    ``user_ip``, else globally), returning HTTP 429 once exceeded."""
-
-    def decorator(view):
-        window = _SlidingWindow(attempts, seconds)
-
-        @functools.wraps(view)
-        def wrapper(*args, **kwargs):
-            if not window.allow(_client_ip() if user_ip else "*"):
-                return jsonify({"ok": False, "error": "Too many attempts. Try again later."}), 429
-            return view(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
-
-
-def _port_open(port: int) -> bool:
-    try:
-        with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-            return True
-    except OSError:
-        return False
-
-
-def _workload_running(bench_dir: Path, toml_path: Path) -> bool | None:
-    """Whether a production bench's workload is currently running — used to
-    gate start/stop/restart controls for other benches in the switcher. None
-    if the check itself fails (e.g. process manager CLI not installed)."""
-    from pilot.core.bench import Bench
-    from pilot.managers.process_manager import ProcessManager
-
-    try:
-        bench = Bench(BenchTomlStore(toml_path).read(), bench_dir)
-        return ProcessManager.for_bench(bench).is_running()
-    except Exception:
-        return None
-
-
-def _admin_running(bench_dir: Path, toml_path: Path) -> bool | None:
-    """Whether a production bench's admin control plane is up — socket-activated,
-    so a listening socket counts even while the workload is stopped. Lets the UI
-    show 'Admin active' instead of 'Stopped' for a provisioned-but-not-started
-    bench. None if the check fails."""
-    from pilot.core.bench import Bench
-    from pilot.managers.process_manager import ProcessManager
-
-    try:
-        bench = Bench(BenchConfig.from_file(toml_path), bench_dir)
-        return ProcessManager.for_bench(bench).is_admin_running()
-    except Exception:
-        return None
-
-
-def _admin_cert_exists(bench_dir: Path, toml_path: Path) -> bool:
-    """Whether the admin domain's TLS cert is in place — gates whether nginx
-    serves the admin over https yet. False on any failure (treat as plain http)."""
-    from pilot.core.bench import Bench
-    from pilot.managers.nginx_manager import NginxManager
-
-    try:
-        bench = Bench(BenchTomlStore(toml_path).read(), bench_dir)
-        return NginxManager(bench).admin_cert_exists()
-    except Exception:
-        return False
-
-
-def _site_count(bench_dir: Path) -> int:
-    """Number of real sites in a bench — a sites/ subdir is a site iff it holds a
-    site_config.json (skips assets/, apps.txt, etc.)."""
-    sites_dir = bench_dir / "sites"
-    if not sites_dir.is_dir():
-        return 0
-    return sum(1 for d in sites_dir.iterdir() if d.is_dir() and (d / "site_config.json").exists())
-
-
-def _persist_toml(bench_dir: Path, updates: dict) -> None:
-    """Merge ``updates`` into a bench's bench.toml in place, preserving other keys."""
-    store = BenchTomlStore.for_bench(bench_dir)
-    data = store.read_raw()
-    for section, values in updates.items():
-        data.setdefault(section, {}).update(values)
-    store.write_raw(data)
 
 
 def _wizard_status(bench_root: Path) -> dict:
@@ -185,10 +42,7 @@ def _wizard_status(bench_root: Path) -> dict:
 
 
 def _setup_complete(bench_root: Path, config: BenchConfig) -> bool:
-    """Whether first-time setup has fully finished — used to retire a stale wizard
-    marker. A production bench isn't done until production is enabled (the deploy
-    sets it last); a dev bench is done once init has. Either way, the wizard's
-    setup task must no longer be running."""
+    """Whether first-time setup has fully finished."""
     if not (bench_root / "env" / "bin" / "python").exists() or not config.admin.password:
         return False
     if config.production.process_manager and not config.production.enabled:
@@ -205,14 +59,7 @@ def _setup_complete(bench_root: Path, config: BenchConfig) -> bool:
 
 
 def _install_idle_watchdog(app: Flask) -> None:
-    """Stop the admin after a period of inactivity when socket-activated.
-
-    Enabled only when BENCH_ADMIN_IDLE_TIMEOUT is set, which the systemd service
-    unit does. Under gunicorn (workers=1, preload_app=False) this runs in the
-    worker, so os.getppid() is the gunicorn arbiter — SIGTERM to it triggers a
-    graceful shutdown and the service stops. systemd keeps the .socket listening,
-    so the next request re-activates the service.
-    """
+    """Stop the admin after a period of inactivity when socket-activated."""
     raw = os.environ.get("BENCH_ADMIN_IDLE_TIMEOUT")
     if not raw:
         return
@@ -247,7 +94,7 @@ def create_app(bench_root: Path) -> Flask:
     app.config["TEMPLATES_AUTO_RELOAD"] = False
 
     _install_idle_watchdog(app)
-    used_logins = _UsedTokens()
+    used_logins = UsedTokens()
 
     def _load_config():
         return BenchTomlStore.for_bench(bench_root).read()
@@ -258,9 +105,22 @@ def create_app(bench_root: Path) -> Flask:
         return None
 
     def _is_authenticated(config: BenchConfig) -> bool:
-        from pilot.commands.generate_session import verify_token
+        from pilot.commands.generate_session import decode_token
 
-        return verify_token(request.cookies.get("sid", ""), config.admin.jwt_secret)
+        token = _extract_token()
+        if not token:
+            return False
+        claims = decode_token(token, config.admin.jwt_secret)
+        if claims is None:
+            return False
+        g.jwt_claims = claims
+        return True
+
+    def _extract_token() -> str | None:
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            return auth_header[7:]
+        return request.cookies.get("sid")
 
     def _set_sid_cookie(resp, sid: str, config: BenchConfig):
         resp.set_cookie("sid", sid, max_age=24 * 3600, httponly=True,
@@ -275,6 +135,7 @@ def create_app(bench_root: Path) -> Flask:
 
     @app.before_request
     def _guard():
+        g.jwt_claims = None
         if not request.path.startswith("/api") or request.path in _OPEN_PATHS:
             return None
         is_setup = request.path.startswith("/api/setup/")
@@ -288,8 +149,6 @@ def create_app(bench_root: Path) -> Flask:
 
     @app.route("/api/ping")
     def api_ping():
-        # Liveness check: no auth, always 200. CORS-open so the frontend can probe
-        # both http:// and https:// of the current host while recovering.
         resp = jsonify({"ok": True})
         resp.headers["Access-Control-Allow-Origin"] = "*"
         return resp
@@ -303,11 +162,6 @@ def create_app(bench_root: Path) -> Flask:
             return jsonify({"enabled": False, "error": str(exc)}), 503
         if not initialized or not config.admin.password:
             return jsonify(_wizard_status(bench_root))
-        # The bench looks initialized, but the wizard's own production deploy may
-        # still be mid-flight (env + password exist before production is enabled).
-        # The wizard marker tells that apart from an independent `setup production`
-        # re-run, which never writes it. Clear a stale marker once setup is truly
-        # complete so a crashed/closed wizard can't trap the bench in setup mode.
         marker = wizard_marker_path(bench_root)
         if marker.exists():
             if _setup_complete(bench_root, config):
@@ -316,16 +170,14 @@ def create_app(bench_root: Path) -> Flask:
                 return jsonify(_wizard_status(bench_root))
         from pilot.platform import native_process_manager
 
-        return jsonify(
-            {
-                "enabled": config.admin.enabled,
-                "name": config.name,
-                "db_type": config.db_type,
-                "production": config.production.enabled,
-                "native_process_manager": native_process_manager(),
-                "authenticated": _is_authenticated(config),
-            }
-        )
+        return jsonify({
+            "enabled": config.admin.enabled,
+            "name": config.name,
+            "db_type": config.db_type,
+            "production": config.production.enabled,
+            "native_process_manager": native_process_manager(),
+            "authenticated": _is_authenticated(config),
+        })
 
     @app.route("/api/login", methods=["POST"])
     @rate_limit(5, 60, user_ip=True)
@@ -357,321 +209,10 @@ def create_app(bench_root: Path) -> Flask:
         resp.delete_cookie("sid")
         return resp
 
-    @app.route("/api/benches/")
-    def api_benches():
-        benches_dir = bench_root.parent
-        benches = []
-        for bench_dir in sorted(benches_dir.iterdir()):
-            if not bench_dir.is_dir():
-                continue
-            toml_path = bench_dir / "bench.toml"
-            if not toml_path.exists():
-                continue
-            try:
-                config = BenchTomlStore(toml_path).read_raw()
-                admin = config.get("admin", {})
-                prod = config.get("production", {})
-                port = admin.get("port")
-                name = config.get("bench", {}).get("name", bench_dir.name)
-                if not port:
-                    continue
-                pm = str(prod.get("process_manager", "")).lower()
-                pm = "" if pm in ("", "none") else ("supervisor" if pm == "supervisord" else pm)
-                production = bool(prod.get("enabled", pm != ""))
-                domain = admin.get("domain", "")
-                tls = bool(admin.get("tls", False))
-                # The admin binds `port` directly in dev, but under socket
-                # activation gunicorn binds internal_port (port + 1) and nginx
-                # serves the public domain — nothing listens on `port` itself.
-                # A production admin stays reachable while its workload is
-                # stopped; a stopped dev bench is unavailable (dead port).
-                reachable = _port_open(port) or _port_open(port + 1)
-                # Open over the scheme nginx actually serves: https only once the
-                # cert is in place, else http — a provisioned-but-not-set-up bench
-                # is served plain http even when tls is configured.
-                serves_https = tls and _admin_cert_exists(bench_dir, toml_path)
-                scheme = "https" if serves_https else "http"
-                admin_url = f"{scheme}://{domain}" if production and domain else ""
-                workload_running = _workload_running(bench_dir, toml_path) if production else None
-                admin_running = _admin_running(bench_dir, toml_path) if production else None
-                benches.append({
-                    "name": name,
-                    "port": port,
-                    "domain": domain,
-                    "production": production,
-                    "process_manager": pm or None,
-                    "reachable": reachable,
-                    "admin_url": admin_url,
-                    "workload_running": workload_running,
-                    "admin_running": admin_running,
-                    "site_count": _site_count(bench_dir),
-                })
-            except Exception:
-                continue
-        return jsonify(benches)
-
-    @app.route("/api/benches/<name>/<action>", methods=["POST"])
-    def api_benches_control(name, action):
-        if action not in ("start", "stop", "restart"):
-            return jsonify({"ok": False, "error": f"Unknown action '{action}'."}), 400
-        if not _NAME_RE.match(name):
-            return jsonify({"ok": False, "error": "Invalid bench name."}), 400
-
-        target_dir = bench_root.parent / name
-        toml_path = target_dir / "bench.toml"
-        if not toml_path.exists():
-            return jsonify({"ok": False, "error": f"Bench '{name}' not found."}), 404
-
-        try:
-            target_config = BenchTomlStore(toml_path).read_raw()
-        except Exception as exc:
-            return jsonify({"ok": False, "error": str(exc)}), 500
-        if not target_config.get("production", {}).get("enabled"):
-            return jsonify({"ok": False, "error": "Start/stop/restart from here is only supported for production benches."}), 400
-
-        cli_root = _cli_root()
-        try:
-            result = subprocess.run(
-                [str(cli_root / "bench"), "-b", name, action],
-                cwd=cli_root, capture_output=True, text=True, timeout=60,
-            )
-        except subprocess.TimeoutExpired:
-            return jsonify({"ok": False, "error": f"'{action}' timed out."}), 500
-        if result.returncode != 0:
-            return jsonify({"ok": False, "error": (result.stderr or result.stdout).strip()}), 500
-        return jsonify({"ok": True})
-
-    @app.route("/api/benches/<name>", methods=["DELETE"])
-    def api_benches_drop(name):
-        if not _NAME_RE.match(name):
-            return jsonify({"ok": False, "error": "Invalid bench name."}), 400
-
-        target_dir = bench_root.parent / name
-        toml_path = target_dir / "bench.toml"
-        if not toml_path.exists():
-            return jsonify({"ok": False, "error": f"Bench '{name}' not found."}), 404
-        if target_dir.resolve() == bench_root.resolve():
-            return jsonify({"ok": False, "error": "Can't drop the bench you're currently using."}), 400
-
-        # The drop itself re-checks for sites, but reject early with a clear
-        # message rather than shelling out only to fail.
-        sites = _site_count(target_dir)
-        if sites:
-            return jsonify({"ok": False, "error": f"Bench '{name}' has {sites} site(s). Drop them first."}), 400
-
-        cli_root = _cli_root()
-        try:
-            result = subprocess.run(
-                [str(cli_root / "bench"), "--yes", "-b", name, "drop"],
-                cwd=cli_root, capture_output=True, text=True, timeout=180,
-            )
-        except subprocess.TimeoutExpired:
-            return jsonify({"ok": False, "error": "Drop timed out."}), 500
-        if result.returncode != 0:
-            return jsonify({"ok": False, "error": (result.stderr or result.stdout).strip()}), 500
-        return jsonify({"ok": True})
-
-    @app.route("/api/benches/wildcard-domains", methods=["GET"])
-    def api_benches_wildcard_domains():
-        """Wildcard domain suffixes (no leading '*') new bench admin domains may be built from."""
-        from pilot.core.domain_controller import DomainRouteProvider
-        from pilot.utils import wildcard_suffix
-
-        try:
-            patterns = DomainRouteProvider.wildcard_domains()
-        except Exception as e:
-            return jsonify({"error": str(e)}), 500
-        return jsonify({"domains": [wildcard_suffix(p) for p in patterns]})
-
-    @app.route("/api/benches/new", methods=["POST"])
-    def api_benches_new():
-        from pilot.utils import host_owner, normalize_host
-
-        data = request.get_json(silent=True) or {}
-        name = (data.get("name") or "").strip()
-        if not name or not _NAME_RE.match(name):
-            return jsonify({"error": "Bench name must contain only letters, numbers, '-' and '_'"}), 400
-
-        from pilot.config.production_config import VALID_PROCESS_MANAGERS
-        from pilot.platform import is_alpine
-
-        process_manager = (data.get("process_manager") or "").strip().lower()
-        if process_manager == "supervisord":
-            process_manager = "supervisor"
-        if process_manager not in VALID_PROCESS_MANAGERS:
-            return jsonify({"error": f"Choose a process manager: {', '.join(VALID_PROCESS_MANAGERS)}."}), 400
-        if is_alpine() and process_manager == "systemd":
-            # Alpine has no systemd; the UI offers OpenRC there, but coerce any
-            # stale systemd request to OpenRC (the native Alpine manager) so a
-            # cached client can never deploy an unmanageable bench.
-            process_manager = "openrc"
-
-        db_type = (data.get("db_type") or "mariadb").strip()
-        if db_type not in ("mariadb", "postgres"):
-            return jsonify({"error": "Database must be 'mariadb' or 'postgres'."}), 400
-
-        admin_domain = (data.get("admin_domain") or "").strip()
-        if not admin_domain:
-            return jsonify({"error": "Admin domain is required so the bench is reachable in production."}), 400
-        if not _ADMIN_DOMAIN_RE.match(admin_domain):
-            return jsonify({"error": f"'{admin_domain}' is not a valid hostname."}), 400
-
-        new_dir = bench_root.parent / name
-        owner = host_owner(new_dir, admin_domain)
-        if owner:
-            return jsonify({"error": f"Admin domain '{admin_domain}' is already used by bench '{owner}'."}), 400
-        if normalize_host(admin_domain) == normalize_host(name):
-            return jsonify({"error": "Admin domain must differ from the bench/site name."}), 400
-
-        from pilot.core.domain_controller import DomainRouteProvider
-        from pilot.utils import matches_wildcard
-
-        patterns = DomainRouteProvider.wildcard_domains()
-        if patterns and not matches_wildcard(admin_domain, patterns):
-            return jsonify({"error": f"Admin domain must match one of: {', '.join(patterns)}."}), 400
-
-        # New benches from the UI come up plain HTTP; the user enables HTTPS
-        # later from Settings (or the wizard). Never inherit a sibling's TLS here.
-        admin_tls = bool(data.get("admin_tls", False))
-
-        try:
-            NewCommand(new_dir, name, process_manager=process_manager,
-                       admin_domain=admin_domain, admin_tls=admin_tls, db_type=db_type).run()
-        except BenchError as exc:
-            return jsonify({"error": str(exc)}), 400
-
-        new_toml = BenchTomlStore.for_bench(new_dir).read_raw()
-        new_port = new_toml["admin"]["port"]
-
-        cli_root = _cli_root()
-        admin = new_toml.get("admin", {})
-
-        # A production parent brings up the new bench's OWN admin service (socket-
-        # activated, self-managing) and routes its domain to it. The admin serves
-        # the setup wizard until the bench is initialized; the user then runs
-        # `setup production` from it, which starts the workload. No standalone
-        # wizard server — the bench's admin handles its own lifecycle.
-        if _current_is_production():
-            try:
-                from pilot.config.bench_config import BenchConfig
-                from pilot.core.bench import Bench
-                from pilot.managers.nginx_manager import NginxManager
-
-                bench = Bench(BenchTomlStore.for_bench(new_dir).read(), new_dir)
-                # Register the admin domain with the domain provider (if any) before
-                # routing it, so it resolves to this server — the wizard is reached
-                # at this domain. The wizard's later `setup production` sees the
-                # domain unchanged and won't re-register it.
-                DomainRouteProvider(bench).register(admin_domain, admin_domain)
-                # Not deployed yet (production.enabled is false at this point), so
-                # pick the manager by the configured process_manager rather than
-                # via the factory, which gates on enabled.
-                configured_pm = bench.config.production.process_manager
-                if configured_pm == "systemd":
-                    from pilot.managers.process_managers.systemd import SystemdProcessManager as PM
-                elif configured_pm == "openrc":
-                    from pilot.managers.process_managers.openrc import OpenRCProcessManager as PM
-                else:
-                    from pilot.managers.process_managers.supervisor import SupervisorProcessManager as PM
-                PM(bench).start_admin()
-                nginx = NginxManager(bench)
-                nginx.generate_config()
-                nginx.install_config()
-                nginx.reload()
-                # The admin now runs under the chosen process manager, so record
-                # the bench as production — otherwise `bench status`/`stop` fall
-                # back to the foreground (Procfile) manager and misreport it. The
-                # workload simply stays stopped until the user finishes setup.
-                _persist_toml(new_dir, {"production": {"enabled": True}})
-                # The wizard is reached over the scheme nginx serves *now* — https
-                # only once the cert is actually in place, else http (TLS is set up
-                # later). Report it so the client never redirects to a scheme that
-                # isn't listening yet.
-                serves_https = bool(bench.config.admin.tls and nginx.admin_cert_exists())
-                # The IP the domain's A record should point at, so the browser can
-                # confirm (via DoH) that DNS has propagated to it specifically.
-                server_ip = DomainRouteProvider._server_ip()
-            except Exception as exc:
-                return jsonify({"error": f"Failed to bring up the new bench: {exc}"}), 500
-            return jsonify({"name": name, "port": new_port, "wizard_at_domain": True,
-                            "domain": admin.get("domain", ""),
-                            "scheme": "https" if serves_https else "http",
-                            "server_ip": server_ip})
-
-        # Dev parent (no process manager): run a standalone wizard server on the
-        # bench's admin port and reach it on this host. Strip WERKZEUG_* so a
-        # dev-mode reloader's stale socket fd isn't inherited; strip BENCH_ADMIN_*
-        # so the admin's idle-timeout/root don't leak in.
-        spawn_env = {
-            k: v for k, v in os.environ.items()
-            if not k.startswith("WERKZEUG_") and not k.startswith("BENCH_ADMIN_")
-        }
-        spawn_env["PYTHONPATH"] = str(cli_root)
-        subprocess.Popen(
-            [str(cli_root / ".admin-venv" / "bin" / "python"), "-m", "admin.backend.server",
-             "--bench-root", str(new_dir), "--port", str(new_port), "--timeout", "7200", "--wizard"],
-            cwd=str(cli_root), env=spawn_env,
-            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True,
-        )
-        return jsonify({"name": name, "port": new_port, "wizard_at_domain": False,
-                        "domain": admin.get("domain", "")})
-
-    def _nginx_http_port() -> int:
-        # Shared host: one nginx serves every bench on the same http_port.
-        try:
-            return int(BenchTomlStore.for_bench(bench_root).read_raw().get("nginx", {}).get("http_port", 80))
-        except Exception:
-            return 80
-
-    def _wizard_responds(domain: str, scheme: str = "http") -> bool:
-        """Readiness for a production bench's wizard: nginx routes the domain to the
-        admin and the admin answers. Probed over loopback with a Host header, so no
-        DNS (and no stale DNS cache) is involved — DNS propagation to the browser is
-        the client's concern. /api/ping is unauthenticated and always 200 over http;
-        for an https bench :80 instead redirects to https, and that redirect only
-        exists once the cert is in place — so it is itself the readiness signal."""
-        conn = http.client.HTTPConnection("127.0.0.1", _nginx_http_port(), timeout=3)
-        try:
-            conn.request("GET", "/api/ping", headers={"Host": domain})
-            status = conn.getresponse().status
-            return status == 200 or (scheme == "https" and status in (301, 308))
-        except OSError:
-            return False
-        finally:
-            conn.close()
-
-    def _current_is_production() -> bool:
-        # Read the flag straight from toml (no full validation) so a slightly
-        # incomplete current config can't block creating a new bench.
-        try:
-            prod = BenchTomlStore.for_bench(bench_root).read_raw().get("production", {})
-            pm = str(prod.get("process_manager", "")).lower()
-            return bool(prod.get("enabled", pm not in ("", "none")))
-        except Exception:
-            return False
-
-    @app.route("/api/benches/ready")
-    def api_benches_ready():
-        # A production bench is reached at its admin domain: ready once the wizard
-        # actually answers there (DNS propagated, nginx routing, admin up).
-        domain = (request.args.get("domain") or "").strip()
-        if domain:
-            scheme = (request.args.get("scheme") or "http").strip()
-            return jsonify({"ready": _wizard_responds(domain, scheme)})
-        try:
-            port = int(request.args.get("port", ""))
-        except ValueError:
-            return jsonify({"ready": False}), 400
-        try:
-            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
-                pass
-            return jsonify({"ready": True})
-        except OSError:
-            return jsonify({"ready": False})
-
     app.register_blueprint(setup_bp, url_prefix="/api/setup")
     app.register_blueprint(dashboard_bp, url_prefix="/api")
     app.register_blueprint(apps_bp, url_prefix="/api/apps")
+    app.register_blueprint(benches_bp, url_prefix="/api/benches")
     app.register_blueprint(sites_bp, url_prefix="/api/sites")
     app.register_blueprint(processes_bp, url_prefix="/api/processes")
     app.register_blueprint(logs_bp, url_prefix="/api/logs")

--- a/admin/backend/auth.py
+++ b/admin/backend/auth.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import functools
+
+from flask import g, jsonify
+
+
+def require_scope(site):
+    """Allow or reject the request based on the JWT ``scope`` claim."""
+    from pilot.commands.generate_session import has_scope
+
+    if callable(site):
+        resolve = site
+    else:
+        def resolve(kwargs):
+            return site
+
+    def decorator(view):
+        @functools.wraps(view)
+        def wrapper(*args, **kwargs):
+            claims = getattr(g, "jwt_claims", None)
+            if not has_scope(claims, resolve(kwargs)):
+                return jsonify({"error": "Not authorized for this site"}), 403
+            return view(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def current_site_scope() -> str | None:
+    """Return the ``site`` claim from the current JWT, or None."""
+    claims = getattr(g, "jwt_claims", None)
+    if not claims:
+        return None
+    return claims.get("site")

--- a/admin/backend/bench_helpers.py
+++ b/admin/backend/bench_helpers.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import http.client
+import socket
+from pathlib import Path
+
+from pilot.config.bench_config import BenchConfig
+from pilot.config.toml_store import BenchTomlStore
+
+
+def port_open(port: int) -> bool:
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+            return True
+    except OSError:
+        return False
+
+
+def workload_running(bench_dir: Path, toml_path: Path) -> bool | None:
+    """Whether a production bench's workload is currently running, or None if unknown."""
+    from pilot.core.bench import Bench
+    from pilot.managers.process_manager import ProcessManager
+
+    try:
+        bench = Bench(BenchTomlStore(toml_path).read(), bench_dir)
+        return ProcessManager.for_bench(bench).is_running()
+    except Exception:
+        return None
+
+
+def admin_running(bench_dir: Path, toml_path: Path) -> bool | None:
+    """Whether a production bench's admin control plane is up, or None if unknown."""
+    from pilot.core.bench import Bench
+    from pilot.managers.process_manager import ProcessManager
+
+    try:
+        bench = Bench(BenchConfig.from_file(toml_path), bench_dir)
+        return ProcessManager.for_bench(bench).is_admin_running()
+    except Exception:
+        return None
+
+
+def admin_cert_exists(bench_dir: Path, toml_path: Path) -> bool:
+    """Whether the admin domain's TLS cert is in place."""
+    from pilot.core.bench import Bench
+    from pilot.managers.nginx_manager import NginxManager
+
+    try:
+        bench = Bench(BenchTomlStore(toml_path).read(), bench_dir)
+        return NginxManager(bench).admin_cert_exists()
+    except Exception:
+        return False
+
+
+def site_count(bench_dir: Path) -> int:
+    """Number of sites in a bench."""
+    sites_dir = bench_dir / "sites"
+    if not sites_dir.is_dir():
+        return 0
+    return sum(1 for d in sites_dir.iterdir() if d.is_dir() and (d / "site_config.json").exists())
+
+
+def persist_toml(bench_dir: Path, updates: dict) -> None:
+    """Merge ``updates`` into a bench's bench.toml in place."""
+    store = BenchTomlStore.for_bench(bench_dir)
+    data = store.read_raw()
+    for section, values in updates.items():
+        data.setdefault(section, {}).update(values)
+    store.write_raw(data)
+
+
+def nginx_http_port(bench_root: Path) -> int:
+    try:
+        return int(BenchTomlStore.for_bench(bench_root).read_raw().get("nginx", {}).get("http_port", 80))
+    except Exception:
+        return 80
+
+
+def wizard_responds(bench_root: Path, domain: str, scheme: str = "http") -> bool:
+    """Whether a production bench's wizard answers at its admin domain."""
+    conn = http.client.HTTPConnection("127.0.0.1", nginx_http_port(bench_root), timeout=3)
+    try:
+        conn.request("GET", "/api/ping", headers={"Host": domain})
+        status = conn.getresponse().status
+        return status == 200 or (scheme == "https" and status in (301, 308))
+    except OSError:
+        return False
+    finally:
+        conn.close()
+
+
+def current_is_production(bench_root: Path) -> bool:
+    try:
+        prod = BenchTomlStore.for_bench(bench_root).read_raw().get("production", {})
+        pm = str(prod.get("process_manager", "")).lower()
+        return bool(prod.get("enabled", pm not in ("", "none")))
+    except Exception:
+        return False

--- a/admin/backend/rate_limit.py
+++ b/admin/backend/rate_limit.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import functools
+import threading
+import time
+
+from flask import jsonify, request
+
+
+class SlidingWindow:
+    """In-memory sliding-window request counter, safe for the admin's single gunicorn worker."""
+
+    def __init__(self, max_hits: int, window: int) -> None:
+        self._max = max_hits
+        self._window = window
+        self._hits: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+
+    def allow(self, key: str) -> bool:
+        now = time.monotonic()
+        with self._lock:
+            recent = [t for t in self._hits.get(key, []) if now - t < self._window]
+            if len(recent) >= self._max:
+                self._hits[key] = recent
+                return False
+            recent.append(now)
+            self._hits[key] = recent
+            return True
+
+
+class UsedTokens:
+    """Tracks consumed one-time sign-in token ids; entries self-expire."""
+
+    def __init__(self) -> None:
+        self._used: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def use(self, jti: str, exp: float) -> bool:
+        now = time.time()
+        with self._lock:
+            self._used = {j: e for j, e in self._used.items() if e > now}
+            if jti in self._used:
+                return False
+            self._used[jti] = exp
+            return True
+
+
+def _client_ip() -> str:
+    """Client IP from X-Real-IP (nginx) or direct peer."""
+    return request.headers.get("X-Real-IP") or request.remote_addr or "unknown"
+
+
+def rate_limit(attempts: int, seconds: int, user_ip: bool = True):
+    """Allow at most ``attempts`` calls per ``seconds``, returning HTTP 429 once exceeded."""
+
+    def decorator(view):
+        window = SlidingWindow(attempts, seconds)
+
+        @functools.wraps(view)
+        def wrapper(*args, **kwargs):
+            if not window.allow(_client_ip() if user_ip else "*"):
+                return jsonify({"ok": False, "error": "Too many attempts. Try again later."}), 429
+            return view(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/admin/backend/views/benches.py
+++ b/admin/backend/views/benches.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import os
+import re
+import socket
+import subprocess
+from pathlib import Path
+
+from flask import Blueprint, current_app, jsonify, request
+
+from admin.backend.bench_helpers import (
+    admin_cert_exists,
+    admin_running,
+    current_is_production,
+    persist_toml,
+    port_open,
+    site_count,
+    wizard_responds,
+    workload_running,
+)
+from pilot.commands.admin import _cli_root
+from pilot.commands.new import NewCommand
+from pilot.config.toml_store import BenchTomlStore
+from pilot.exceptions import BenchError
+
+benches_bp = Blueprint("benches", __name__)
+
+_NAME_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+_ADMIN_DOMAIN_RE = re.compile(
+    r"^(?=.{1,253}$)[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+)
+
+
+@benches_bp.route("/")
+def get_all():
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    benches_dir = bench_root.parent
+    benches = []
+    for bench_dir in sorted(benches_dir.iterdir()):
+        if not bench_dir.is_dir():
+            continue
+        toml_path = bench_dir / "bench.toml"
+        if not toml_path.exists():
+            continue
+        try:
+            config = BenchTomlStore(toml_path).read_raw()
+            admin = config.get("admin", {})
+            prod = config.get("production", {})
+            port = admin.get("port")
+            name = config.get("bench", {}).get("name", bench_dir.name)
+            if not port:
+                continue
+            pm = str(prod.get("process_manager", "")).lower()
+            pm = "" if pm in ("", "none") else ("supervisor" if pm == "supervisord" else pm)
+            production = bool(prod.get("enabled", pm != ""))
+            domain = admin.get("domain", "")
+            tls = bool(admin.get("tls", False))
+            reachable = port_open(port) or port_open(port + 1)
+            serves_https = tls and admin_cert_exists(bench_dir, toml_path)
+            scheme = "https" if serves_https else "http"
+            admin_url = f"{scheme}://{domain}" if production and domain else ""
+            workload = workload_running(bench_dir, toml_path) if production else None
+            admin = admin_running(bench_dir, toml_path) if production else None
+            benches.append({
+                "name": name,
+                "port": port,
+                "domain": domain,
+                "production": production,
+                "process_manager": pm or None,
+                "reachable": reachable,
+                "admin_url": admin_url,
+                "workload_running": workload,
+                "admin_running": admin,
+                "site_count": site_count(bench_dir),
+            })
+        except Exception:
+            continue
+    return jsonify(benches)
+
+
+@benches_bp.route("/<name>/actions/<action_name>", methods=["POST"])
+def run_action(name, action_name):
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    if action_name not in ("start", "stop", "restart"):
+        return jsonify({"ok": False, "error": f"Unknown action '{action_name}'."}), 400
+    if not _NAME_RE.match(name):
+        return jsonify({"ok": False, "error": "Invalid bench name."}), 400
+
+    target_dir = bench_root.parent / name
+    toml_path = target_dir / "bench.toml"
+    if not toml_path.exists():
+        return jsonify({"ok": False, "error": f"Bench '{name}' not found."}), 404
+
+    try:
+        target_config = BenchTomlStore(toml_path).read_raw()
+    except Exception as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 500
+    if not target_config.get("production", {}).get("enabled"):
+        return jsonify({"ok": False, "error": "Start/stop/restart from here is only supported for production benches."}), 400
+
+    cli_root = _cli_root()
+    try:
+        result = subprocess.run(
+            [str(cli_root / "bench"), "-b", name, action_name],
+            cwd=cli_root, capture_output=True, text=True, timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        return jsonify({"ok": False, "error": f"'{action_name}' timed out."}), 500
+    if result.returncode != 0:
+        return jsonify({"ok": False, "error": (result.stderr or result.stdout).strip()}), 500
+    return jsonify({"ok": True})
+
+
+@benches_bp.route("/<name>", methods=["DELETE"])
+def drop(name):
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    if not _NAME_RE.match(name):
+        return jsonify({"ok": False, "error": "Invalid bench name."}), 400
+
+    target_dir = bench_root.parent / name
+    toml_path = target_dir / "bench.toml"
+    if not toml_path.exists():
+        return jsonify({"ok": False, "error": f"Bench '{name}' not found."}), 404
+    if target_dir.resolve() == bench_root.resolve():
+        return jsonify({"ok": False, "error": "Can't drop the bench you're currently using."}), 400
+
+    sites = site_count(target_dir)
+    if sites:
+        return jsonify({"ok": False, "error": f"Bench '{name}' has {sites} site(s). Drop them first."}), 400
+
+    cli_root = _cli_root()
+    try:
+        result = subprocess.run(
+            [str(cli_root / "bench"), "--yes", "-b", name, "drop"],
+            cwd=cli_root, capture_output=True, text=True, timeout=180,
+        )
+    except subprocess.TimeoutExpired:
+        return jsonify({"ok": False, "error": "Drop timed out."}), 500
+    if result.returncode != 0:
+        return jsonify({"ok": False, "error": (result.stderr or result.stdout).strip()}), 500
+    return jsonify({"ok": True})
+
+
+@benches_bp.route("/wildcard-domains", methods=["GET"])
+def wildcard_domains():
+    """Wildcard domain suffixes new bench admin domains may be built from."""
+    from pilot.core.domain_controller import DomainRouteProvider
+    from pilot.utils import wildcard_suffix
+
+    try:
+        patterns = DomainRouteProvider.wildcard_domains()
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    return jsonify({"domains": [wildcard_suffix(p) for p in patterns]})
+
+
+@benches_bp.route("/new", methods=["POST"])
+def new():
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    from pilot.utils import host_owner, normalize_host
+
+    data = request.get_json(silent=True) or {}
+    name = (data.get("name") or "").strip()
+    if not name or not _NAME_RE.match(name):
+        return jsonify({"error": "Bench name must contain only letters, numbers, '-' and '_'"}), 400
+
+    from pilot.config.production_config import VALID_PROCESS_MANAGERS
+    from pilot.platform import is_alpine
+
+    process_manager = (data.get("process_manager") or "").strip().lower()
+    if process_manager == "supervisord":
+        process_manager = "supervisor"
+    if process_manager not in VALID_PROCESS_MANAGERS:
+        return jsonify({"error": f"Choose a process manager: {', '.join(VALID_PROCESS_MANAGERS)}."}), 400
+    if is_alpine() and process_manager == "systemd":
+        process_manager = "openrc"
+
+    db_type = (data.get("db_type") or "mariadb").strip()
+    if db_type not in ("mariadb", "postgres"):
+        return jsonify({"error": "Database must be 'mariadb' or 'postgres'."}), 400
+
+    admin_domain = (data.get("admin_domain") or "").strip()
+    if not admin_domain:
+        return jsonify({"error": "Admin domain is required so the bench is reachable in production."}), 400
+    if not _ADMIN_DOMAIN_RE.match(admin_domain):
+        return jsonify({"error": f"'{admin_domain}' is not a valid hostname."}), 400
+
+    new_dir = bench_root.parent / name
+    owner = host_owner(new_dir, admin_domain)
+    if owner:
+        return jsonify({"error": f"Admin domain '{admin_domain}' is already used by bench '{owner}'."}), 400
+    if normalize_host(admin_domain) == normalize_host(name):
+        return jsonify({"error": "Admin domain must differ from the bench/site name."}), 400
+
+    from pilot.core.domain_controller import DomainRouteProvider
+    from pilot.utils import matches_wildcard
+
+    patterns = DomainRouteProvider.wildcard_domains()
+    if patterns and not matches_wildcard(admin_domain, patterns):
+        return jsonify({"error": f"Admin domain must match one of: {', '.join(patterns)}."}), 400
+
+    admin_tls = bool(data.get("admin_tls", False))
+
+    try:
+        NewCommand(new_dir, name, process_manager=process_manager,
+                   admin_domain=admin_domain, admin_tls=admin_tls, db_type=db_type).run()
+    except BenchError as exc:
+        return jsonify({"error": str(exc)}), 400
+
+    new_toml = BenchTomlStore.for_bench(new_dir).read_raw()
+    new_port = new_toml["admin"]["port"]
+
+    cli_root = _cli_root()
+    admin_cfg = new_toml.get("admin", {})
+
+    if current_is_production(bench_root):
+        try:
+            from pilot.config.bench_config import BenchConfig
+            from pilot.core.bench import Bench
+            from pilot.managers.nginx_manager import NginxManager
+
+            bench = Bench(BenchTomlStore.for_bench(new_dir).read(), new_dir)
+            DomainRouteProvider(bench).register(admin_domain, admin_domain)
+            configured_pm = bench.config.production.process_manager
+            if configured_pm == "systemd":
+                from pilot.managers.process_managers.systemd import SystemdProcessManager as PM
+            elif configured_pm == "openrc":
+                from pilot.managers.process_managers.openrc import OpenRCProcessManager as PM
+            else:
+                from pilot.managers.process_managers.supervisor import SupervisorProcessManager as PM
+            PM(bench).start_admin()
+            nginx = NginxManager(bench)
+            nginx.generate_config()
+            nginx.install_config()
+            nginx.reload()
+            persist_toml(new_dir, {"production": {"enabled": True}})
+            serves_https = bool(bench.config.admin.tls and nginx.admin_cert_exists())
+            server_ip = DomainRouteProvider._server_ip()
+        except Exception as exc:
+            return jsonify({"error": f"Failed to bring up the new bench: {exc}"}), 500
+        return jsonify({"name": name, "port": new_port, "wizard_at_domain": True,
+                        "domain": admin_cfg.get("domain", ""),
+                        "scheme": "https" if serves_https else "http",
+                        "server_ip": server_ip})
+
+    spawn_env = {
+        k: v for k, v in os.environ.items()
+        if not k.startswith("WERKZEUG_") and not k.startswith("BENCH_ADMIN_")
+    }
+    spawn_env["PYTHONPATH"] = str(cli_root)
+    subprocess.Popen(
+        [str(cli_root / ".admin-venv" / "bin" / "python"), "-m", "admin.backend.server",
+         "--bench-root", str(new_dir), "--port", str(new_port), "--timeout", "7200", "--wizard"],
+        cwd=str(cli_root), env=spawn_env,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, start_new_session=True,
+    )
+    return jsonify({"name": name, "port": new_port, "wizard_at_domain": False,
+                    "domain": admin_cfg.get("domain", "")})
+
+
+@benches_bp.route("/ready")
+def is_ready():
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    domain = (request.args.get("domain") or "").strip()
+    if domain:
+        scheme = (request.args.get("scheme") or "http").strip()
+        return jsonify({"ready": wizard_responds(bench_root, domain, scheme)})
+    try:
+        port = int(request.args.get("port", ""))
+    except ValueError:
+        return jsonify({"ready": False}), 400
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+            pass
+        return jsonify({"ready": True})
+    except OSError:
+        return jsonify({"ready": False})

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -21,7 +21,7 @@ sites_bp = Blueprint("sites", __name__)
 
 # Confidential / system-managed site_config keys. These are never sent to the
 # admin UI and cannot be edited through it — they are preserved as-is on disk.
-PROTECTED_CONFIG_KEYS = frozenset({"db_name", "db_password", "db_socket", "db_type", "db_user", "installed_apps", "ssl", "domains", "host_name"})
+PROTECTED_CONFIG_KEYS = frozenset({"db_name", "db_password", "db_socket", "db_type", "db_user", "installed_apps", "ssl", "domains", "host_name", "pilot_endpoint", "pilot_auth_token"})
 
 
 @sites_bp.route("/")

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -7,12 +7,15 @@ from pathlib import Path
 
 from flask import Blueprint, current_app, jsonify, request, send_file
 
+from admin.backend.auth import require_scope
 from admin.backend.tasks.callbacks import new_site_failure_callback, ssl_setup_failure_callback
 from ..validators import validate_cron_expression, validate_site_name
 from admin.backend.tasks.manager.task_runner import TaskRunner
 
 from ..readers.app_reader import AppReader
 from ..readers.site_reader import SiteReader
+
+site_name = lambda kw: kw["name"]
 
 sites_bp = Blueprint("sites", __name__)
 
@@ -38,6 +41,7 @@ def index():
 
 
 @sites_bp.route("/<name>")
+@require_scope(site_name)
 def detail(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     try:
@@ -71,6 +75,7 @@ def detail(name: str):
 
 
 @sites_bp.route("/<name>/apps")
+@require_scope(site_name)
 def site_apps(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     try:
@@ -184,6 +189,7 @@ def create_from_upload():
 
 
 @sites_bp.route("/<name>/drop", methods=["POST"])
+@require_scope(site_name)
 def drop_site(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     try:
@@ -194,6 +200,7 @@ def drop_site(name: str):
 
 
 @sites_bp.route("/<name>/reinstall", methods=["POST"])
+@require_scope(site_name)
 def reinstall_site(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     if not (bench_root / "sites" / name / "site_config.json").exists():
@@ -208,6 +215,7 @@ def reinstall_site(name: str):
 
 
 @sites_bp.route("/<name>/force-drop", methods=["POST"])
+@require_scope(site_name)
 def force_drop_site(name: str):
     import shutil
 
@@ -223,6 +231,7 @@ def force_drop_site(name: str):
 
 
 @sites_bp.route("/<name>/backup", methods=["POST"])
+@require_scope(site_name)
 def backup_site(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     try:
@@ -233,6 +242,7 @@ def backup_site(name: str):
 
 
 @sites_bp.route("/<name>/install-app", methods=["POST"])
+@require_scope(site_name)
 def install_app(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     data = request.get_json(silent=True) or {}
@@ -247,6 +257,7 @@ def install_app(name: str):
 
 
 @sites_bp.route("/<name>/get-and-install-app", methods=["POST"])
+@require_scope(site_name)
 def get_and_install_app(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     data = request.get_json(silent=True) or {}
@@ -275,6 +286,7 @@ def get_and_install_app(name: str):
 
 
 @sites_bp.route("/<name>/uninstall-app", methods=["POST"])
+@require_scope(site_name)
 def uninstall_app(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     data = request.get_json(silent=True) or {}
@@ -289,6 +301,7 @@ def uninstall_app(name: str):
 
 
 @sites_bp.route("/<name>/force-uninstall-app", methods=["POST"])
+@require_scope(site_name)
 def force_uninstall_app(name: str):
     import os
     import subprocess as _sp
@@ -339,6 +352,7 @@ def force_uninstall_app(name: str):
 
 
 @sites_bp.route("/<name>/login", methods=["POST"])
+@require_scope(site_name)
 def login_to_site(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     if not (bench_root / "sites" / name / "site_config.json").exists():
@@ -408,6 +422,7 @@ def login_to_site(name: str):
 
 
 @sites_bp.route("/<name>/enable-ssl", methods=["POST"])
+@require_scope(site_name)
 def enable_ssl(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     config_path = bench_root / "sites" / name / "site_config.json"
@@ -481,6 +496,7 @@ def _apply_domains(bench_root: Path, name: str) -> str:
 
 
 @sites_bp.route("/<name>/domains", methods=["GET"])
+@require_scope(site_name)
 def list_domains(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     try:
@@ -491,6 +507,7 @@ def list_domains(name: str):
 
 
 @sites_bp.route("/<name>/domains/dns-records", methods=["POST"])
+@require_scope(site_name)
 def domain_dns_records(name: str):
     """Step 1 of attaching a domain: validate it, return CNAME/A record options."""
     bench_root = Path(current_app.config["BENCH_ROOT"])
@@ -505,6 +522,7 @@ def domain_dns_records(name: str):
 
 
 @sites_bp.route("/<name>/domains", methods=["POST"])
+@require_scope(site_name)
 def add_domain(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     domain = ((request.get_json(silent=True) or {}).get("domain") or "").strip()
@@ -518,6 +536,7 @@ def add_domain(name: str):
 
 
 @sites_bp.route("/<name>/domains", methods=["DELETE"])
+@require_scope(site_name)
 def remove_domain(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     domain = ((request.get_json(silent=True) or {}).get("domain") or "").strip()
@@ -529,6 +548,7 @@ def remove_domain(name: str):
 
 
 @sites_bp.route("/<name>/domains/primary", methods=["POST"])
+@require_scope(site_name)
 def set_primary_domain(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     domain = ((request.get_json(silent=True) or {}).get("domain") or "").strip() or None
@@ -541,6 +561,7 @@ def set_primary_domain(name: str):
 
 
 @sites_bp.route("/<name>/config", methods=["PATCH"])
+@require_scope(site_name)
 def update_config(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     config_path = bench_root / "sites" / name / "site_config.json"
@@ -566,6 +587,7 @@ def update_config(name: str):
 
 
 @sites_bp.route("/<name>/backups")
+@require_scope(site_name)
 def list_backups(name: str):
     from ..readers.backup_reader import BackupReader
 
@@ -595,6 +617,7 @@ def list_backups(name: str):
 
 
 @sites_bp.route("/<name>/backups/download")
+@require_scope(site_name)
 def download_backup(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
     filename = request.args.get("filename", "")
@@ -610,6 +633,7 @@ def download_backup(name: str):
 
 
 @sites_bp.route("/<name>/backup-schedule", methods=["GET"])
+@require_scope(site_name)
 def get_backup_schedule(name: str):
     from ..cron_manager import CronManager
 
@@ -622,6 +646,7 @@ def get_backup_schedule(name: str):
 
 
 @sites_bp.route("/<name>/backup-schedule", methods=["POST"])
+@require_scope(site_name)
 def set_backup_schedule(name: str):
     from ..cron_manager import CronManager
 
@@ -639,6 +664,7 @@ def set_backup_schedule(name: str):
 
 
 @sites_bp.route("/<name>/backup-schedule", methods=["DELETE"])
+@require_scope(site_name)
 def delete_backup_schedule(name: str):
     from ..cron_manager import CronManager
 

--- a/admin/frontend/src/components/BenchSwitcherDialog.vue
+++ b/admin/frontend/src/components/BenchSwitcherDialog.vue
@@ -147,7 +147,7 @@ async function control(bench, action) {
   controlLoading.value = bench.name
   controlError.value = ''
   try {
-    const res = await fetch(`/api/benches/${bench.name}/${action}`, { method: 'POST' })
+    const res = await fetch(`/api/benches/${bench.name}/actions/${action}`, { method: 'POST' })
     const d = await res.json()
     if (!d.ok) { controlError.value = d.error; return }
     await loadBenches()

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -520,10 +520,46 @@ Views catch `ConfigError`, `FileNotFoundError`, and database connection errors a
 - Sessions are Flask cookie-based. The session key is a random 32-byte hex string generated at startup — sessions are invalidated on process restart.
 - `bench generate-admin-session` issues a 5-minute, single-use `?sid=` token that the frontend exchanges for a 1-day `HttpOnly` session cookie — an alternative to password login, signed with `admin.jwt_secret` in `bench.toml`. See [docs/commands.md](commands.md#bench-generate-admin-session).
 - `bench issue-site-token` issues a scoped JWT (`scope: "site"`) for programmatic site-to-bench API calls. The token is restricted to the named site and cannot access other sites or bench-level endpoints. Use it as `Authorization: Bearer <token>`. See [docs/commands.md](commands.md#bench-issue-site-token).
+
 - `LogReader.read_tail` and `stream_tail` validate that the requested filename contains no path separators and resolves to a file inside `logs/`. Any traversal attempt returns HTTP 400.
 - Command execution uses `TaskRunner._build_argv`, which only accepts whitelisted commands. No user-supplied string is passed to a shell.
 - `task_id` values are validated against `^\d{8}-\d{6}-[0-9a-f]{6}$` before being used as directory names.
 - Root MariaDB credentials come from `bench.toml` — the admin must be run by a user who can read that file.
+
+---
+
+### Site-to-bench API
+
+When a site is created through the admin UI, the bench automatically writes two keys into the site's `site_config.json`:
+
+- `pilot_endpoint` — the admin URL of the bench (e.g. `https://admin.example.com`)
+- `pilot_auth_token` — a scoped JWT (`scope: "site"`) valid for 365 days, restricted to that site
+
+The site can use these to call the bench admin API directly — no user login required. For example, from a Frappe hook or background job:
+
+```python
+import frappe
+
+endpoint = frappe.get_site_config().get("pilot_endpoint")
+token = frappe.get_site_config().get("pilot_auth_token")
+headers = {"Authorization": f"Bearer {token}"}
+
+# Install an app on this site
+requests.post(f"{endpoint}/api/sites/{frappe.local.site}/install-app",
+              json={"app_name": "my-app"}, headers=headers)
+
+# Enable SSL
+requests.post(f"{endpoint}/api/sites/{frappe.local.site}/enable-ssl",
+              json={}, headers=headers)
+
+# Set backup schedule
+requests.post(f"{endpoint}/api/sites/{frappe.local.site}/backup-schedule",
+              json={"cron": "0 2 * * *"}, headers=headers)
+```
+
+The token is scoped — it can only act on its own site. Any attempt to access a different site or bench-level endpoints (e.g. `/api/benches`) returns 403.
+
+Both keys are in `PROTECTED_CONFIG_KEYS` — they are never exposed in the admin UI and are preserved across config edits.
 
 ---
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -519,6 +519,7 @@ Views catch `ConfigError`, `FileNotFoundError`, and database connection errors a
 - **Password is mandatory.** The admin refuses all requests with HTTP 503 if `[admin] password` is not set in `bench.toml`. There is no way to bypass authentication.
 - Sessions are Flask cookie-based. The session key is a random 32-byte hex string generated at startup — sessions are invalidated on process restart.
 - `bench generate-admin-session` issues a 5-minute, single-use `?sid=` token that the frontend exchanges for a 1-day `HttpOnly` session cookie — an alternative to password login, signed with `admin.jwt_secret` in `bench.toml`. See [docs/commands.md](commands.md#bench-generate-admin-session).
+- `bench issue-site-token` issues a scoped JWT (`scope: "site"`) for programmatic site-to-bench API calls. The token is restricted to the named site and cannot access other sites or bench-level endpoints. Use it as `Authorization: Bearer <token>`. See [docs/commands.md](commands.md#bench-issue-site-token).
 - `LogReader.read_tail` and `stream_tail` validate that the requested filename contains no path separators and resolves to a file inside `logs/`. Any traversal attempt returns HTTP 400.
 - Command execution uses `TaskRunner._build_argv`, which only accepts whitelisted commands. No user-supplied string is passed to a shell.
 - `task_id` values are validated against `^\d{8}-\d{6}-[0-9a-f]{6}$` before being used as directory names.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -502,6 +502,25 @@ Open the `--full-path` URL in a browser within **5 minutes**: the frontend excha
 
 ---
 
+## `bench issue-site-token`
+
+Issues a scoped JWT for programmatic site-to-bench API calls. The token carries `scope: "site"` and is restricted to the named site — it cannot access other sites or bench-level endpoints.
+
+```bash
+bench -b bench1 issue-site-token "site-name"
+bench -b bench1 issue-site-token "site-name" --ttl 3600   # custom TTL in seconds (default: 86400)
+```
+
+Use the token as a Bearer token in the `Authorization` header:
+
+```bash
+curl -H "Authorization: Bearer <token>" https://admin.example.com/api/sites/site-name
+```
+
+Requires `admin.jwt_secret` to be set in `bench.toml`. See [docs/admin.md](admin.md) for scoped authentication details.
+
+---
+
 ## `bench set-admin-password`
 
 Sets the admin UI password in `bench.toml`. With `--password` omitted it prompts twice (securely, no echo) and confirms they match; the password is never printed or logged.

--- a/pilot/commands/generate_session.py
+++ b/pilot/commands/generate_session.py
@@ -33,13 +33,22 @@ def _sign(signing_input: str, secret: str) -> bytes:
     return hmac.new(secret.encode(), signing_input.encode(), hashlib.sha256).digest()
 
 
-def issue_token(secret: str, ttl: int = DEFAULT_TTL, issued_at: float | None = None, jti: str | None = None) -> str:
+def issue_token(
+    secret: str,
+    ttl: int = DEFAULT_TTL,
+    issued_at: float | None = None,
+    jti: str | None = None,
+    scope: str = "bench",
+    site: str | None = None,
+) -> str:
     if not secret:
         raise ValueError("JWT secret is not configured.")
     now = int(issued_at or time.time())
-    payload = {"sub": "admin", "iat": now, "exp": now + ttl}
+    payload = {"sub": "admin", "iat": now, "exp": now + ttl, "scope": scope}
     if jti:
         payload["jti"] = jti
+    if site:
+        payload["site"] = site
     body = ".".join(
         _b64(json.dumps(part, separators=(",", ":")).encode()) for part in (_HEADER, payload)
     )
@@ -66,9 +75,27 @@ def verify_token(token: str, secret: str) -> bool:
     return decode_token(token, secret) is not None
 
 
+def has_scope(claims: dict | None, site: str) -> bool:
+    if not claims:
+        return False
+    token_scope = claims.get("scope")
+    if token_scope == "bench":
+        return True
+    if token_scope == "site":
+        return claims.get("site") == site
+    return False
+
+
 def issue_login_token(secret: str) -> str:
     """A short-lived, single-use token for the ?sid= sign-in link."""
-    return issue_token(secret, ttl=LOGIN_TTL, jti=secrets.token_urlsafe(8))
+    return issue_token(secret, ttl=LOGIN_TTL, jti=secrets.token_urlsafe(8), scope="bench")
+
+
+def issue_site_token(secret: str, site: str, ttl: int = DEFAULT_TTL) -> str:
+    """A token scoped to a single site for site-to-bench API calls."""
+    if not site:
+        raise ValueError("Site name is required.")
+    return issue_token(secret, ttl=ttl, scope="site", site=site)
 
 
 def ensure_jwt_secret(toml_path) -> str:

--- a/pilot/commands/generate_session.py
+++ b/pilot/commands/generate_session.py
@@ -144,3 +144,28 @@ class GenerateSessionCommand(Command):
         secret = ensure_jwt_secret(self.bench.path / "bench.toml")
         self.bench.config.admin.jwt_secret = secret
         return secret
+
+
+class IssueSiteTokenCommand(Command):
+    name = "issue-site-token"
+    help = "Issue a scoped JWT for site-to-bench API calls."
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("site", help="Site name to scope the token to.")
+        parser.add_argument("--ttl", type=int, default=DEFAULT_TTL,
+                            help="Token TTL in seconds (default: 86400).")
+
+    @classmethod
+    def from_args(cls, args, bench):
+        return cls(bench, args.site, ttl=args.ttl)
+
+    def __init__(self, bench: "Bench", site: str, ttl: int = DEFAULT_TTL) -> None:
+        self.bench = bench
+        self.site = site
+        self.ttl = ttl
+
+    def run(self) -> None:
+        secret = ensure_jwt_secret(self.bench.path / "bench.toml")
+        self.bench.config.admin.jwt_secret = secret
+        print(issue_site_token(secret, self.site, ttl=self.ttl))

--- a/pilot/commands/new_site.py
+++ b/pilot/commands/new_site.py
@@ -49,6 +49,7 @@ class NewSiteCommand(Command):
         print(f"Creating site '{self.name}'...")
         sys.stdout.flush()
         site.create()
+        self._write_pilot_communication_config()
         self.bench.write_common_site_config()
         print(f"\nSite '{self.name}' created successfully.")
         self.build_missing_assets()
@@ -65,6 +66,21 @@ class NewSiteCommand(Command):
         from pilot.core.domain_controller import DomainRouteProvider
 
         DomainRouteProvider(self.bench).register(self.name, self.name)
+
+    def _write_pilot_communication_config(self) -> None:
+        import json
+
+        from pilot.admin_url import admin_url
+        from pilot.commands.generate_session import ensure_jwt_secret, issue_site_token
+
+        config_path = self.bench.sites_path / self.name / "site_config.json"
+        if not config_path.exists():
+            return
+        config = json.loads(config_path.read_text())
+        secret = ensure_jwt_secret(self.bench.path / "bench.toml")
+        config["pilot_endpoint"] = admin_url(self.bench.config)
+        config["pilot_auth_token"] = issue_site_token(secret, self.name, ttl=365 * 24 * 3600)
+        config_path.write_text(json.dumps(config, indent=1))
 
     def build_missing_assets(self):
         from pilot.managers.python_env_manager import PythonEnvManager

--- a/tests/test_admin_app.py
+++ b/tests/test_admin_app.py
@@ -90,7 +90,7 @@ def test_api_benches_includes_production_metadata(tmp_path: Path) -> None:
             f'[production]\nenabled = true\nprocess_manager = "systemd"\n'
         )
         # https only once the cert is in place; pretend it is for this assertion.
-        with patch("admin.backend.app._admin_cert_exists", return_value=True):
+        with patch("admin.backend.views.benches.admin_cert_exists", return_value=True):
             resp = client.get("/api/benches/")
 
     entry = next(b for b in resp.get_json() if b["name"] == "prod-bench")
@@ -113,7 +113,7 @@ def test_api_benches_admin_url_is_http_until_cert_exists(tmp_path: Path) -> None
             f'[admin]\nport = {live_port}\ndomain = "admin-prod.example.com"\ntls = true\n\n'
             f'[production]\nenabled = true\nprocess_manager = "systemd"\n'
         )
-        with patch("admin.backend.app._admin_cert_exists", return_value=False):
+        with patch("admin.backend.views.benches.admin_cert_exists", return_value=False):
             resp = client.get("/api/benches/")
 
     entry = next(b for b in resp.get_json() if b["name"] == "prod-bench")
@@ -379,7 +379,7 @@ def test_api_benches_ready_false_when_nginx_down_at_domain(tmp_path: Path) -> No
     assert resp.get_json() == {"ready": False}
 
 
-# ── POST /api/benches/<name>/<action> ────────────────────────────────────────
+# ── POST /api/benches/<name>/actions/<action_name> ────────────────────────────
 
 
 def _write_prod_bench_toml(bench_dir: Path, name: str) -> None:
@@ -395,7 +395,7 @@ def test_api_benches_control_rejects_unknown_action(tmp_path: Path) -> None:
     client = _client(benches_dir / "current")
     _write_prod_bench_toml(benches_dir / "prod-bench", "prod-bench")
 
-    resp = client.post("/api/benches/prod-bench/wiggle")
+    resp = client.post("/api/benches/prod-bench/actions/wiggle")
 
     assert resp.status_code == 400
     assert resp.get_json()["ok"] is False
@@ -404,7 +404,7 @@ def test_api_benches_control_rejects_unknown_action(tmp_path: Path) -> None:
 def test_api_benches_control_rejects_unknown_bench(tmp_path: Path) -> None:
     client = _client(tmp_path / "benches" / "current")
 
-    resp = client.post("/api/benches/does-not-exist/start")
+    resp = client.post("/api/benches/does-not-exist/actions/start")
 
     assert resp.status_code == 404
     assert resp.get_json()["ok"] is False
@@ -415,7 +415,7 @@ def test_api_benches_control_rejects_dev_bench(tmp_path: Path) -> None:
     client = _client(benches_dir / "current")
     _write_bench_toml(benches_dir / "dev-bench", "dev-bench")
 
-    resp = client.post("/api/benches/dev-bench/start")
+    resp = client.post("/api/benches/dev-bench/actions/start")
 
     assert resp.status_code == 400
     assert "production" in resp.get_json()["error"]
@@ -426,11 +426,11 @@ def test_api_benches_control_runs_pilot_and_reports_success(tmp_path: Path) -> N
     client = _client(benches_dir / "current")
     _write_prod_bench_toml(benches_dir / "prod-bench", "prod-bench")
 
-    with patch("admin.backend.app.subprocess.run") as mock_run:
+    with patch("admin.backend.views.benches.subprocess.run") as mock_run:
         mock_run.return_value.returncode = 0
         mock_run.return_value.stdout = ""
         mock_run.return_value.stderr = ""
-        resp = client.post("/api/benches/prod-bench/restart")
+        resp = client.post("/api/benches/prod-bench/actions/restart")
 
     assert resp.get_json() == {"ok": True}
     argv = mock_run.call_args.args[0]
@@ -442,11 +442,11 @@ def test_api_benches_control_reports_failure(tmp_path: Path) -> None:
     client = _client(benches_dir / "current")
     _write_prod_bench_toml(benches_dir / "prod-bench", "prod-bench")
 
-    with patch("admin.backend.app.subprocess.run") as mock_run:
+    with patch("admin.backend.views.benches.subprocess.run") as mock_run:
         mock_run.return_value.returncode = 1
         mock_run.return_value.stdout = ""
         mock_run.return_value.stderr = "boom"
-        resp = client.post("/api/benches/prod-bench/stop")
+        resp = client.post("/api/benches/prod-bench/actions/stop")
 
     assert resp.status_code == 500
     assert resp.get_json() == {"ok": False, "error": "boom"}
@@ -473,7 +473,7 @@ def test_api_benches_drop_rejects_bench_with_sites(tmp_path: Path) -> None:
     (bench_dir / "sites" / "a.localhost").mkdir(parents=True)
     (bench_dir / "sites" / "a.localhost" / "site_config.json").write_text("{}")
 
-    with patch("admin.backend.app.subprocess.run") as mock_run:
+    with patch("admin.backend.views.benches.subprocess.run") as mock_run:
         resp = client.delete("/api/benches/prod-bench")
 
     assert resp.status_code == 400
@@ -495,7 +495,7 @@ def test_api_benches_drop_runs_pilot(tmp_path: Path) -> None:
     client = _client(benches_dir / "current")
     _write_prod_bench_toml(benches_dir / "prod-bench", "prod-bench")
 
-    with patch("admin.backend.app.subprocess.run") as mock_run:
+    with patch("admin.backend.views.benches.subprocess.run") as mock_run:
         mock_run.return_value.returncode = 0
         mock_run.return_value.stdout = ""
         mock_run.return_value.stderr = ""

--- a/tests/test_admin_session.py
+++ b/tests/test_admin_session.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from pilot.commands.generate_session import decode_token, issue_login_token, issue_token, verify_token
+from pilot.commands.generate_session import decode_token, has_scope, issue_login_token, issue_site_token, issue_token, verify_token
 from pilot.config.bench_config import BenchConfig
 from pilot.config.bench_toml_builder import BenchTomlBuilder
 from pilot.core.bench import Bench
@@ -198,3 +198,223 @@ def test_setup_endpoint_open_before_password_set(tmp_path: Path) -> None:
     app = create_app(tmp_path)  # no bench.toml → first-time setup
     app.config["TESTING"] = True
     assert app.test_client().post("/api/setup/validate-mariadb", json={}).status_code != 401
+
+
+# ── scoped JWT ────────────────────────────────────────────────────────────────
+
+
+def test_issue_token_defaults_to_bench_scope() -> None:
+    claims = decode_token(issue_token("k3y"), "k3y")
+    assert claims["scope"] == "bench"
+    assert "site" not in claims
+
+
+def test_issue_token_with_site_scope() -> None:
+    claims = decode_token(issue_token("k3y", scope="site", site="example.com"), "k3y")
+    assert claims["scope"] == "site"
+    assert claims["site"] == "example.com"
+
+
+def test_has_scope_bench_token_allows_any_site() -> None:
+    claims = decode_token(issue_token("k3y"), "k3y")
+    assert has_scope(claims, "example.com")
+    assert has_scope(claims, "other.com")
+
+
+def test_has_scope_site_token_allows_matching_site() -> None:
+    claims = decode_token(issue_token("k3y", scope="site", site="example.com"), "k3y")
+    assert has_scope(claims, "example.com")
+
+
+def test_has_scope_site_token_rejects_different_site() -> None:
+    claims = decode_token(issue_token("k3y", scope="site", site="example.com"), "k3y")
+    assert not has_scope(claims, "other.com")
+
+
+def test_has_scope_none_claims_rejected() -> None:
+    assert not has_scope(None, "example.com")
+
+
+def test_issue_site_token_creates_scoped_token() -> None:
+    claims = decode_token(issue_site_token("k3y", "example.com"), "k3y")
+    assert claims["scope"] == "site"
+    assert claims["site"] == "example.com"
+
+
+def test_issue_site_token_requires_site() -> None:
+    with pytest.raises(ValueError):
+        issue_site_token("k3y", "")
+
+
+def test_issue_site_token_custom_ttl() -> None:
+    claims = decode_token(issue_site_token("k3y", "example.com", ttl=3600), "k3y")
+    assert claims["site"] == "example.com"
+    assert claims["exp"] - claims["iat"] == 3600
+
+
+def test_require_scope_allows_unscoped_token(tmp_path: Path) -> None:
+    from flask import jsonify
+    from admin.backend.app import create_app
+    from admin.backend.auth import require_scope
+
+    bench_root = tmp_path / "benches" / "current"
+    _initialized_bench(bench_root, "secret", "k3y")
+    app = create_app(bench_root)
+    app.config["TESTING"] = True
+
+    @app.route("/api/test-scoped")
+    @require_scope("example.com")
+    def scoped_view():
+        return jsonify({"ok": True})
+
+    client = app.test_client()
+    client.set_cookie("sid", issue_token("k3y"))
+    assert client.get("/api/test-scoped").status_code == 200
+
+
+def test_require_scope_allows_matching_scoped_token(tmp_path: Path) -> None:
+    from flask import jsonify
+    from admin.backend.app import create_app
+    from admin.backend.auth import require_scope
+
+    bench_root = tmp_path / "benches" / "current"
+    _initialized_bench(bench_root, "secret", "k3y")
+    app = create_app(bench_root)
+    app.config["TESTING"] = True
+
+    @app.route("/api/test-scoped")
+    @require_scope("example.com")
+    def scoped_view():
+        return jsonify({"ok": True})
+
+    client = app.test_client()
+    client.set_cookie("sid", issue_token("k3y", scope="site", site="example.com"))
+    assert client.get("/api/test-scoped").status_code == 200
+
+
+def test_require_scope_rejects_mismatched_scoped_token(tmp_path: Path) -> None:
+    from flask import jsonify
+    from admin.backend.app import create_app
+    from admin.backend.auth import require_scope
+
+    bench_root = tmp_path / "benches" / "current"
+    _initialized_bench(bench_root, "secret", "k3y")
+    app = create_app(bench_root)
+    app.config["TESTING"] = True
+
+    @app.route("/api/test-scoped")
+    @require_scope("example.com")
+    def scoped_view():
+        return jsonify({"ok": True})
+
+    client = app.test_client()
+    client.set_cookie("sid", issue_token("k3y", scope="site", site="other.com"))
+    assert client.get("/api/test-scoped").status_code == 403
+
+
+def test_current_site_scope_returns_site_from_claims(tmp_path: Path) -> None:
+    from flask import jsonify
+    from admin.backend.app import create_app
+    from admin.backend.auth import current_site_scope
+
+    bench_root = tmp_path / "benches" / "current"
+    _initialized_bench(bench_root, "secret", "k3y")
+    app = create_app(bench_root)
+    app.config["TESTING"] = True
+
+    @app.route("/api/test-scope")
+    def scope_view():
+        return jsonify({"site": current_site_scope()})
+
+    client = app.test_client()
+    client.set_cookie("sid", issue_token("k3y", scope="site", site="example.com"))
+    assert client.get("/api/test-scope").get_json()["site"] == "example.com"
+
+
+def test_current_site_scope_returns_none_for_unscoped(tmp_path: Path) -> None:
+    from flask import jsonify
+    from admin.backend.app import create_app
+    from admin.backend.auth import current_site_scope
+
+    bench_root = tmp_path / "benches" / "current"
+    _initialized_bench(bench_root, "secret", "k3y")
+    app = create_app(bench_root)
+    app.config["TESTING"] = True
+
+    @app.route("/api/test-scope")
+    def scope_view():
+        return jsonify({"site": current_site_scope()})
+
+    client = app.test_client()
+    client.set_cookie("sid", issue_token("k3y"))
+    assert client.get("/api/test-scope").get_json()["site"] is None
+
+
+def test_bearer_token_authenticates(tmp_path: Path) -> None:
+    client = _client(tmp_path)
+    token = issue_token("k3y")
+    resp = client.get("/api/benches/", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code != 401
+
+
+def test_bearer_token_with_site_scope(tmp_path: Path) -> None:
+    from flask import jsonify
+    from admin.backend.app import create_app
+    from admin.backend.auth import require_scope
+
+    bench_root = tmp_path / "benches" / "current"
+    _initialized_bench(bench_root, "secret", "k3y")
+    app = create_app(bench_root)
+    app.config["TESTING"] = True
+
+    @app.route("/api/test-scoped")
+    @require_scope("example.com")
+    def scoped_view():
+        return jsonify({"ok": True})
+
+    client = app.test_client()
+    token = issue_site_token("k3y", "example.com")
+    resp = client.get("/api/test-scoped", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+
+
+def test_bearer_token_wrong_site_rejected(tmp_path: Path) -> None:
+    from flask import jsonify
+    from admin.backend.app import create_app
+    from admin.backend.auth import require_scope
+
+    bench_root = tmp_path / "benches" / "current"
+    _initialized_bench(bench_root, "secret", "k3y")
+    app = create_app(bench_root)
+    app.config["TESTING"] = True
+
+    @app.route("/api/test-scoped")
+    @require_scope("example.com")
+    def scoped_view():
+        return jsonify({"ok": True})
+
+    client = app.test_client()
+    token = issue_site_token("k3y", "other.com")
+    resp = client.get("/api/test-scoped", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 403
+
+
+def test_require_scope_with_callable(tmp_path: Path) -> None:
+    from flask import jsonify
+    from admin.backend.app import create_app
+    from admin.backend.auth import require_scope
+
+    bench_root = tmp_path / "benches" / "current"
+    _initialized_bench(bench_root, "secret", "k3y")
+    app = create_app(bench_root)
+    app.config["TESTING"] = True
+
+    @app.route("/api/sites/<name>/action")
+    @require_scope(lambda kw: kw["name"])
+    def scoped_view(name):
+        return jsonify({"ok": True, "site": name})
+
+    client = app.test_client()
+    client.set_cookie("sid", issue_token("k3y", scope="site", site="example.com"))
+    assert client.get("/api/sites/example.com/action").status_code == 200
+    assert client.get("/api/sites/other.com/action").status_code == 403


### PR DESCRIPTION
Scoped authentication will help in integrating in-site actions with better security. During site creation, bench will inject scoped tokens which can be used by the site to query or perform action.

Any site can't perform action on other site.

Site config keys (Managed by bench/pilot) :
- pilot_endpoint : Base url for api call
- pilot_auth_token : Authentication token, add in request as `Authorization: "Bearer <pilot_auth_token>"`

