### PR TITLE
feat: Add SQLite experimental support

### DIFF
--- a/admin/backend/tasks/jobs/new_site_task.py
+++ b/admin/backend/tasks/jobs/new_site_task.py
@@ -8,15 +8,17 @@ class NewSiteTask(BaseTask):
         p = super()._parser()
         p.add_argument("name")
         p.add_argument("--admin-password", default="admin")
+        p.add_argument("--db-type", default=None)
         return p
 
     def __init__(self, bench, bench_root, args):
         super().__init__(bench, bench_root, args)
         self.name = args.name
         self.admin_password = args.admin_password
+        self.db_type = args.db_type
 
     def run(self) -> None:
-        NewSiteCommand(self.bench, self.name, [], self.admin_password).run()
+        NewSiteCommand(self.bench, self.name, [], self.admin_password, db_type=self.db_type).run()
 
 
 if __name__ == "__main__":

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -153,6 +153,8 @@ class TaskRunner:
             argv = [sys.executable, "-m", "admin.backend.tasks.jobs.new_site_task", str(self._bench_root), args["name"]]
             if args.get("admin_password"):
                 argv += ["--admin-password", args["admin_password"]]
+            if args.get("db_type"):
+                argv += ["--db-type", args["db_type"]]
             return argv
         if command == "drop-site":
             return [sys.executable, "-m", "admin.backend.tasks.jobs.drop_site_task", str(self._bench_root), args["site"]]

--- a/admin/backend/views/benches.py
+++ b/admin/backend/views/benches.py
@@ -176,8 +176,8 @@ def new():
         process_manager = "openrc"
 
     db_type = (data.get("db_type") or "mariadb").strip()
-    if db_type not in ("mariadb", "postgres"):
-        return jsonify({"error": "Database must be 'mariadb' or 'postgres'."}), 400
+    if db_type not in ("mariadb", "postgres", "sqlite"):
+        return jsonify({"error": "Database must be 'mariadb', 'postgres', or 'sqlite'."}), 400
 
     admin_domain = (data.get("admin_domain") or "").strip()
     if not admin_domain:

--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -202,9 +202,9 @@ def _assign_postgres_port(bench_root: Path, settings: dict) -> None:
 def _validate(data: dict) -> str | None:
     if not data.get("admin_password"):
         return "admin_password is required"
-    # Each engine needs its superuser password: frappe connects over TCP, where a
-    # blank password fails password auth and would only surface at first site
-    # creation. init sets this password on a fresh install.
+    # Each server-based engine needs its superuser password: frappe connects over
+    # TCP, where a blank password fails password auth and would only surface at
+    # first site creation. init sets this password on a fresh install.
     db_type = data.get("db_type", "mariadb")
     if db_type == "mariadb" and not data.get("mariadb_password"):
         return "mariadb_password is required"

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -131,7 +131,7 @@ def create():
     data = request.get_json(silent=True) or {}
 
     name = (data.get("name") or "").strip()
-    admin_password = (data.get("admin_password") or "admin").strip() or "admin"
+    admin_password = secrets.token_urlsafe(16)
     db_type = (data.get("db_type") or "").strip()
     if db_type and db_type not in ("mariadb", "postgres", "sqlite"):
         return jsonify({"ok": False, "error": f"Invalid db_type '{db_type}'."})

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import secrets
+import subprocess
 from dataclasses import asdict
 from pathlib import Path
 
@@ -357,20 +358,39 @@ def force_uninstall_app(name: str):
     return jsonify({"ok": True})
 
 
+def _get_site_sid(bench_root: Path, site: str, user: str = "Administrator") -> tuple[str | None, str]:
+    import re
+
+    # bench binary lives at project root; bench_root is <project>/benches/<name>
+    bench_bin = bench_root.parent.parent / "bench"
+    bench_name = bench_root.name
+    benches_dir = bench_root.parent
+
+    result = subprocess.run(
+        [str(bench_bin), "-b", bench_name, "--site", site, "browse", "--user", user],
+        capture_output=True, text=True, timeout=30, cwd=str(benches_dir),
+    )
+    output = (result.stdout or "") + (result.stderr or "")
+    if m := re.search(r"sid=([a-zA-Z0-9]+)", output):
+        sid = m.group(1)
+        if sid and sid not in (user, "Guest"):
+            return sid, ""
+    return None, f"bench={bench_bin} exit={result.returncode}\n{output[:500]}"
+
+
 @sites_bp.route("/<name>/login", methods=["POST"])
 @require_scope(site_name)
 def login_to_site(name: str):
