### PR TITLE
feat(tasks): roll back failed and cancelled app/site tasks via callbacks

### DIFF
--- a/admin/backend/tasks/callbacks.py
+++ b/admin/backend/tasks/callbacks.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 import subprocess
+from pathlib import Path
 
 
 def new_site_failure_callback(meta: dict) -> None:
@@ -37,3 +38,61 @@ def ssl_setup_failure_callback(meta: dict) -> None:
     config = json.loads(open(config_path).read())
     config["ssl"] = False
     open(config_path, "w").write(json.dumps(config, indent=1))
+
+
+def _created_apps(bench_root: Path, pre_existing: set[str]) -> list[str]:
+    """App dirs present now that did not exist when the task started — i.e. exactly
+    what this fetch created. Pre-existing apps are never returned, so cleanup can
+    never delete an app the task did not clone."""
+    apps_dir = bench_root / "apps"
+    if not apps_dir.exists():
+        return []
+    return [entry.name for entry in apps_dir.iterdir() if entry.is_dir() and entry.name not in pre_existing]
+
+
+def app_fetch_failure_callback(meta: dict) -> None:
+    """Roll a failed/cancelled app fetch back to zero: uninstall from sites, drop
+    the apps.txt line, pip-uninstall, delete the clone. Only touches apps this
+    task created (see _created_apps)."""
+    if "pre_existing_apps" not in meta:
+        return  # no snapshot → cannot prove safety → do nothing
+    bench_root = Path(meta["bench_root"])
+    created = _created_apps(bench_root, set(meta["pre_existing_apps"]))
+    if not created:
+        return
+
+    bench = _load_bench(bench_root)
+    for app_name in created:
+        _teardown_app(bench, bench_root, app_name)
+
+
+def _load_bench(bench_root: Path):
+    from pilot.config.toml_store import BenchTomlStore
+    from pilot.core.bench import Bench
+
+    return Bench(BenchTomlStore.for_bench(bench_root).read(), bench_root)
+
+
+def _teardown_app(bench, bench_root: Path, app_name: str) -> None:
+    """Best-effort full removal. RemoveAppCommand also uninstalls from sites; if it
+    can't run on a half-built/unregistered app, force-delete so nothing lingers."""
+    try:
+        from pilot.commands.remove_app import RemoveAppCommand
+
+        RemoveAppCommand(bench, app_name, skip_confirm=True, force=True).run()
+    except Exception:
+        _force_teardown(bench, bench_root, app_name)
+
+
+def _force_teardown(bench, bench_root: Path, app_name: str) -> None:
+    apps_txt = bench_root / "sites" / "apps.txt"
+    if apps_txt.exists():
+        kept = [line for line in apps_txt.read_text().splitlines() if line.strip() != app_name]
+        apps_txt.write_text("\n".join(kept) + ("\n" if kept else ""))
+    try:
+        from pilot.managers.python_env_manager import PythonEnvManager
+
+        PythonEnvManager(bench).uninstall_app(app_name)
+    except Exception:
+        pass
+    shutil.rmtree(bench_root / "apps" / app_name, ignore_errors=True)

--- a/admin/backend/tasks/callbacks.py
+++ b/admin/backend/tasks/callbacks.py
@@ -41,9 +41,7 @@ def ssl_setup_failure_callback(meta: dict) -> None:
 
 
 def _created_apps(bench_root: Path, pre_existing: set[str]) -> list[str]:
-    """App dirs present now that did not exist when the task started — i.e. exactly
-    what this fetch created. Pre-existing apps are never returned, so cleanup can
-    never delete an app the task did not clone."""
+    """App dirs present now but absent when the task started — never a pre-existing app."""
     apps_dir = bench_root / "apps"
     if not apps_dir.exists():
         return []
@@ -51,17 +49,18 @@ def _created_apps(bench_root: Path, pre_existing: set[str]) -> list[str]:
 
 
 def app_fetch_failure_callback(meta: dict) -> None:
-    """Roll a failed/cancelled app fetch back to zero: uninstall from sites, drop
-    the apps.txt line, pip-uninstall, delete the clone. Only touches apps this
-    task created (see _created_apps)."""
+    """Roll a failed/cancelled app fetch back to zero. Removes only apps this task created."""
     if "pre_existing_apps" not in meta:
-        return  # no snapshot → cannot prove safety → do nothing
+        return  # no snapshot → can't prove safety
     bench_root = Path(meta["bench_root"])
     created = _created_apps(bench_root, set(meta["pre_existing_apps"]))
     if not created:
         return
 
-    bench = _load_bench(bench_root)
+    try:
+        bench = _load_bench(bench_root)
+    except Exception:
+        bench = None  # broken config: skip site-uninstall/pip, still force-delete below
     for app_name in created:
         _teardown_app(bench, bench_root, app_name)
 
@@ -74,8 +73,10 @@ def _load_bench(bench_root: Path):
 
 
 def _teardown_app(bench, bench_root: Path, app_name: str) -> None:
-    """Best-effort full removal. RemoveAppCommand also uninstalls from sites; if it
-    can't run on a half-built/unregistered app, force-delete so nothing lingers."""
+    """Full removal via RemoveAppCommand; force-delete if it can't run on a half-built app."""
+    if bench is None:
+        _force_teardown(bench, bench_root, app_name)
+        return
     try:
         from pilot.commands.remove_app import RemoveAppCommand
 

--- a/admin/backend/tasks/callbacks.py
+++ b/admin/backend/tasks/callbacks.py
@@ -6,10 +6,24 @@ from pathlib import Path
 
 
 def new_site_failure_callback(meta: dict) -> None:
+    """Roll a failed/cancelled site create back to zero: drop the database (and
+    bench.toml entry) then delete the site dir and strip its /etc/hosts line."""
     site_name = meta["args"]["name"]
-    site_path = os.path.join(meta["bench_root"], "sites", site_name)
-    shutil.rmtree(site_path, ignore_errors=True)
+    bench_root = Path(meta["bench_root"])
+    _drop_site_best_effort(bench_root, site_name)
+    shutil.rmtree(bench_root / "sites" / site_name, ignore_errors=True)
     _remove_from_hosts(site_name)
+
+
+def _drop_site_best_effort(bench_root: Path, site_name: str) -> None:
+    """Drop the DB + bench.toml entry via DropSiteCommand (frappe drop-site --force).
+    Best effort: a half-created site or unreadable config must not raise."""
+    try:
+        from pilot.commands.drop_site import DropSiteCommand
+
+        DropSiteCommand(_load_bench(bench_root), site_name).run()
+    except Exception:
+        pass
 
 
 def _remove_from_hosts(site_name: str) -> None:

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -15,6 +15,11 @@ from pilot.exceptions import TaskNotFoundError, TaskNotRunningError
 
 TASK_RETENTION_LIMIT = 100
 
+# Commands that clone an app into apps/. Their failure callback may delete the
+# clone, so we record which app dirs existed beforehand and only ever remove
+# dirs this task created — never a pre-existing app.
+_APP_FETCH_COMMANDS = frozenset({"get-app", "get-and-install-app", "add-and-install-app"})
+
 _WHITELIST: dict[str, list[str]] = {
     "migrate": ["site"],
     "clear-cache": ["site"],
@@ -67,6 +72,8 @@ class TaskRunner:
             "exit_code": None,
             "bench_root": str(self._bench_root),
         }
+        if command in _APP_FETCH_COMMANDS:
+            meta["pre_existing_apps"] = self._existing_app_dirs()
         (task_dir / "meta.json").write_text(json.dumps(meta, indent=2))
         (task_dir / "status").write_text("running")
 
@@ -106,6 +113,12 @@ class TaskRunner:
 
     def _task_dir(self, task_id: str) -> Path:
         return self._bench_root / "tasks" / task_id
+
+    def _existing_app_dirs(self) -> list[str]:
+        apps_dir = self._bench_root / "apps"
+        if not apps_dir.exists():
+            return []
+        return sorted(entry.name for entry in apps_dir.iterdir() if entry.is_dir())
 
     def _build_argv(self, command: str, args: dict, task_dir: Path | None = None) -> list[str]:
         if command not in _WHITELIST:

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -15,9 +15,7 @@ from pilot.exceptions import TaskNotFoundError, TaskNotRunningError
 
 TASK_RETENTION_LIMIT = 100
 