+    import json
+
     bench_root = Path(current_app.config["BENCH_ROOT"])
-    if not (bench_root / "sites" / name / "site_config.json").exists():
+    site_config_path = bench_root / "sites" / name / "site_config.json"
+    if not site_config_path.exists():
         return jsonify({"ok": False, "error": "Site not found."}), 404
 
-    data = request.get_json(silent=True) or {}
-    password = (data.get("password") or "").strip()
-    if not password:
-        return jsonify({"ok": False, "error": "Password is required."})
-
-    import http.client
-    import urllib.parse
+    sid, debug = _get_site_sid(bench_root, name)
+    if not sid:
+        return jsonify({"ok": False, "error": "Could not create login session.", "debug": debug})
 
     from pilot.config.toml_store import BenchTomlStore
 
@@ -382,42 +402,9 @@ def login_to_site(name: str):
         http_port = 8000
         nginx_enabled = False
 
-    try:
-        conn = http.client.HTTPConnection("localhost", http_port, timeout=10)
-        conn.request(
-            "POST",
-            "/api/method/login",
-            body=urllib.parse.urlencode({"usr": "Administrator", "pwd": password}),
-            headers={
-                "Host": name,
-                "X-Frappe-Site-Name": name,
-                "Content-Type": "application/x-www-form-urlencoded",
-            },
-        )
-        resp = conn.getresponse()
-    except OSError as e:
-        return jsonify({"ok": False, "error": f"Could not reach site web server: {e}"})
-
-    if resp.status == 401:
-        return jsonify({"ok": False, "error": "Incorrect password."})
-    if resp.status != 200:
-        return jsonify({"ok": False, "error": f"Site returned HTTP {resp.status}."})
-
-    sid = None
-    for header, value in resp.getheaders():
-        if header.lower() == "set-cookie" and value.startswith("sid="):
-            sid = value.split("=", 1)[1].split(";")[0]
-            break
-
-    if not sid or sid == "Guest":
-        return jsonify({"ok": False, "error": "Login failed — wrong password?"})
-
-    # Behind nginx the site is served by domain on 80/443; only dev talks to the gunicorn port directly.
     if nginx_enabled:
-        import json
-
         try:
-            ssl = bool(json.loads((bench_root / "sites" / name / "site_config.json").read_text()).get("ssl"))
+            ssl = bool(json.loads(site_config_path.read_text()).get("ssl"))
         except Exception:
             ssl = False
         url = f"{'https' if ssl else 'http'}://{name}/desk?sid={sid}"

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -132,14 +132,20 @@ def create():
 
     name = (data.get("name") or "").strip()
     admin_password = (data.get("admin_password") or "admin").strip() or "admin"
+    db_type = (data.get("db_type") or "").strip()
+    if db_type and db_type not in ("mariadb", "postgres", "sqlite"):
+        return jsonify({"ok": False, "error": f"Invalid db_type '{db_type}'."})
     err = validate_site_name(name) or _new_site_name_error(bench_root, name)
     if err:
         return jsonify({"ok": False, "error": err})
 
+    task_args: dict = {"name": name, "admin_password": admin_password}
+    if db_type:
+        task_args["db_type"] = db_type
     try:
         task_id = TaskRunner(bench_root).run(
             "new-site",
-            {"name": name, "admin_password": admin_password},
+            task_args,
             callbacks={"on_failure": new_site_failure_callback},
         )
     except Exception as e:

--- a/admin/frontend/src/components/SettingsModal.vue
+++ b/admin/frontend/src/components/SettingsModal.vue
@@ -36,11 +36,14 @@ const BASE_TABS = [
 ]
 const isLinux = ref(false)
 const TABS = computed(() => {
-  // A bench runs a single engine — show only that engine's tab (after Appearance).
-  const dbTab = form.value?.bench?.db_type === 'postgres'
+  const dbType = form.value?.bench?.db_type
+  const dbTab = dbType === 'postgres'
     ? { key: 'postgres', label: 'PostgreSQL' }
+    : dbType === 'sqlite' ? null
     : { key: 'mariadb', label: 'MariaDB' }
-  const tabs = [...BASE_TABS.slice(0, 3), dbTab, ...BASE_TABS.slice(3)]
+  const tabs = [...BASE_TABS.slice(0, 3)]
+  if (dbTab) tabs.push(dbTab)
+  tabs.push(...BASE_TABS.slice(3))
   if (isLinux.value) tabs.push({ key: 'volume', label: 'ZFS Volume' })
   return tabs
 })