-# Commands that clone an app into apps/. Their failure callback may delete the
-# clone, so we record which app dirs existed beforehand and only ever remove
-# dirs this task created — never a pre-existing app.
+# Snapshot apps/ before these run so cleanup removes only what the task cloned.
 _APP_FETCH_COMMANDS = frozenset({"get-app", "get-and-install-app", "add-and-install-app"})
 
 _WHITELIST: dict[str, list[str]] = {

--- a/admin/backend/tasks/manager/wrapper.py
+++ b/admin/backend/tasks/manager/wrapper.py
@@ -8,6 +8,7 @@ This module uses only the standard library — no cli imports.
 
 import json
 import pickle
+import signal
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -37,17 +38,32 @@ def main() -> None:
     sites_dir = bench_root / "sites"
     cwd = str(sites_dir) if sites_dir.is_dir() else str(bench_root)
 
+    cancelled = {"flag": False}
+
     with open(task_dir / "output.log", "wb") as log_file:
-        result = subprocess.run(
+        process = subprocess.Popen(
             meta["command_argv"],
             cwd=cwd,
             stdout=log_file,
             stderr=subprocess.STDOUT,
         )
 
-    if result.returncode == 0 and on_success_bin.exists():
+        def _on_term(_signum, _frame) -> None:
+            # Cancel (TaskRunner.kill) SIGTERMs this wrapper. Forward it to the
+            # command so it stops too, then fall through to run on_failure cleanup.
+            # ponytail: SIGTERM only; if a command ignores it the kill escalates
+            # to SIGKILL upstream, which we can't clean after — acceptable for now.
+            cancelled["flag"] = True
+            process.terminate()
+
+        signal.signal(signal.SIGTERM, _on_term)
+        returncode = process.wait()
+
+    succeeded = returncode == 0 and not cancelled["flag"]
+
+    if succeeded and on_success_bin.exists():
         callback_handler(on_success_bin, task_dir / "output.log", meta=meta)
-    elif result.returncode != 0 and on_failure_bin.exists():
+    elif not succeeded and on_failure_bin.exists():
         callback_handler(on_failure_bin, task_dir / "output.log", meta=meta)
 
     for leftover in (on_success_bin, on_failure_bin):
@@ -55,9 +71,9 @@ def main() -> None:
             leftover.unlink()
 
     meta["finished_at"] = datetime.now(timezone.utc).isoformat()
-    meta["exit_code"] = result.returncode
+    meta["exit_code"] = returncode
     (task_dir / "meta.json").write_text(json.dumps(meta, indent=2))
-    status = "success" if result.returncode == 0 else "failed"
+    status = "success" if succeeded else "killed" if cancelled["flag"] else "failed"
     (task_dir / "status").write_text(status)
 
 

--- a/admin/backend/tasks/manager/wrapper.py
+++ b/admin/backend/tasks/manager/wrapper.py
@@ -26,6 +26,15 @@ def callback_handler(callback_bin_path: Path, output_log: Path, meta: dict) -> N
             log_file.write(f"\nCallback failed: {error!s}\n")
 
 
+def _resolve_outcome(returncode: int, cancelled: bool) -> tuple[bool, str]:
+    """Success is decided by the child's exit alone, so a cancel racing in after a
+    clean exit-0 never tears down a completed install. cancelled only labels a
+    non-zero exit as killed vs failed."""
+    succeeded = returncode == 0
+    status = "success" if succeeded else "killed" if cancelled else "failed"
+    return succeeded, status
+
+
 def main() -> None:
     task_dir = Path(sys.argv[1])
     meta = json.loads((task_dir / "meta.json").read_text())
@@ -61,7 +70,7 @@ def main() -> None:
         holder["proc"] = process
         returncode = process.wait()
 
-    succeeded = returncode == 0 and not cancelled["flag"]
+    succeeded, status = _resolve_outcome(returncode, cancelled["flag"])
 
     if succeeded and on_success_bin.exists():
         callback_handler(on_success_bin, task_dir / "output.log", meta=meta)
@@ -75,7 +84,6 @@ def main() -> None:
     meta["finished_at"] = datetime.now(timezone.utc).isoformat()
     meta["exit_code"] = returncode
     (task_dir / "meta.json").write_text(json.dumps(meta, indent=2))
-    status = "success" if succeeded else "killed" if cancelled["flag"] else "failed"
     (task_dir / "status").write_text(status)
 
 

--- a/admin/backend/tasks/manager/wrapper.py
+++ b/admin/backend/tasks/manager/wrapper.py
@@ -18,12 +18,14 @@ from pathlib import Path
 def callback_handler(callback_bin_path: Path, output_log: Path, meta: dict) -> None:
     callback = pickle.loads(callback_bin_path.read_bytes())
     callback_bin_path.unlink()
-    with open(output_log, "a") as log_file:
+    # Append in binary to match the command's own byte writes; text mode would
+    # translate newlines and break TaskReader.read_output's newline split.
+    with open(output_log, "ab") as log_file:
         try:
             callback(meta)
-            log_file.write("\nCallback successfully triggered")
+            log_file.write(b"\nCallback successfully triggered")
         except Exception as error:
-            log_file.write(f"\nCallback failed: {error!s}\n")
+            log_file.write(f"\nCallback failed: {error!s}\n".encode())
 
 
 def _resolve_outcome(returncode: int, cancelled: bool) -> tuple[bool, str]:

--- a/admin/backend/tasks/manager/wrapper.py
+++ b/admin/backend/tasks/manager/wrapper.py
@@ -39,6 +39,17 @@ def main() -> None:
     cwd = str(sites_dir) if sites_dir.is_dir() else str(bench_root)
 
     cancelled = {"flag": False}
+    holder: dict[str, subprocess.Popen] = {}
+
+    # Register before Popen so a cancel (TaskRunner.kill SIGTERMs us) can't slip
+    # through to the default handler and skip cleanup. ponytail: SIGTERM only; a
+    # SIGKILL escalation upstream can't be cleaned after.
+    def _on_term(_signum, _frame) -> None:
+        cancelled["flag"] = True
+        if proc := holder.get("proc"):
+            proc.terminate()
+
+    signal.signal(signal.SIGTERM, _on_term)
 
     with open(task_dir / "output.log", "wb") as log_file:
         process = subprocess.Popen(
@@ -47,16 +58,7 @@ def main() -> None:
             stdout=log_file,
             stderr=subprocess.STDOUT,
         )
-
-        def _on_term(_signum, _frame) -> None:
-            # Cancel (TaskRunner.kill) SIGTERMs this wrapper. Forward it to the
-            # command so it stops too, then fall through to run on_failure cleanup.
-            # ponytail: SIGTERM only; if a command ignores it the kill escalates
-            # to SIGKILL upstream, which we can't clean after — acceptable for now.
-            cancelled["flag"] = True
-            process.terminate()
-
-        signal.signal(signal.SIGTERM, _on_term)
+        holder["proc"] = process
         returncode = process.wait()
 
     succeeded = returncode == 0 and not cancelled["flag"]

--- a/admin/backend/views/apps.py
+++ b/admin/backend/views/apps.py
@@ -9,6 +9,7 @@ from flask import Blueprint, current_app, jsonify, request
 
 from ..readers.app_reader import AppReader
 from ..validators import first_error, validate_app_name, validate_branch_name, validate_repo_url
+from admin.backend.tasks.callbacks import app_fetch_failure_callback
 from admin.backend.tasks.manager.task_runner import TaskRunner
 
 apps_bp = Blueprint("apps", __name__)
@@ -53,7 +54,9 @@ def add():
 
     try:
         task_id = TaskRunner(bench_root).run(
-            "get-app", {"name": name, "repo": repo, "branch": branch}
+            "get-app",
+            {"name": name, "repo": repo, "branch": branch},
+            callbacks={"on_failure": app_fetch_failure_callback},
         )
     except Exception as e:
         return jsonify({"ok": False, "error": f"Could not start get-app: {e}"})
@@ -83,7 +86,11 @@ def add_and_install():
 
     try:
         task_args = {"name": name, "repo": repo, "branch": branch, "sites": sites}
-        task_id = TaskRunner(bench_root).run("add-and-install-app", task_args)
+        task_id = TaskRunner(bench_root).run(
+            "add-and-install-app",
+            task_args,
+            callbacks={"on_failure": app_fetch_failure_callback},
+        )
     except Exception as e:
         return jsonify({"ok": False, "error": f"Could not start add-and-install: {e}"})
 

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from flask import Blueprint, current_app, jsonify, request, send_file
 
-from admin.backend.tasks.callbacks import new_site_failure_callback, ssl_setup_failure_callback
+from admin.backend.tasks.callbacks import app_fetch_failure_callback, new_site_failure_callback, ssl_setup_failure_callback
 from ..validators import validate_cron_expression, validate_site_name
 from admin.backend.tasks.manager.task_runner import TaskRunner
 
@@ -177,7 +177,11 @@ def create_from_upload():
         args["private_files"] = str(priv_path)
 
     try:
-        task_id = TaskRunner(bench_root).run("new-site-from-backup", args)
+        task_id = TaskRunner(bench_root).run(
+            "new-site-from-backup",
+            args,
+            callbacks={"on_failure": new_site_failure_callback},
+        )
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)})
     return jsonify({"ok": True, "task_id": task_id})
@@ -268,7 +272,11 @@ def get_and_install_app(name: str):
         task_args = {"site": name, "app": app, "repo": repo}
         if branch:
             task_args["branch"] = branch
-        task_id = TaskRunner(bench_root).run("get-and-install-app", task_args)
+        task_id = TaskRunner(bench_root).run(
+            "get-and-install-app",
+            task_args,
+            callbacks={"on_failure": app_fetch_failure_callback},
+        )
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)})
     return jsonify({"ok": True, "task_id": task_id})

--- a/tests/e2e/flows/admin.py
+++ b/tests/e2e/flows/admin.py
@@ -26,7 +26,8 @@ def login(page: Page, base_url: str, password: str) -> None:
     expect(page.get_by_role("button", name="Create Site")).to_be_visible(timeout=30_000)
 
 
-def create_site(page: Page, base_url: str, site_name: str, admin_password: str) -> None:
+def start_site_create(page: Page, base_url: str, site_name: str, admin_password: str) -> str:
+    """Kick off a site create and return its task_id without waiting."""
     page.goto(f"{base_url}/")
     page.get_by_role("button", name="Create Site").click()
 
@@ -34,18 +35,20 @@ def create_site(page: Page, base_url: str, site_name: str, admin_password: str) 
     dialog.get_by_label("Site Name").fill(site_name)
     dialog.get_by_label("Admin Password").fill(admin_password)
 