@@ -55,7 +58,12 @@ const saveSuccess = ref('')
 
 const form = ref(null)
 
-const dbEngineLabel = computed(() => (form.value?.bench?.db_type === 'postgres' ? 'PostgreSQL' : 'MariaDB'))
+const dbEngineLabel = computed(() => {
+  const t = form.value?.bench?.db_type
+  if (t === 'postgres') return 'PostgreSQL'
+  if (t === 'sqlite') return 'SQLite'
+  return 'MariaDB'
+})
 
 async function load() {
   loading.value = true

--- a/admin/frontend/src/pages/SiteDetail.vue
+++ b/admin/frontend/src/pages/SiteDetail.vue
@@ -46,10 +46,7 @@ const uninstallTarget = ref('')
 const forceUninstallLoading = ref(false)
 const forceUninstallError = ref('')
 
-const showLogin = ref(false)
-const loginPassword = ref('')
 const loginLoading = ref(false)
-const loginError = ref('')
 
 const sslLoading = ref(false)
 const sslError = ref('')
@@ -243,24 +240,15 @@ async function setPrimary(domain) {
 }
 
 async function loginToSite() {
-  loginError.value = ''
+  actionError.value = ''
   loginLoading.value = true
   try {
-    const res = await fetch(`/api/sites/${siteName}/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ password: loginPassword.value }),
-    })
+    const res = await fetch(`/api/sites/${siteName}/login`, { method: 'POST' })
     const d = await res.json()
-    if (d.ok) {
-      showLogin.value = false
-      loginPassword.value = ''
-      window.open(d.url, '_blank')
-    } else {
-      loginError.value = d.error
-    }
+    if (d.ok) window.open(d.url, '_blank')
+    else actionError.value = d.error
   } catch (e) {
-    loginError.value = e.message
+    actionError.value = e.message
   } finally {
     loginLoading.value = false
   }
@@ -790,7 +778,7 @@ onMounted(() => {
             </div>
           </div>
           <div class="flex shrink-0 items-center gap-2">
-            <Button variant="outline" @click="showLogin = true">
+            <Button variant="outline" :loading="loginLoading" @click="loginToSite">
               Login
             </Button>
           </div>
@@ -1161,22 +1149,6 @@ onMounted(() => {
           <Button variant="solid" :loading="sslLoading" :disabled="!sslEmail" @click="enableSsl(sslEmail)">
             Enable SSL
           </Button>
-        </div>
-      </template>
-    </Dialog>
-
-    <Dialog v-model="showLogin" :options="{ title: 'Login to Site', size: 'sm' }">
-      <template #body-content>
-        <div @pointerdown.stop>
-          <FormControl label="Administrator password" type="password" v-model="loginPassword" placeholder="admin"
-            @keydown.enter="loginToSite" />
-          <ErrorMessage :message="loginError" class="mt-2" />
-          <div class="mt-4 flex justify-end gap-2">
-            <Button variant="ghost" @click="showLogin = false">Cancel</Button>
-            <Button variant="solid" :loading="loginLoading" :disabled="!loginPassword" @click="loginToSite">
-              Login
-            </Button>
-          </div>
         </div>
       </template>
     </Dialog>

--- a/admin/frontend/src/pages/Sites.vue
+++ b/admin/frontend/src/pages/Sites.vue
@@ -44,7 +44,6 @@ const siteName = ref('')
 const sitePrefix = ref('')
 const wildcardDomains = ref([])
 const selectedSuffix = ref('')
-const adminPassword = ref('')
 const creating = ref(false)
 const createError = ref('')
 const benchDbType = ref('')
@@ -112,7 +111,7 @@ async function createSite() {
       res = await fetch('/api/sites/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: siteName.value.trim(), admin_password: adminPassword.value.trim(), db_type: siteDbType.value }),
+        body: JSON.stringify({ name: siteName.value.trim(), db_type: siteDbType.value }),
       })
     } else if (restoreMode.value === 'existing') {
       const set = backupSets.value.find(s => s.timestamp === selectedBackupTs.value)
@@ -120,14 +119,12 @@ async function createSite() {
       const pub = set.files.find(f => f.kind === 'public-file')
       const priv = set.files.find(f => f.kind === 'private-file')
       const body = { command: 'new-site-from-backup', name: siteName.value.trim(), db_file: db.path }
-      if (adminPassword.value.trim()) body.admin_password = adminPassword.value.trim()
       if (pub) body.public_files = pub.path
       if (priv) body.private_files = priv.path
       res = await fetch('/api/tasks/run', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
     } else {
       const fd = new FormData()
       fd.append('name', siteName.value.trim())
-      fd.append('admin_password', adminPassword.value.trim())
       fd.append('db_file', uploadDb.value)
       if (uploadPublic.value) fd.append('public_files', uploadPublic.value)
       if (uploadPrivate.value) fd.append('private_files', uploadPrivate.value)
@@ -157,7 +154,6 @@ function openCreate() {
   showCreate.value = true
   siteName.value = ''
   sitePrefix.value = ''
-  adminPassword.value = ''
   loadWildcardDomains()
   createError.value = ''
   benchDbType.value = ''
@@ -279,8 +275,6 @@ onMounted(() => { loadSites(); loadRegistry(); checkAppUpdates() })
               <span v-else class="flex shrink-0 items-center whitespace-nowrap text-sm text-ink-gray-6">{{ wildcardDomains[0] }}</span>
             </div>
           </div>
-          <FormControl label="Admin Password" type="password" v-model="adminPassword" placeholder="admin" description="Leave blank to use 'admin'" />
-
           <div v-if="siteDbType">
             <span class="mb-1.5 block text-xs text-ink-gray-5">Database</span>
             <div class="grid grid-cols-2 gap-2">

--- a/admin/frontend/src/pages/Sites.vue
+++ b/admin/frontend/src/pages/Sites.vue
@@ -47,6 +47,8 @@ const selectedSuffix = ref('')
 const adminPassword = ref('')
 const creating = ref(false)
 const createError = ref('')
+const benchDbType = ref('')
+const siteDbType = ref('')
 const restoreFromBackup = ref(false)
 const restoreMode = ref('existing')
 const backupSourceSite = ref('')
@@ -110,7 +112,7 @@ async function createSite() {
       res = await fetch('/api/sites/create', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: siteName.value.trim(), admin_password: adminPassword.value.trim() }),
+        body: JSON.stringify({ name: siteName.value.trim(), admin_password: adminPassword.value.trim(), db_type: siteDbType.value }),
       })
     } else if (restoreMode.value === 'existing') {
       const set = backupSets.value.find(s => s.timestamp === selectedBackupTs.value)
@@ -158,6 +160,12 @@ function openCreate() {
   adminPassword.value = ''
   loadWildcardDomains()
   createError.value = ''
+  benchDbType.value = ''
+  siteDbType.value = ''
+  fetch('/api/status').then(r => r.json()).then(d => {
+    benchDbType.value = d.db_type || 'mariadb'
+    siteDbType.value = benchDbType.value
+  }).catch(() => {})
   restoreFromBackup.value = false
   restoreMode.value = 'existing'
   backupSourceSite.value = ''
@@ -272,6 +280,30 @@ onMounted(() => { loadSites(); loadRegistry(); checkAppUpdates() })
             </div>
           </div>
           <FormControl label="Admin Password" type="password" v-model="adminPassword" placeholder="admin" description="Leave blank to use 'admin'" />
+
+          <div v-if="siteDbType">
+            <span class="mb-1.5 block text-xs text-ink-gray-5">Database</span>
+            <div class="grid grid-cols-2 gap-2">
+              <button
+                type="button"
+                class="rounded-lg border p-3 text-left transition-colors"
+                :class="siteDbType !== 'sqlite' ? 'border-outline-gray-3 bg-surface-gray-2' : 'border-outline-gray-2 hover:bg-surface-gray-1'"
+                @click="siteDbType = benchDbType !== 'sqlite' ? benchDbType : 'mariadb'"
+              >
+                <span class="block text-sm font-medium text-ink-gray-9">{{ benchDbType === 'postgres' ? 'PostgreSQL' : 'MariaDB' }}</span>
+                <span class="block text-xs text-ink-gray-5">Recommended</span>
+              </button>
+              <button
+                type="button"
+                class="rounded-lg border p-3 text-left transition-colors"
+                :class="siteDbType === 'sqlite' ? 'border-outline-gray-3 bg-surface-gray-2' : 'border-outline-gray-2 hover:bg-surface-gray-1'"
+                @click="siteDbType = 'sqlite'"
+              >
+                <span class="block text-sm font-medium text-ink-gray-9">SQLite</span>
+                <span class="block text-xs text-ink-gray-5">Experimental</span>
+              </button>
+            </div>
+          </div>
 
           <div class="border-t pt-4">
             <Switch v-model="restoreFromBackup" label="Restore from backup" />

--- a/pilot/commands/init.py
+++ b/pilot/commands/init.py
@@ -209,6 +209,8 @@ class InitCommand(Command):
         # A bench runs exactly one engine; install/provision only that one.
         if self.bench.config.db_type == "postgres":
             self._postgres_manager().provision()
+        elif self.bench.config.db_type == "sqlite":
+            pass
         else:
             self._install_mariadb()
 

--- a/pilot/commands/new.py
+++ b/pilot/commands/new.py
@@ -26,7 +26,7 @@ class NewCommand(Command):
         parser.add_argument(
             "--database",
             default="mariadb",
-            choices=["mariadb", "postgres"],
+            choices=["mariadb", "postgres", "sqlite"],
             help="Database engine for this bench's sites (default: mariadb).",
         )
 

--- a/pilot/commands/new_site.py
+++ b/pilot/commands/new_site.py
@@ -31,11 +31,12 @@ class NewSiteCommand(Command):
             app_names = [framework] if framework else []
         return cls(bench, args.name, app_names, args.admin_password)
 
-    def __init__(self, bench: "Bench", name: str, apps: list[str], admin_password: str = "admin") -> None:
+    def __init__(self, bench: "Bench", name: str, apps: list[str], admin_password: str = "admin", db_type: str | None = None) -> None:
         self.bench = bench
         self.name = name
         self.apps = apps
         self.admin_password = admin_password
+        self.db_type = db_type
         self._via_wildcard = False
 
     def run(self) -> None:
@@ -48,7 +49,7 @@ class NewSiteCommand(Command):
         site = Site(SiteConfig(name=self.name, apps=self.apps, admin_password=self.admin_password, ssl=ssl), self.bench)
         print(f"Creating site '{self.name}'...")
         sys.stdout.flush()
-        site.create()
+        site.create(db_type=self.db_type)
         self._write_pilot_communication_config()
         self.bench.write_common_site_config()
         print(f"\nSite '{self.name}' created successfully.")

--- a/pilot/config/bench_config.py
+++ b/pilot/config/bench_config.py
@@ -272,8 +272,8 @@ class BenchConfig:
             raise ConfigError(f"bench.socketio_backend '{self.socketio_backend}' is invalid. Must be 'python' or 'node'.")
 
     def _validate_db_type(self) -> None:
-        if self.db_type not in ("mariadb", "postgres"):
-            raise ConfigError(f"bench.db_type '{self.db_type}' is invalid. Must be 'mariadb' or 'postgres'.")
+        if self.db_type not in ("mariadb", "postgres", "sqlite"):
+            raise ConfigError(f"bench.db_type '{self.db_type}' is invalid. Must be 'mariadb', 'postgres', or 'sqlite'.")
 
     def _validate_redis_ports(self) -> None:
         ports = [self.redis.cache_port, self.redis.queue_port]

--- a/pilot/core/bench.py
+++ b/pilot/core/bench.py
@@ -57,6 +57,8 @@ class Bench:
         if self.config.db_type == "postgres":
             pg = self.config.postgres
             return ["--db-root-username", pg.admin_user, "--db-root-password", self.postgres_root_password()]
+        if self.config.db_type == "sqlite":
+            return []
         mariadb = self.config.mariadb
         return ["--db-root-username", mariadb.admin_user, "--db-root-password", mariadb.root_password]
 

--- a/pilot/core/site.py
+++ b/pilot/core/site.py
@@ -28,10 +28,16 @@ class Site:
         """Build a frappe bench_helper command."""
         return [*self.bench.frappe_call, *args]
 
-    def create(self) -> None:
+    def create(self, db_type: str | None = None) -> None:
         cmd = self._frappe_call("frappe", "--site", self.config.name, "new-site", self.config.name)
         cmd += ["--admin-password", self.config.admin_password]
-        cmd += self._postgres_db_args() if self.bench.config.db_type == "postgres" else self._mariadb_db_args()
+        effective = db_type or self.bench.config.db_type
+        if effective == "postgres":
+            cmd += self._postgres_db_args()
+        elif effective == "sqlite":
+            cmd += self._sqlite_db_args()
+        else:
+            cmd += self._mariadb_db_args()
         run_command(cmd, cwd=self.bench.sites_path, stream_output=True)
 
     def _mariadb_db_args(self) -> list[str]:
@@ -60,6 +66,9 @@ class Site:
             "--db-root-username", postgres.admin_user,
             "--db-root-password", self.bench.postgres_root_password(),
         ]
+
+    def _sqlite_db_args(self) -> list[str]:
+        return ["--db-type", "sqlite"]
 
     def restore(self, db_file: str, public_files: str | None = None, private_files: str | None = None) -> None:
         cmd = self._frappe_call("frappe", "--site", self.config.name, "restore", db_file)

--- a/tests/e2e/flows/admin.py
+++ b/tests/e2e/flows/admin.py
@@ -26,13 +26,14 @@ def login(page: Page, base_url: str, password: str) -> None:
     expect(page.get_by_role("button", name="Create Site")).to_be_visible(timeout=30_000)
 
 
-def create_site(page: Page, base_url: str, site_name: str, admin_password: str) -> None:
+def create_site(page: Page, base_url: str, site_name: str, db_type: str = "") -> None:
     page.goto(f"{base_url}/")
     page.get_by_role("button", name="Create Site").click()
 
     dialog = page.get_by_role("dialog")
     dialog.get_by_label("Site Name").fill(site_name)
-    dialog.get_by_label("Admin Password").fill(admin_password)
+    if db_type == "sqlite":
+        dialog.get_by_role("button", name="SQLite").click()
 
     task_id = run_task_action(
         page,

--- a/tests/e2e/specs/test_bench_lifecycle.py
+++ b/tests/e2e/specs/test_bench_lifecycle.py
@@ -48,7 +48,6 @@ VOLUMES = _truthy("E2E_VOLUMES")  # ZFS — dedicated only, mirrors production
 BENCH_NAME = f"e2e-postgres-{DB_MODE}" if DB_TYPE == "postgres" else f"e2e-{DB_MODE}{'-zfs' if VOLUMES else ''}"
 
 SITE = "site1.localhost"
-SITE_ADMIN_PASSWORD = "admin"
 MARIADB_PASSWORD = os.environ.get("E2E_MARIADB_PASSWORD", "admin")
 POSTGRES_PASSWORD = os.environ.get("E2E_POSTGRES_PASSWORD", "admin")
 
@@ -94,7 +93,7 @@ def test_logs_into_admin(bench, page):
 
 
 def test_creates_a_new_site(bench, page):
-    create_site(page, bench.admin_url, SITE, SITE_ADMIN_PASSWORD)
+    create_site(page, bench.admin_url, SITE)
     assert site_exists(page, bench.admin_url, SITE)
     # A fresh site always has frappe installed.
     assert "frappe" in installed_apps(page, bench.admin_url, SITE)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -565,9 +565,17 @@ def test_db_type_postgres_roundtrip() -> None:
     assert 'db_type = "postgres"' in bench_config_to_toml(config)
 
 
-def test_invalid_db_type_rejected() -> None:
+def test_db_type_sqlite_roundtrip() -> None:
     data = copy.deepcopy(MINIMAL_VALID_DATA)
     data["bench"]["db_type"] = "sqlite"
+    config = load_from_dict(data)
+    assert config.db_type == "sqlite"
+    assert 'db_type = "sqlite"' in bench_config_to_toml(config)
+
+
+def test_invalid_db_type_rejected() -> None:
+    data = copy.deepcopy(MINIMAL_VALID_DATA)
+    data["bench"]["db_type"] = "mongodb"
     with pytest.raises(ConfigError) as exc_info:
         load_from_dict(data)
     assert "bench.db_type" in str(exc_info.value)


### PR DESCRIPTION
<img width="908" height="508" alt="image" src="https://github.com/user-attachments/assets/da2921f3-7392-43b8-b54f-44655df7f6e5" />

Bench is always created with postgres or mariadb. So, while creating site it will show up the main database and SQlite as an option. SQLite is still at experimental stage and might be useful for small app only.

Additionally,
- removed the requirement of providing admin password, now it sets a random secret internally
- in `login to site`, it does password-less login.  