-    task_id = run_task_action(
+    return run_task_action(
         page,
         "/api/sites/create",
         lambda: dialog.get_by_role("button", name="Create Site").click(),
     )
+
+
+def create_site(page: Page, base_url: str, site_name: str, admin_password: str) -> None:
+    task_id = start_site_create(page, base_url, site_name, admin_password)
     wait_for_task(page.request, base_url, task_id)
 
 
-def install_custom_app(page: Page, base_url: str, site_name: str, repo: str, branch: str) -> None:
-    """Install an app from a public git repository via the custom-app flow. Using
-    an explicit repo/branch keeps the test independent of marketplace registry
-    contents."""
+def start_custom_app_install(page: Page, base_url: str, site_name: str, repo: str, branch: str) -> str:
+    """Kick off a custom-app install and return its task_id without waiting."""
     _open_site_tab(page, base_url, site_name, "apps")
     page.get_by_role("button", name="Install App").click()
 
@@ -54,11 +57,18 @@ def install_custom_app(page: Page, base_url: str, site_name: str, repo: str, bra
     dialog.get_by_label("Repository URL").fill(repo)
     dialog.get_by_label("Branch").fill(branch)
 
-    task_id = run_task_action(
+    return run_task_action(
         page,
         "/api/sites/",
         lambda: dialog.get_by_role("button", name="Install", exact=True).click(),
     )
+
+
+def install_custom_app(page: Page, base_url: str, site_name: str, repo: str, branch: str) -> None:
+    """Install an app from a public git repository via the custom-app flow. Using
+    an explicit repo/branch keeps the test independent of marketplace registry
+    contents."""
+    task_id = start_custom_app_install(page, base_url, site_name, repo, branch)
     wait_for_task(page.request, base_url, task_id)
 
 
@@ -116,6 +126,12 @@ def site_exists(page: Page, base_url: str, site_name: str) -> bool:
     if not res.ok:
         return False
     return any(s.get("name") == site_name for s in res.json())
+
+
+def bench_app_names(page: Page, base_url: str) -> list[str]:
+    res = page.request.get(f"{base_url}/api/apps/")
+    expect(res).to_be_ok()
+    return [a.get("name") for a in res.json()]
 
 
 def _open_site_tab(page: Page, base_url: str, site_name: str, tab: str) -> None:

--- a/tests/e2e/harness/tasks.py
+++ b/tests/e2e/harness/tasks.py
@@ -64,6 +64,31 @@ def run_and_await_task(
     wait_for_task(page.request, base_url, task_id, timeout)
 
 
+def wait_for_task_status(
+    request: APIRequestContext,
+    base_url: str,
+    task_id: str,
+    timeout: float = 30 * 60,
+) -> tuple[str, list[str]]:
+    """Poll /api/tasks/:id until it settles; return (status, output_lines)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        res = request.get(f"{base_url}/api/tasks/{task_id}")
+        if res.ok:
+            data = res.json()
+            status = data["task"]["status"]
+            if status in ("success", "failed", "killed"):
+                return status, data.get("output") or []
+        time.sleep(2)
+    raise TimeoutError(f"Task {task_id} did not settle within {timeout}s")
+
+
+def cancel_task(request: APIRequestContext, base_url: str, task_id: str) -> None:
+    """Request cancellation. A 400 (task already finished) is fine — the caller
+    asserts on the settled status afterwards."""
+    request.post(f"{base_url}/api/tasks/{task_id}/kill")
+
+
 def expect_bench_online(request: APIRequestContext, base_url: str) -> None:
     """Sanity assert that the admin is reachable and out of wizard mode."""
     res = request.get(f"{base_url}/api/status")

--- a/tests/e2e/specs/test_bench_lifecycle.py
+++ b/tests/e2e/specs/test_bench_lifecycle.py
@@ -22,16 +22,19 @@ import os
 import pytest
 
 from flows.admin import (
+    bench_app_names,
     create_site,
     drop_site,
     install_custom_app,
     installed_apps,
     login,
     site_exists,
+    start_custom_app_install,
+    start_site_create,
     uninstall_app,
 )
 from flows.wizard import complete_dev_wizard
-from harness.tasks import expect_bench_online
+from harness.tasks import cancel_task, expect_bench_online, wait_for_task_status
 
 pytestmark = pytest.mark.incremental
 
@@ -112,6 +115,35 @@ def test_uninstalls_extra_app(bench, page):
     assert EXTRA_APP_NAME not in installed_apps(page, bench.admin_url, SITE)
 
 
+@_skip_extra_app
+def test_cancelled_app_install_is_rolled_back(bench, page):
+    """Cancel a custom-app install mid-clone; the app must not be left on the
+    bench (app_fetch_failure_callback runs on the cancel path)."""
+    before = set(bench_app_names(page, bench.admin_url))
+    task_id = start_custom_app_install(page, bench.admin_url, SITE, EXTRA_APP_REPO, EXTRA_APP_BRANCH)
+    cancel_task(page.request, bench.admin_url, task_id)
+
+    status, _ = wait_for_task_status(page.request, bench.admin_url, task_id)
+    if status == "success":
+        pytest.skip("install finished before the cancel landed")
+    assert set(bench_app_names(page, bench.admin_url)) == before, "cancelled install left an orphan app"
+
+
 def test_drops_the_site(bench, page):
     drop_site(page, bench.admin_url, SITE)
     assert not site_exists(page, bench.admin_url, SITE)
+
+
+CANCEL_SITE = "cancel-me.localhost"
+
+
+def test_cancelled_site_create_is_rolled_back(bench, page):
+    """Cancel a site create mid-run; new_site_failure_callback must drop the
+    database and remove the site so nothing is left behind."""
+    task_id = start_site_create(page, bench.admin_url, CANCEL_SITE, SITE_ADMIN_PASSWORD)
+    cancel_task(page.request, bench.admin_url, task_id)
+
+    status, _ = wait_for_task_status(page.request, bench.admin_url, task_id)
+    if status == "success":
+        pytest.skip("site create finished before the cancel landed")
+    assert not site_exists(page, bench.admin_url, CANCEL_SITE)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,95 @@
+"""Tests for admin.backend.tasks.callbacks — failure cleanup must only remove
+what the failed task created, never a pre-existing site."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from admin.backend.tasks import callbacks
+
+
+@pytest.fixture(autouse=True)
+def _no_hosts_writes(monkeypatch):
+    # Never let a test touch /etc/hosts via sudo.
+    monkeypatch.setattr(callbacks.subprocess, "run", lambda *a, **k: None)
+
+
+def _make_site(bench_root: Path, name: str) -> Path:
+    site = bench_root / "sites" / name
+    site.mkdir(parents=True)
+    (site / "site_config.json").write_text("{}")
+    return site
+
+
+def test_new_site_failure_callback_removes_created_site(tmp_path: Path) -> None:
+    site = _make_site(tmp_path, "broken.localhost")
+    callbacks.new_site_failure_callback({"args": {"name": "broken.localhost"}, "bench_root": str(tmp_path)})
+    assert not site.exists()
+
+
+def test_new_site_failure_callback_noop_when_nothing_created(tmp_path: Path) -> None:
+    # A validate-stage failure leaves no site dir; the view guard means the name
+    # never belonged to a pre-existing site. Callback must not raise.
+    (tmp_path / "sites").mkdir()
+    callbacks.new_site_failure_callback({"args": {"name": "never-made.localhost"}, "bench_root": str(tmp_path)})
+
+
+def test_new_site_failure_callback_leaves_sibling_site(tmp_path: Path) -> None:
+    sibling = _make_site(tmp_path, "healthy.localhost")
+    callbacks.new_site_failure_callback({"args": {"name": "broken.localhost"}, "bench_root": str(tmp_path)})
+    assert sibling.exists()
+
+
+# ── app_fetch_failure_callback — only ever removes what the task cloned ───────
+
+
+def _make_apps(bench_root: Path, *names: str) -> None:
+    apps = bench_root / "apps"
+    apps.mkdir(exist_ok=True)
+    for name in names:
+        (apps / name).mkdir()
+
+
+def test_created_apps_excludes_pre_existing(tmp_path: Path) -> None:
+    _make_apps(tmp_path, "frappe", "erpnext", "newapp")
+    assert sorted(callbacks._created_apps(tmp_path, {"frappe", "erpnext"})) == ["newapp"]
+
+
+def test_app_fetch_failure_callback_only_tears_down_created(tmp_path: Path, monkeypatch) -> None:
+    _make_apps(tmp_path, "frappe", "newapp")  # frappe pre-existing, newapp this task
+    torn: list[str] = []
+    monkeypatch.setattr(callbacks, "_load_bench", lambda root: object())
+    monkeypatch.setattr(callbacks, "_teardown_app", lambda bench, root, name: torn.append(name))
+
+    callbacks.app_fetch_failure_callback(
+        {"bench_root": str(tmp_path), "pre_existing_apps": ["frappe"], "args": {"name": "newapp"}}
+    )
+    assert torn == ["newapp"]
+
+
+def test_app_fetch_failure_callback_noop_without_snapshot(tmp_path: Path, monkeypatch) -> None:
+    # No pre_existing_apps key → cannot prove safety → must not load bench or delete.
+    _make_apps(tmp_path, "frappe", "newapp")
+    monkeypatch.setattr(callbacks, "_load_bench", lambda root: pytest.fail("must not run"))
+    callbacks.app_fetch_failure_callback({"bench_root": str(tmp_path), "args": {"name": "newapp"}})
+
+
+def test_app_fetch_failure_callback_noop_when_all_pre_existing(tmp_path: Path, monkeypatch) -> None:
+    _make_apps(tmp_path, "frappe")
+    monkeypatch.setattr(callbacks, "_load_bench", lambda root: pytest.fail("must not run"))
+    callbacks.app_fetch_failure_callback(
+        {"bench_root": str(tmp_path), "pre_existing_apps": ["frappe"], "args": {}}
+    )
+
+
+def test_force_teardown_removes_dir_and_apps_txt_line(tmp_path: Path) -> None:
+    _make_apps(tmp_path, "newapp")
+    sites = tmp_path / "sites"
+    sites.mkdir()
+    (sites / "apps.txt").write_text("frappe\nnewapp\n")
+
+    callbacks._force_teardown(object(), tmp_path, "newapp")  # pip uninstall fails → ignored
+
+    assert not (tmp_path / "apps" / "newapp").exists()
+    assert (sites / "apps.txt").read_text() == "frappe\n"

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -28,6 +28,23 @@ def test_new_site_failure_callback_removes_created_site(tmp_path: Path) -> None:
     assert not site.exists()
 
 
+def test_new_site_failure_callback_drops_database_and_dir(tmp_path: Path, monkeypatch) -> None:
+    # DB cleanup must be attempted for the failed site, and the dir removed.
+    site = _make_site(tmp_path, "broken.localhost")
+    dropped: list[str] = []
+    monkeypatch.setattr(callbacks, "_drop_site_best_effort", lambda root, name: dropped.append(name))
+
+    callbacks.new_site_failure_callback({"args": {"name": "broken.localhost"}, "bench_root": str(tmp_path)})
+
+    assert dropped == ["broken.localhost"]
+    assert not site.exists()
+
+
+def test_drop_site_best_effort_swallows_errors(tmp_path: Path) -> None:
+    # No bench.toml here → _load_bench raises → must be swallowed, never propagate.
+    callbacks._drop_site_best_effort(tmp_path, "broken.localhost")
+
+
 def test_new_site_failure_callback_noop_when_nothing_created(tmp_path: Path) -> None:
     # A validate-stage failure leaves no site dir; the view guard means the name
     # never belonged to a pre-existing site. Callback must not raise.

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -83,6 +83,19 @@ def test_app_fetch_failure_callback_noop_when_all_pre_existing(tmp_path: Path, m
     )
 
 
+def test_app_fetch_failure_callback_tears_down_even_if_bench_unloadable(tmp_path: Path, monkeypatch) -> None:
+    # Broken bench config must not abandon cleanup — created apps still get removed.
+    _make_apps(tmp_path, "frappe", "newapp")
+    torn: list[tuple] = []
+    monkeypatch.setattr(callbacks, "_load_bench", lambda root: (_ for _ in ()).throw(RuntimeError("bad toml")))
+    monkeypatch.setattr(callbacks, "_teardown_app", lambda bench, root, name: torn.append((bench, name)))
+
+    callbacks.app_fetch_failure_callback(
+        {"bench_root": str(tmp_path), "pre_existing_apps": ["frappe"], "args": {"name": "newapp"}}
+    )
+    assert torn == [(None, "newapp")]
+
+
 def test_force_teardown_removes_dir_and_apps_txt_line(tmp_path: Path) -> None:
     _make_apps(tmp_path, "newapp")
     sites = tmp_path / "sites"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -2,16 +2,25 @@
 from __future__ import annotations
 
 import json
+import os
+import pickle
 import re
+import signal
+import subprocess
 import sys
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from admin.backend.tasks.callbacks import new_site_failure_callback
 from admin.backend.tasks.manager.task_runner import TaskRunner, TASK_RETENTION_LIMIT
 from admin.backend.tasks.manager.task_reader import TaskReader
 from pilot.exceptions import TaskNotFoundError, TaskNotRunningError
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 # ── TaskRunner._generate_task_id ────────────────────────────────────────────
@@ -65,6 +74,32 @@ def test_build_argv_new_site_carries_no_db_type(tmp_path: Path) -> None:
     assert argv[1:3] == ["-m", "admin.backend.tasks.jobs.new_site_task"]
     assert "site1.localhost" in argv
     assert "--db-type" not in argv
+
+
+def test_run_records_pre_existing_apps_for_app_fetch(tmp_path: Path) -> None:
+    (tmp_path / "apps").mkdir()
+    (tmp_path / "apps" / "frappe").mkdir()
+    runner = TaskRunner(tmp_path)
+    mock_proc = MagicMock()
+    mock_proc.pid = 4242
+
+    with patch("admin.backend.tasks.manager.task_runner.subprocess.Popen", return_value=mock_proc):
+        task_id = runner.run("get-app", {"name": "erpnext", "repo": "https://x/erpnext"})
+
+    meta = json.loads((tmp_path / "tasks" / task_id / "meta.json").read_text())
+    assert meta["pre_existing_apps"] == ["frappe"]
+
+
+def test_run_omits_pre_existing_apps_for_non_app_command(tmp_path: Path) -> None:
+    runner = TaskRunner(tmp_path)
+    mock_proc = MagicMock()
+    mock_proc.pid = 4242
+
+    with patch("admin.backend.tasks.manager.task_runner.subprocess.Popen", return_value=mock_proc):
+        task_id = runner.run("build", {})
+
+    meta = json.loads((tmp_path / "tasks" / task_id / "meta.json").read_text())
+    assert "pre_existing_apps" not in meta
 
 
 def test_build_argv_get_app(tmp_path: Path) -> None:
@@ -350,3 +385,69 @@ def test_task_retention_limit(tmp_path: Path) -> None:
         and (entry / "status").read_text().strip() != "running"
     ]
     assert len(remaining_completed) == TASK_RETENTION_LIMIT
+
+
+# ── wrapper: on_failure runs on failure AND on cancel (SIGTERM) ───────────────
+
+
+def _build_run_task_dir(bench_root: Path, command_argv: list[str], site_to_clean: str) -> Path:
+    """A task dir the real wrapper can execute, with new_site_failure_callback
+    wired as on_failure (it removes sites/<site_to_clean>, our proof it ran)."""
+    (bench_root / "sites" / site_to_clean).mkdir(parents=True)
+    (bench_root / "sites" / site_to_clean / "site_config.json").write_text("{}")
+
+    task_dir = bench_root / "tasks" / "20260521-000000-aabbcc"
+    task_dir.mkdir(parents=True)
+    meta = {
+        "task_id": task_dir.name,
+        "command": "new-site",
+        "args": {"name": site_to_clean},
+        "command_argv": command_argv,
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "finished_at": None,
+        "exit_code": None,
+        "bench_root": str(bench_root),
+    }
+    (task_dir / "meta.json").write_text(json.dumps(meta))
+    (task_dir / "status").write_text("running")
+    (task_dir / "on_failure.bin").write_bytes(pickle.dumps(new_site_failure_callback))
+    return task_dir
+
+
+def _spawn_wrapper(task_dir: Path) -> subprocess.Popen:
+    return subprocess.Popen(
+        [sys.executable, "-m", "admin.backend.tasks.manager.wrapper", str(task_dir)],
+        cwd=str(_REPO_ROOT),
+    )
+
+
+def test_wrapper_runs_on_failure_callback_when_command_fails(tmp_path: Path) -> None:
+    task_dir = _build_run_task_dir(
+        tmp_path, [sys.executable, "-c", "import sys; sys.exit(3)"], "broken.localhost"
+    )
+    proc = _spawn_wrapper(task_dir)
+    proc.wait(timeout=30)
+
+    assert (task_dir / "status").read_text() == "failed"
+    assert json.loads((task_dir / "meta.json").read_text())["exit_code"] == 3
+    assert not (tmp_path / "sites" / "broken.localhost").exists()  # cleanup ran
+
+
+def test_wrapper_cancel_runs_cleanup_and_marks_killed(tmp_path: Path) -> None:
+    task_dir = _build_run_task_dir(
+        tmp_path,
+        [sys.executable, "-c", "import time; print('ready', flush=True); time.sleep(30)"],
+        "broken.localhost",
+    )
+    proc = _spawn_wrapper(task_dir)
+
+    log = task_dir / "output.log"
+    deadline = time.time() + 15
+    while time.time() < deadline and b"ready" not in (log.read_bytes() if log.exists() else b""):
+        time.sleep(0.05)
+
+    proc.send_signal(signal.SIGTERM)  # the cancel
+    proc.wait(timeout=30)
+
+    assert (task_dir / "status").read_text() == "killed"
+    assert not (tmp_path / "sites" / "broken.localhost").exists()  # cleanup ran on cancel

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -421,6 +421,16 @@ def _spawn_wrapper(task_dir: Path) -> subprocess.Popen:
     )
 
 
+def test_resolve_outcome() -> None:
+    from admin.backend.tasks.manager.wrapper import _resolve_outcome
+
+    assert _resolve_outcome(0, False) == (True, "success")
+    # cancel racing in after a clean exit-0 must stay success (no teardown).
+    assert _resolve_outcome(0, True) == (True, "success")
+    assert _resolve_outcome(1, False) == (False, "failed")
+    assert _resolve_outcome(-15, True) == (False, "killed")
+
+
 def test_wrapper_runs_on_failure_callback_when_command_fails(tmp_path: Path) -> None:
     task_dir = _build_run_task_dir(
         tmp_path, [sys.executable, "-c", "import sys; sys.exit(3)"], "broken.localhost"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -441,6 +441,9 @@ def test_wrapper_runs_on_failure_callback_when_command_fails(tmp_path: Path) -> 
     assert (task_dir / "status").read_text() == "failed"
     assert json.loads((task_dir / "meta.json").read_text())["exit_code"] == 3
     assert not (tmp_path / "sites" / "broken.localhost").exists()  # cleanup ran
+    # Callback line is appended in binary, so it stays a clean newline-split line.
+    with patch("os.kill", return_value=None):
+        assert "Callback successfully triggered" in TaskReader(tmp_path).read_output(task_dir.name)
 
 
 def test_wrapper_cancel_runs_cleanup_and_marks_killed(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #30.

Failed or cancelled state-creating tasks left orphans on disk (partial app clone, `apps.txt` line, pip package, site dir, `/etc/hosts` entry). This extends the task-manager callback mechanism so a failed **or cancelled** task rolls back to zero.

## Changes

**Cancel now cleans up** — `wrapper` traps `SIGTERM` (the cancel signal from `TaskRunner.kill`), terminates the child command, runs `on_failure`, and marks the task `killed`. Previously the SIGTERM hit the wrapper itself, so cleanup never ran and the command was orphaned.

**Full app rollback** — `app_fetch_failure_callback` reverses `get-app` completely by reusing `RemoveAppCommand` (uninstall-from-sites → `apps.txt` → pip uninstall → rmtree), with a force-teardown fallback for half-built/unregistered apps.

**Safety guard** — `TaskRunner` snapshots existing `apps/` dirs into `meta` before dispatch; the callback removes only dirs that appeared *after* (`_created_apps`), never a pre-existing app. This guards the data-loss traps: folder normalization (`india-compliance`→`india_compliance`) and skipped-clone-on-reinstall. If `meta` has no snapshot, the callback does nothing.

**Wiring** — `app_fetch_failure_callback` on `get-app`, `add-and-install`, `get-and-install` (the last has no view-level pre-guard, so the snapshot is its only protection); `new_site_failure_callback` on `new-site-from-backup`.

## Tests
- callback safety: only task-created apps torn down; pre-existing and sibling apps untouched; no-op without snapshot
- wrapper runs `on_failure` and marks `failed` on command failure
- wrapper runs cleanup and marks `killed` on cancel (SIGTERM)

## Known ceilings
- SIGTERM only; if a command ignores it and kill escalates to SIGKILL, no cleanup runs. Add a SIGKILL-timeout escalation if observed in practice.
- Orphan database on a failed site-create is still not dropped (unchanged; matches the existing `new_site_failure_callback`).