### PR TITLE
feat: MariaDB→PostgreSQL backup conversion for Postgres benches

### DIFF
--- a/admin/backend/readers/backup_reader.py
+++ b/admin/backend/readers/backup_reader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gzip
 import re
 from dataclasses import dataclass
 from datetime import datetime
@@ -18,6 +19,29 @@ _REMOTE_FILE_KINDS = {
     "private_files": "private-file",
     "site_config": "site_config",
 }
+
+_MARIADB_MARKERS = ("MariaDB dump", "MySQL dump", "/*!40101", "CREATE TABLE `")
+_POSTGRES_MARKERS = ("PostgreSQL database dump", 'CREATE TABLE "', "CREATE TABLE public.", "COPY public.")
+
+
+def dump_engine(path: str | Path) -> str:
+    """Return the engine ("mariadb" or "postgres") a SQL backup was produced by.
+
+    Mirrors frappe.installer.get_dump_db_type: mysqldump quotes identifiers with
+    backticks and emits `MariaDB dump`; pg_dump uses double quotes and `COPY public.`.
+    """
+    path = str(path)
+    try:
+        opener = gzip.open if path.endswith(".gz") else open
+        with opener(path, "rb") as f:
+            header = f.read(2048).decode(errors="ignore")
+    except OSError:
+        return "mariadb"
+    if any(marker in header for marker in _MARIADB_MARKERS):
+        return "mariadb"
+    if any(marker in header for marker in _POSTGRES_MARKERS):
+        return "postgres"
+    return "mariadb" if "`" in header else "postgres"
 
 
 @dataclass

--- a/admin/backend/readers/backup_reader.py
+++ b/admin/backend/readers/backup_reader.py
@@ -35,7 +35,9 @@ def dump_engine(path: str | Path) -> str:
         opener = gzip.open if path.endswith(".gz") else open
         with opener(path, "rb") as f:
             header = f.read(2048).decode(errors="ignore")
-    except OSError:
+    except Exception:
+        # Unreadable / corrupt / truncated upload: fall back so the caller returns a
+        # clean error, not a 500 (zlib.error and EOFError from gzip aren't OSErrors).
         return "mariadb"
     if any(marker in header for marker in _MARIADB_MARKERS):
         return "mariadb"

--- a/admin/backend/tasks/jobs/new_site_from_backup_task.py
+++ b/admin/backend/tasks/jobs/new_site_from_backup_task.py
@@ -14,6 +14,7 @@ class NewSiteFromBackupTask(BaseTask):
         p.add_argument("--admin-password", default="admin")
         p.add_argument("--public-files", default=None)
         p.add_argument("--private-files", default=None)
+        p.add_argument("--force", action="store_true")
         return p
 
     def __init__(self, bench, bench_root, args):
@@ -23,6 +24,7 @@ class NewSiteFromBackupTask(BaseTask):
         self.admin_password = args.admin_password
         self.public_files = args.public_files
         self.private_files = args.private_files
+        self.force = args.force
 
     def run(self) -> None:
         self._step("restore", f"Restore site {self.name} from backup")
@@ -33,6 +35,7 @@ class NewSiteFromBackupTask(BaseTask):
             admin_password=self.admin_password,
             public_files=self.public_files,
             private_files=self.private_files,
+            force=self.force,
         ).run()
         self._step("done")
 

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -159,7 +159,7 @@ class TaskRunner:
         if command == "new-site":
             argv = [sys.executable, "-m", "admin.backend.tasks.jobs.new_site_task", str(self._bench_root), args["name"]]
             if args.get("admin_password"):
-                argv += ["--admin-password", args["admin_password"]]
+                argv += [f"--admin-password={args['admin_password']}"]
             if args.get("db_type"):
                 argv += ["--db-type", args["db_type"]]
             if args.get("apps"):
@@ -169,7 +169,7 @@ class TaskRunner:
             return [sys.executable, "-m", "admin.backend.tasks.jobs.drop_site_task", str(self._bench_root), args["site"]]
         if command == "reinstall-site":
             argv = [sys.executable, "-m", "admin.backend.tasks.jobs.reinstall_site_task", str(self._bench_root), args["site"]]
-            argv += ["--admin-password", args["admin_password"]]
+            argv += [f"--admin-password={args['admin_password']}"]
             return argv
         if command == "delete-backup":
             return [sys.executable, "-m", "admin.backend.tasks.jobs.delete_backup_task", str(self._bench_root), args["site"], *args["filenames"]]
@@ -200,7 +200,7 @@ class TaskRunner:
         if command == "new-site-from-backup":
             argv = [sys.executable, "-m", "admin.backend.tasks.jobs.new_site_from_backup_task", str(self._bench_root), args["name"], args["db_file"]]
             if args.get("admin_password"):
-                argv += ["--admin-password", args["admin_password"]]
+                argv += [f"--admin-password={args['admin_password']}"]
             if args.get("public_files"):
                 argv += ["--public-files", args["public_files"]]
             if args.get("private_files"):

--- a/admin/backend/tasks/manager/task_runner.py
+++ b/admin/backend/tasks/manager/task_runner.py
@@ -205,6 +205,8 @@ class TaskRunner:
                 argv += ["--public-files", args["public_files"]]
             if args.get("private_files"):
                 argv += ["--private-files", args["private_files"]]
+            if args.get("convert"):
+                argv += ["--force"]
             return argv
         if command == "update-cli":
             return [sys.executable, "-m", "admin.backend.tasks.jobs.update_cli_task", str(self._bench_root)]

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import secrets
+import shutil
 import subprocess
 from dataclasses import asdict
 from pathlib import Path
@@ -13,7 +14,11 @@ from admin.backend.tasks.callbacks import new_site_failure_callback, ssl_setup_f
 from ..validators import validate_cron_expression, validate_site_name
 from admin.backend.tasks.manager.task_runner import TaskRunner
 
+from pilot.config.bench_config import BenchConfig
+from pilot.platform import is_linux, is_x86_64
+
 from ..readers.app_reader import AppReader
+from ..readers.backup_reader import dump_engine
 from ..readers.site_reader import SiteReader
 
 site_name = lambda kw: kw["name"]
@@ -195,11 +200,60 @@ def create_from_upload():
         priv_upload.save(str(priv_path))
         args["private_files"] = str(priv_path)
 
+    # A MariaDB backup uploaded for a PostgreSQL site must be converted with pgloader.
+    config = BenchConfig.from_file(bench_root / "bench.toml")
+    if config.db_type == "postgres" and dump_engine(db_path) == "mariadb":
+        # pgloader only runs on x86_64 Linux — block early rather than fail mid-restore.
+        if not (is_linux() and is_x86_64()):
+            return jsonify(
+                {
+                    "ok": False,
+                    "error": (
+                        "This is a MariaDB backup; restoring it onto a PostgreSQL site needs pgloader, "
+                        "which only runs on x86_64 Linux. Convert it on an x86_64 Linux host first, then "
+                        "upload the resulting PostgreSQL backup."
+                    ),
+                }
+            )
+        # Have the user confirm the conversion (experimental, not guaranteed). The saved
+        # paths are returned so the confirm can resume without re-uploading.
+        if request.form.get("convert") != "true":
+            return jsonify(
+                {
+                    "ok": False,
+                    "needs_conversion_confirm": True,
+                    "message": (
+                        "You have uploaded a MariaDB backup for a PostgreSQL site restore. "
+                        "It will be converted with pgloader before restoring.\n\n"
+                        "• This does not work on ARM / Apple Silicon.\n"
+                        "• PostgreSQL support is experimental, so a successful conversion is not guaranteed."
+                    ),
+                    "name": name,
+                    "db_file": str(db_path),
+                    "public_files": args.get("public_files"),
+                    "private_files": args.get("private_files"),
+                }
+            )
+
     try:
         task_id = TaskRunner(bench_root).run("new-site-from-backup", args)
     except Exception as e:
         return jsonify({"ok": False, "error": str(e)})
     return jsonify({"ok": True, "task_id": task_id})
+
+
+@sites_bp.route("/discard-upload", methods=["POST"])
+def discard_upload():
+    """Delete an uploaded backup that won't be restored (e.g. the user cancelled the
+    MariaDB→PostgreSQL conversion prompt), so it doesn't linger in tmp/uploads."""
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    db_file = (request.get_json(silent=True) or {}).get("db_file") or ""
+    uploads_root = (bench_root / "tmp" / "uploads").resolve()
+    token_dir = Path(db_file).resolve().parent
+    # Only ever remove a token directory directly under this bench's upload staging area.
+    if token_dir.parent == uploads_root:
+        shutil.rmtree(token_dir, ignore_errors=True)
+    return jsonify({"ok": True})
 
 
 @sites_bp.route("/<name>/drop", methods=["POST"])

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -205,6 +205,8 @@ def create_from_upload():
     if config.db_type == "postgres" and dump_engine(db_path) == "mariadb":
         # pgloader only runs on x86_64 Linux — block early rather than fail mid-restore.
         if not (is_linux() and is_x86_64()):
+            # Dead end (no resume), so discard the staged upload instead of leaking it.
+            shutil.rmtree(upload_dir, ignore_errors=True)
             return jsonify(
                 {
                     "ok": False,

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -237,6 +237,9 @@ def create_from_upload():
                     "private_files": args.get("private_files"),
                 }
             )
+        # Conversion confirmed: mark it so the task adds --force, which the restore
+        # needs to stage the MariaDB dump for pgloader.
+        args["convert"] = True
 
     try:
         task_id = TaskRunner(bench_root).run("new-site-from-backup", args)

--- a/admin/backend/views/sites.py
+++ b/admin/backend/views/sites.py
@@ -14,7 +14,6 @@ from admin.backend.tasks.callbacks import new_site_failure_callback, ssl_setup_f
 from ..validators import validate_cron_expression, validate_site_name
 from admin.backend.tasks.manager.task_runner import TaskRunner
 
-from pilot.config.bench_config import BenchConfig
 from pilot.platform import is_linux, is_x86_64
 
 from ..readers.app_reader import AppReader
@@ -201,7 +200,9 @@ def create_from_upload():
         args["private_files"] = str(priv_path)
 
     # A MariaDB backup uploaded for a PostgreSQL site must be converted with pgloader.
-    config = BenchConfig.from_file(bench_root / "bench.toml")
+    from pilot.config.toml_store import BenchTomlStore
+
+    config = BenchTomlStore.for_bench(bench_root).read()
     if config.db_type == "postgres" and dump_engine(db_path) == "mariadb":
         # pgloader only runs on x86_64 Linux — block early rather than fail mid-restore.
         if not (is_linux() and is_x86_64()):

--- a/pilot/commands/restore_site_from_backup.py
+++ b/pilot/commands/restore_site_from_backup.py
@@ -16,6 +16,7 @@ class NewSiteFromBackupCommand:
         admin_password: str = "admin",
         public_files: str | None = None,
         private_files: str | None = None,
+        force: bool = False,
     ) -> None:
         self.bench = bench
         self.name = name
@@ -23,16 +24,18 @@ class NewSiteFromBackupCommand:
         self.admin_password = admin_password
         self.public_files = public_files
         self.private_files = private_files
+        self.force = force
 
     def run(self) -> None:
         from pilot.commands.new_site import NewSiteCommand
         from pilot.config.site_config import SiteConfig
         from pilot.core.site import Site
 
-        # The site is created with (and restored into) the bench's single engine;
-        # the backup must have been taken from a bench of that same engine.
+        # The site is created with (and restored into) the bench's single engine. A
+        # MariaDB backup on a PostgreSQL bench is converted by frappe during restore;
+        # force=True skips the interactive conversion confirm (already confirmed upstream).
         NewSiteCommand(self.bench, self.name, [], self.admin_password).run()
         print(f"Restoring backup: {self.db_file}")
         sys.stdout.flush()
         site = Site(SiteConfig(name=self.name, apps=[]), self.bench)
-        site.restore(self.db_file, self.public_files, self.private_files)
+        site.restore(self.db_file, self.public_files, self.private_files, force=self.force)

--- a/pilot/core/bench.py
+++ b/pilot/core/bench.py
@@ -72,6 +72,22 @@ class Bench:
         mariadb = self.config.mariadb
         return ["--db-root-username", mariadb.admin_user, "--db-root-password", mariadb.root_password]
 
+    def source_mariadb_args(self) -> list[str]:
+        """This bench's MariaDB connection, passed to frappe restore so a MariaDB backup
+        on a PostgreSQL site can be staged there for pgloader conversion. frappe ignores
+        these unless the backup being restored is actually a MariaDB dump."""
+        mariadb = self.config.mariadb
+        return [
+            "--source-mariadb-host",
+            mariadb.host,
+            "--source-mariadb-port",
+            str(mariadb.port),
+            "--source-mariadb-root-username",
+            mariadb.admin_user,
+            "--source-mariadb-root-password",
+            mariadb.root_password,
+        ]
+
     def postgres_root_password(self) -> str:
         # frappe's postgres setup falls back to an interactive getpass() — which
         # hangs the background task — when the password is empty. Pass a non-empty

--- a/pilot/core/site.py
+++ b/pilot/core/site.py
@@ -83,10 +83,11 @@ class Site:
             cmd += ["--with-private-files", private_files]
         if force:
             cmd.append("--force")
-        # A MariaDB backup restored onto a PostgreSQL site is converted via pgloader,
-        # which stages the dump in this bench's MariaDB server; frappe ignores these
-        # args for PostgreSQL backups.
-        if self.bench.config.db_type == "postgres":
+        # Converting a MariaDB backup onto a PostgreSQL site needs this bench's MariaDB
+        # server (pgloader stages the dump there); only conversion restores set force.
+        # Gate on it so a plain postgres->postgres restore doesn't expose the MariaDB
+        # root password in the process list.
+        if self.bench.config.db_type == "postgres" and force:
             cmd += self.bench.source_mariadb_args()
         # restore reads the engine from the site's config (frappe.init); it only
         # needs the matching root credentials, not a --db-type flag.

--- a/pilot/core/site.py
+++ b/pilot/core/site.py
@@ -60,22 +60,34 @@ class Site:
     def _postgres_db_args(self) -> list[str]:
         postgres = self.bench.config.postgres
         return [
-            "--db-type", "postgres",
-            "--db-host", postgres.host,
-            "--db-port", str(postgres.port),
-            "--db-root-username", postgres.admin_user,
-            "--db-root-password", self.bench.postgres_root_password(),
+            "--db-type",
+            "postgres",
+            "--db-host",
+            postgres.host,
+            "--db-port",
+            str(postgres.port),
+            "--db-root-username",
+            postgres.admin_user,
+            "--db-root-password",
+            self.bench.postgres_root_password(),
         ]
 
     def _sqlite_db_args(self) -> list[str]:
         return ["--db-type", "sqlite"]
 
-    def restore(self, db_file: str, public_files: str | None = None, private_files: str | None = None) -> None:
+    def restore(self, db_file: str, public_files: str | None = None, private_files: str | None = None, force: bool = False) -> None:
         cmd = self._frappe_call("frappe", "--site", self.config.name, "restore", db_file)
         if public_files:
             cmd += ["--with-public-files", public_files]
         if private_files:
             cmd += ["--with-private-files", private_files]
+        if force:
+            cmd.append("--force")
+        # A MariaDB backup restored onto a PostgreSQL site is converted via pgloader,
+        # which stages the dump in this bench's MariaDB server; frappe ignores these
+        # args for PostgreSQL backups.
+        if self.bench.config.db_type == "postgres":
+            cmd += self.bench.source_mariadb_args()
         # restore reads the engine from the site's config (frappe.init); it only
         # needs the matching root credentials, not a --db-type flag.
         cmd += self.bench.db_root_args()

--- a/pilot/managers/postgres_manager.py
+++ b/pilot/managers/postgres_manager.py
@@ -14,6 +14,7 @@ from pilot.platform import (
     is_alpine,
     is_linux,
     is_macos,
+    is_x86_64,
     service_command,
     service_enable_command,
     service_running,
@@ -119,6 +120,19 @@ class PostgresManager:
             return
         get_package_manager().install("postgresql", "postgresql-client")
 
+    def _install_conversion_tools(self) -> None:
+        """Install pgloader (+ MariaDB client) used to convert MariaDB backups to PostgreSQL.
+
+        pgloader only runs on x86_64 Linux, so it's skipped elsewhere — conversion errors
+        clearly there. Best-effort: a missing pgloader package must not fail provisioning.
+        """
+        if which("pgloader") or not (is_linux() and is_x86_64()):
+            return
+        try:
+            get_package_manager().install("pgloader", "mariadb-client")
+        except subprocess.CalledProcessError:
+            print("  Warning: could not install pgloader; MariaDB→PostgreSQL conversion will be unavailable.")
+
     def alpine_packages(self) -> list[str]:
         major = self._alpine_major()
         return [f"postgresql{major}", f"postgresql{major}-client"]
@@ -219,6 +233,7 @@ class PostgresManager:
     def provision(self) -> None:
         """Install, start, enable and secure the server. Idempotent — safe to re-run."""
         self.install()
+        self._install_conversion_tools()
         if self.is_dedicated:
             self._provision_instance()
         else:
@@ -236,10 +251,17 @@ class PostgresManager:
         if not supports_dedicated_postgres():
             raise RuntimeError("Dedicated PostgreSQL clusters require systemd (postgresql-common); use the shared server instead.")
         if not self._cluster_row():
-            run_command(_privileged([
-                "pg_createcluster", self._detected_version(), self.config.instance,
-                "-p", str(self.config.port),
-            ]))
+            run_command(
+                _privileged(
+                    [
+                        "pg_createcluster",
+                        self._detected_version(),
+                        self.config.instance,
+                        "-p",
+                        str(self.config.port),
+                    ]
+                )
+            )
         # Start directly (not via systemd's templated unit — see _ctlcluster).
         if not self.is_running():
             self.start()
@@ -259,10 +281,7 @@ class PostgresManager:
         """Ensure the admin role exists with the configured password so frappe can
         connect over TCP. Idempotent: a no-op once credentials work."""
         if not self.config.root_password:
-            print(
-                "  postgres.root_password is empty — skipping superuser setup. "
-                "Set it in Settings before creating PostgreSQL sites."
-            )
+            print("  postgres.root_password is empty — skipping superuser setup. Set it in Settings before creating PostgreSQL sites.")
             return
         if self.check_credentials():
             return

--- a/pilot/platform.py
+++ b/pilot/platform.py
@@ -35,6 +35,10 @@ def is_linux() -> bool:
     return detect() == Platform.LINUX
 
 
+def is_x86_64() -> bool:
+    return platform.machine().lower() in ("x86_64", "amd64")
+
+
 def is_alpine() -> bool:
     """Return True on Alpine Linux (apk package manager, OpenRC, musl libc)."""
     if not is_linux():

--- a/tests/test_admin_app.py
+++ b/tests/test_admin_app.py
@@ -389,7 +389,10 @@ def test_api_benches_ready_false_when_nginx_down_at_domain(tmp_path: Path) -> No
 
 def _write_prod_bench_toml(bench_dir: Path, name: str) -> None:
     bench_dir.mkdir(parents=True, exist_ok=True)
-    (bench_dir / "bench.toml").write_text(f'[bench]\nname = "{name}"\n\n[admin]\nport = 9999\n\n[production]\nenabled = true\nprocess_manager = "systemd"\n')
+    (bench_dir / "bench.toml").write_text(
+        f'[bench]\nname = "{name}"\n\n[admin]\nport = 9999\n\n'
+        f'[production]\nenabled = true\nprocess_manager = "systemd"\n'
+    )
 
 
 def test_api_benches_control_rejects_unknown_action(tmp_path: Path) -> None:

--- a/tests/test_admin_app.py
+++ b/tests/test_admin_app.py
@@ -578,6 +578,8 @@ def test_upload_mariadb_to_postgres_blocked_off_x86_linux(tmp_path: Path) -> Non
     assert "needs_conversion_confirm" not in payload
     assert "x86_64" in payload["error"]
     run.assert_not_called()
+    uploads = tmp_path / "benches" / "current" / "tmp" / "uploads"
+    assert list(uploads.iterdir()) == []  # dead-end upload is cleaned up, not leaked
 
 
 def test_discard_upload_removes_staged_dir(tmp_path: Path) -> None:

--- a/tests/test_admin_app.py
+++ b/tests/test_admin_app.py
@@ -147,8 +147,7 @@ def test_api_benches_new_creates_bench(tmp_path: Path) -> None:
     benches_dir = tmp_path / "benches"
     client = _client(benches_dir / "current")
 
-    with patch("subprocess.Popen") as mock_popen, \
-         patch("pilot.core.domain_controller.DomainRouteProvider.wildcard_domains", return_value=[]):
+    with patch("subprocess.Popen") as mock_popen, patch("pilot.core.domain_controller.DomainRouteProvider.wildcard_domains", return_value=[]):
         resp = client.post("/api/benches/new", json=_new_payload("fresh"))
 
     assert resp.get_json()["name"] == "fresh"

--- a/tests/test_admin_app.py
+++ b/tests/test_admin_app.py
@@ -533,7 +533,7 @@ def test_create_site_does_not_carry_db_type(tmp_path: Path) -> None:
 # ── upload a MariaDB backup onto a PostgreSQL bench — prompt before converting ──
 
 
-def _upload_mariadb_dump(client, name: str = "new.localhost"):
+def _upload_mariadb_dump(client, name: str = "new.localhost", convert: bool = False):
     import gzip
     import io
 
@@ -541,11 +541,10 @@ def _upload_mariadb_dump(client, name: str = "new.localhost"):
     with gzip.GzipFile(fileobj=buf, mode="wb") as gz:
         gz.write(b"-- MariaDB dump 10.19\nCREATE TABLE `tabUser` (\n")
     buf.seek(0)
-    return client.post(
-        "/api/sites/create-from-upload",
-        data={"name": name, "admin_password": "admin", "db_file": (buf, "backup.sql.gz")},
-        content_type="multipart/form-data",
-    )
+    data = {"name": name, "admin_password": "admin", "db_file": (buf, "backup.sql.gz")}
+    if convert:
+        data["convert"] = "true"
+    return client.post("/api/sites/create-from-upload", data=data, content_type="multipart/form-data")
 
 
 def test_upload_mariadb_to_postgres_prompts_for_conversion(tmp_path: Path) -> None:
@@ -563,6 +562,21 @@ def test_upload_mariadb_to_postgres_prompts_for_conversion(tmp_path: Path) -> No
     assert "pgloader" in payload["message"]
     assert payload["db_file"]
     run.assert_not_called()  # restore must wait for the user to confirm
+
+
+def test_upload_mariadb_to_postgres_convert_confirmed_forces(tmp_path: Path) -> None:
+    client = _client(tmp_path / "benches" / "current", db_type="postgres")
+    with (
+        patch("admin.backend.views.sites._new_site_name_error", return_value=None),
+        patch("admin.backend.views.sites.is_linux", return_value=True),
+        patch("admin.backend.views.sites.is_x86_64", return_value=True),
+        patch("admin.backend.views.sites.TaskRunner.run", return_value="tid") as run,
+    ):
+        resp = _upload_mariadb_dump(client, convert=True)
+
+    assert resp.get_json()["ok"] is True
+    # convert must reach the task so _build_argv adds --force (which drives the conversion)
+    assert run.call_args.args[1]["convert"] is True
 
 
 def test_upload_mariadb_to_postgres_blocked_off_x86_linux(tmp_path: Path) -> None:

--- a/tests/test_admin_app.py
+++ b/tests/test_admin_app.py
@@ -22,11 +22,11 @@ def _write_raw_bench_toml(bench_dir: Path, name: str, admin_port: int) -> None:
     (bench_dir / "bench.toml").write_text(f'[bench]\nname = "{name}"\n\n[admin]\nport = {admin_port}\n')
 
 
-def _client(bench_root: Path, password: str = "secret"):
+def _client(bench_root: Path, password: str = "secret", **settings):
     from admin.backend.app import create_app
     from pilot.commands.generate_session import ensure_jwt_secret, issue_token
 
-    _write_bench_toml(bench_root, bench_root.name, admin_enabled=True, admin_password=password)
+    _write_bench_toml(bench_root, bench_root.name, admin_enabled=True, admin_password=password, **settings)
     secret = ensure_jwt_secret(bench_root / "bench.toml")
     app = create_app(bench_root)
     app.config["TESTING"] = True
@@ -85,9 +85,7 @@ def test_api_benches_includes_production_metadata(tmp_path: Path) -> None:
         prod_dir = benches_dir / "prod-bench"
         prod_dir.mkdir(parents=True, exist_ok=True)
         (prod_dir / "bench.toml").write_text(
-            f'[bench]\nname = "prod-bench"\n\n'
-            f'[admin]\nport = {live_port}\ndomain = "admin-prod.example.com"\ntls = true\n\n'
-            f'[production]\nenabled = true\nprocess_manager = "systemd"\n'
+            f'[bench]\nname = "prod-bench"\n\n[admin]\nport = {live_port}\ndomain = "admin-prod.example.com"\ntls = true\n\n[production]\nenabled = true\nprocess_manager = "systemd"\n'
         )
         # https only once the cert is in place; pretend it is for this assertion.
         with patch("admin.backend.views.benches.admin_cert_exists", return_value=True):
@@ -109,9 +107,7 @@ def test_api_benches_admin_url_is_http_until_cert_exists(tmp_path: Path) -> None
         prod_dir = benches_dir / "prod-bench"
         prod_dir.mkdir(parents=True, exist_ok=True)
         (prod_dir / "bench.toml").write_text(
-            f'[bench]\nname = "prod-bench"\n\n'
-            f'[admin]\nport = {live_port}\ndomain = "admin-prod.example.com"\ntls = true\n\n'
-            f'[production]\nenabled = true\nprocess_manager = "systemd"\n'
+            f'[bench]\nname = "prod-bench"\n\n[admin]\nport = {live_port}\ndomain = "admin-prod.example.com"\ntls = true\n\n[production]\nenabled = true\nprocess_manager = "systemd"\n'
         )
         with patch("admin.backend.views.benches.admin_cert_exists", return_value=False):
             resp = client.get("/api/benches/")
@@ -172,15 +168,13 @@ def test_api_benches_new_routes_wizard_at_domain_when_production(tmp_path: Path)
     # installs, so WizardSetupTask finishes the job via SetupProductionCommand.
     benches_dir = tmp_path / "benches"
     current = benches_dir / "current"
-    _write_bench_toml(current, "current", admin_enabled=True, admin_password="secret",
-                      admin_domain="current-admin.example.com", admin_tls=True)
+    _write_bench_toml(current, "current", admin_enabled=True, admin_password="secret", admin_domain="current-admin.example.com", admin_tls=True)
     from admin.backend.app import create_app
+
     toml = (current / "bench.toml").read_text()
-    (current / "bench.toml").write_text(
-        toml.replace("enabled = false\nuse_companion_manager",
-                     'enabled = true\nprocess_manager = "systemd"\nuse_companion_manager')
-    )
+    (current / "bench.toml").write_text(toml.replace("enabled = false\nuse_companion_manager", 'enabled = true\nprocess_manager = "systemd"\nuse_companion_manager'))
     from pilot.commands.generate_session import ensure_jwt_secret, issue_token
+
     secret = ensure_jwt_secret(current / "bench.toml")
     app = create_app(current)
     app.config["TESTING"] = True
@@ -260,9 +254,7 @@ def test_api_benches_new_rejects_duplicate_admin_domain(tmp_path: Path) -> None:
     client = _client(benches_dir / "current")
     other = benches_dir / "other"
     (other / "sites").mkdir(parents=True, exist_ok=True)
-    (other / "bench.toml").write_text(
-        '[bench]\nname = "other"\n\n[admin]\ndomain = "shared-admin.example.com"\n'
-    )
+    (other / "bench.toml").write_text('[bench]\nname = "other"\n\n[admin]\ndomain = "shared-admin.example.com"\n')
 
     resp = client.post("/api/benches/new", json=_new_payload("fresh", admin_domain="shared-admin.example.com"))
 
@@ -398,10 +390,7 @@ def test_api_benches_ready_false_when_nginx_down_at_domain(tmp_path: Path) -> No
 
 def _write_prod_bench_toml(bench_dir: Path, name: str) -> None:
     bench_dir.mkdir(parents=True, exist_ok=True)
-    (bench_dir / "bench.toml").write_text(
-        f'[bench]\nname = "{name}"\n\n[admin]\nport = 9999\n\n'
-        f'[production]\nenabled = true\nprocess_manager = "systemd"\n'
-    )
+    (bench_dir / "bench.toml").write_text(f'[bench]\nname = "{name}"\n\n[admin]\nport = 9999\n\n[production]\nenabled = true\nprocess_manager = "systemd"\n')
 
 
 def test_api_benches_control_rejects_unknown_action(tmp_path: Path) -> None:
@@ -519,6 +508,7 @@ def test_api_benches_drop_runs_pilot(tmp_path: Path) -> None:
     argv = mock_run.call_args.args[0]
     assert argv[-4:] == ["--yes", "-b", "prod-bench", "drop"]
 
+
 # ── POST /api/sites/create — engine is bench-level, not per-site ──────────────
 
 
@@ -531,9 +521,88 @@ def test_create_site_does_not_carry_db_type(tmp_path: Path) -> None:
         captured["args"] = args
         return "task_123"
 
-    with patch("admin.backend.views.sites._new_site_name_error", return_value=None), \
-         patch("admin.backend.views.sites.TaskRunner.run", new=fake_run):
+    with patch("admin.backend.views.sites._new_site_name_error", return_value=None), patch("admin.backend.views.sites.TaskRunner.run", new=fake_run):
         resp = client.post("/api/sites/create", json={"name": "s.localhost"})
 
     assert resp.get_json()["ok"] is True
     assert "db_type" not in captured["args"]
+
+
+# ── upload a MariaDB backup onto a PostgreSQL bench — prompt before converting ──
+
+
+def _upload_mariadb_dump(client, name: str = "new.localhost"):
+    import gzip
+    import io
+
+    buf = io.BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode="wb") as gz:
+        gz.write(b"-- MariaDB dump 10.19\nCREATE TABLE `tabUser` (\n")
+    buf.seek(0)
+    return client.post(
+        "/api/sites/create-from-upload",
+        data={"name": name, "admin_password": "admin", "db_file": (buf, "backup.sql.gz")},
+        content_type="multipart/form-data",
+    )
+
+
+def test_upload_mariadb_to_postgres_prompts_for_conversion(tmp_path: Path) -> None:
+    client = _client(tmp_path / "benches" / "current", db_type="postgres")
+    with (
+        patch("admin.backend.views.sites._new_site_name_error", return_value=None),
+        patch("admin.backend.views.sites.is_linux", return_value=True),
+        patch("admin.backend.views.sites.is_x86_64", return_value=True),
+        patch("admin.backend.views.sites.TaskRunner.run") as run,
+    ):
+        resp = _upload_mariadb_dump(client)
+
+    payload = resp.get_json()
+    assert payload["needs_conversion_confirm"] is True
+    assert "pgloader" in payload["message"]
+    assert payload["db_file"]
+    run.assert_not_called()  # restore must wait for the user to confirm
+
+
+def test_upload_mariadb_to_postgres_blocked_off_x86_linux(tmp_path: Path) -> None:
+    client = _client(tmp_path / "benches" / "current", db_type="postgres")
+    with (
+        patch("admin.backend.views.sites._new_site_name_error", return_value=None),
+        patch("admin.backend.views.sites.is_linux", return_value=True),
+        patch("admin.backend.views.sites.is_x86_64", return_value=False),
+        patch("admin.backend.views.sites.TaskRunner.run") as run,
+    ):
+        resp = _upload_mariadb_dump(client)
+
+    payload = resp.get_json()
+    assert payload["ok"] is False
+    assert "needs_conversion_confirm" not in payload
+    assert "x86_64" in payload["error"]
+    run.assert_not_called()
+
+
+def test_discard_upload_removes_staged_dir(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    client = _client(bench_root)
+    upload_dir = bench_root / "tmp" / "uploads" / "tok123"
+    upload_dir.mkdir(parents=True)
+    db_file = upload_dir / "backup.sql.gz"
+    db_file.write_text("x")
+
+    resp = client.post("/api/sites/discard-upload", json={"db_file": str(db_file)})
+
+    assert resp.get_json()["ok"] is True
+    assert not upload_dir.exists()
+
+
+def test_discard_upload_ignores_paths_outside_uploads(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    client = _client(bench_root)
+    outside = bench_root / "important"
+    outside.mkdir(parents=True)
+    keep = outside / "f.txt"
+    keep.write_text("keep")
+
+    resp = client.post("/api/sites/discard-upload", json={"db_file": str(keep)})
+
+    assert resp.get_json()["ok"] is True
+    assert keep.exists()  # not under tmp/uploads — left untouched

--- a/tests/test_backup_reader.py
+++ b/tests/test_backup_reader.py
@@ -1,0 +1,31 @@
+"""Tests for admin.backend.readers.backup_reader.dump_engine."""
+
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+from admin.backend.readers.backup_reader import dump_engine
+
+_MARIADB = "-- begin frappe metadata\n-- end frappe metadata\n/*!40101 SET NAMES utf8mb4 */;\n-- MariaDB dump 10.19\nCREATE TABLE `tabUser` (\n  `name` varchar(140) NOT NULL\n);\n"
+_POSTGRES = '-- begin frappe metadata\n-- end frappe metadata\n--\n-- PostgreSQL database dump\n--\nCREATE TABLE public."tabUser" (\n  "name" varchar(140) NOT NULL\n);\n'
+
+
+def _gz(path: Path, text: str) -> Path:
+    with gzip.open(path, "wt") as f:
+        f.write(text)
+    return path
+
+
+def test_dump_engine_detects_mariadb_gz(tmp_path: Path) -> None:
+    assert dump_engine(_gz(tmp_path / "m.sql.gz", _MARIADB)) == "mariadb"
+
+
+def test_dump_engine_detects_postgres_gz(tmp_path: Path) -> None:
+    assert dump_engine(_gz(tmp_path / "p.sql.gz", _POSTGRES)) == "postgres"
+
+
+def test_dump_engine_detects_plain_sql(tmp_path: Path) -> None:
+    path = tmp_path / "m.sql"
+    path.write_text(_MARIADB)
+    assert dump_engine(path) == "mariadb"

--- a/tests/test_backup_reader.py
+++ b/tests/test_backup_reader.py
@@ -29,3 +29,13 @@ def test_dump_engine_detects_plain_sql(tmp_path: Path) -> None:
     path = tmp_path / "m.sql"
     path.write_text(_MARIADB)
     assert dump_engine(path) == "mariadb"
+
+
+def test_dump_engine_falls_back_on_decompression_error(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    # zlib.error / EOFError from a corrupt/truncated gzip aren't OSError; dump_engine
+    # must swallow them and fall back rather than 500 the upload handler.
+    path = _gz(tmp_path / "c.sql.gz", _MARIADB)
+    with patch("admin.backend.readers.backup_reader.gzip.open", side_effect=EOFError("truncated")):
+        assert dump_engine(path) == "mariadb"

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -49,9 +49,40 @@ def test_install_uses_apt_packages_on_linux() -> None:
 
 def test_install_uses_brew_formula_on_macos() -> None:
     m, pkg = _mgr(version="16"), MagicMock()
-    with patch.object(m, "is_installed", return_value=False), patch(f"{MODULE}.is_macos", return_value=True), patch.object(m, "_installed_brew_formula", return_value=None), patch(f"{MODULE}.get_package_manager", return_value=pkg):
+    with (
+        patch.object(m, "is_installed", return_value=False),
+        patch(f"{MODULE}.is_macos", return_value=True),
+        patch.object(m, "_installed_brew_formula", return_value=None),
+        patch(f"{MODULE}.get_package_manager", return_value=pkg),
+    ):
         m.install()
     pkg.install.assert_called_once_with("postgresql@16")
+
+
+def test_conversion_tools_installed_on_x86_linux() -> None:
+    m, pkg = _mgr(), MagicMock()
+    with (
+        patch(f"{MODULE}.which", return_value=None),
+        patch(f"{MODULE}.is_linux", return_value=True),
+        patch(f"{MODULE}.is_x86_64", return_value=True),
+        patch(f"{MODULE}.get_package_manager", return_value=pkg),
+    ):
+        m._install_conversion_tools()
+    pkg.install.assert_called_once_with("pgloader", "mariadb-client")
+
+
+def test_conversion_tools_skipped_when_pgloader_present() -> None:
+    m = _mgr()
+    with patch(f"{MODULE}.which", return_value="/usr/bin/pgloader"), patch(f"{MODULE}.get_package_manager") as gpm:
+        m._install_conversion_tools()
+    gpm.assert_not_called()
+
+
+def test_conversion_tools_skipped_off_x86_linux() -> None:
+    m = _mgr()
+    with patch(f"{MODULE}.which", return_value=None), patch(f"{MODULE}.is_linux", return_value=True), patch(f"{MODULE}.is_x86_64", return_value=False), patch(f"{MODULE}.get_package_manager") as gpm:
+        m._install_conversion_tools()
+    gpm.assert_not_called()
 
 
 # ── secure ────────────────────────────────────────────────────────────────────
@@ -137,7 +168,16 @@ def test_start_targets_brew_on_macos() -> None:
 
 def test_provision_orchestrates_steps() -> None:
     m = _mgr(root_password="pw")
-    with patch(f"{MODULE}.is_alpine", return_value=False), patch.object(m, "install") as ins, patch.object(m, "enable") as en, patch.object(m, "is_running", return_value=False), patch.object(m, "start") as st, patch.object(m, "_wait_until_reachable"), patch.object(m, "secure") as sec:
+    with (
+        patch(f"{MODULE}.is_alpine", return_value=False),
+        patch.object(m, "install") as ins,
+        patch.object(m, "_install_conversion_tools"),
+        patch.object(m, "enable") as en,
+        patch.object(m, "is_running", return_value=False),
+        patch.object(m, "start") as st,
+        patch.object(m, "_wait_until_reachable"),
+        patch.object(m, "secure") as sec,
+    ):
         m.provision()
     ins.assert_called_once()
     en.assert_called_once()
@@ -150,9 +190,13 @@ def test_provision_orchestrates_steps() -> None:
 
 def test_install_uses_versioned_packages_on_alpine() -> None:
     m, pkg = _mgr(), MagicMock()
-    with patch.object(m, "is_installed", return_value=False), patch(f"{MODULE}.is_macos", return_value=False), \
-         patch(f"{MODULE}.is_alpine", return_value=True), patch.object(m, "_alpine_major", return_value="17"), \
-         patch(f"{MODULE}.get_package_manager", return_value=pkg):
+    with (
+        patch.object(m, "is_installed", return_value=False),
+        patch(f"{MODULE}.is_macos", return_value=False),
+        patch(f"{MODULE}.is_alpine", return_value=True),
+        patch.object(m, "_alpine_major", return_value="17"),
+        patch(f"{MODULE}.get_package_manager", return_value=pkg),
+    ):
         m.install()
     pkg.install.assert_called_once_with("postgresql17", "postgresql17-client")
 
@@ -198,18 +242,22 @@ def test_pick_dedicated_postgres_port_skips_shared_and_siblings(tmp_path) -> Non
 
 def test_provision_routes_to_instance_when_dedicated() -> None:
     m = _dedicated("b1", root_password="pw")
-    with patch.object(m, "install"), patch.object(m, "_provision_instance") as prov, \
-         patch.object(m, "_wait_until_reachable"), patch.object(m, "secure"):
+    with patch.object(m, "install"), patch.object(m, "_provision_instance") as prov, patch.object(m, "_wait_until_reachable"), patch.object(m, "secure"):
         m.provision()
     prov.assert_called_once()
 
 
 def test_provision_instance_creates_then_starts_cluster() -> None:
     m = _dedicated("b1", port=5440)
-    with patch(f"{MODULE}.supports_dedicated_postgres", return_value=True), \
-         patch.object(m, "_cluster_row", return_value=[]), patch.object(m, "_detected_version", return_value="16"), \
-         patch.object(m, "is_running", return_value=False), patch.object(m, "start") as start, \
-         patch.object(m, "enable"), patch(f"{MODULE}.run_command") as rc:
+    with (
+        patch(f"{MODULE}.supports_dedicated_postgres", return_value=True),
+        patch.object(m, "_cluster_row", return_value=[]),
+        patch.object(m, "_detected_version", return_value="16"),
+        patch.object(m, "is_running", return_value=False),
+        patch.object(m, "start") as start,
+        patch.object(m, "enable"),
+        patch(f"{MODULE}.run_command") as rc,
+    ):
         m._provision_instance()
     args = rc.call_args[0][0]
     assert "pg_createcluster" in args and "16" in args and "b1" in args
@@ -237,8 +285,7 @@ def test_provision_instance_rejects_when_unsupported() -> None:
 
 def test_remove_instance_drops_cluster() -> None:
     m = _dedicated("b1")
-    with patch(f"{MODULE}.supports_dedicated_postgres", return_value=True), \
-         patch.object(m, "_cluster_version", return_value="16"), patch(f"{MODULE}.run_command") as rc:
+    with patch(f"{MODULE}.supports_dedicated_postgres", return_value=True), patch.object(m, "_cluster_version", return_value="16"), patch(f"{MODULE}.run_command") as rc:
         m.remove_instance()
     args = rc.call_args[0][0]
     assert "pg_dropcluster" in args and "16" in args and "b1" in args and "--stop" in args

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -242,7 +242,7 @@ def test_pick_dedicated_postgres_port_skips_shared_and_siblings(tmp_path) -> Non
 
 def test_provision_routes_to_instance_when_dedicated() -> None:
     m = _dedicated("b1", root_password="pw")
-    with patch.object(m, "install"), patch.object(m, "_provision_instance") as prov, patch.object(m, "_wait_until_reachable"), patch.object(m, "secure"):
+    with patch.object(m, "install"), patch.object(m, "_install_conversion_tools"), patch.object(m, "_provision_instance") as prov, patch.object(m, "_wait_until_reachable"), patch.object(m, "secure"):
         m.provision()
     prov.assert_called_once()
 

--- a/tests/test_site_restore.py
+++ b/tests/test_site_restore.py
@@ -17,7 +17,7 @@ from pilot.core.bench import Bench
 from pilot.core.site import Site
 
 
-def _restore_cmd(tmp_path: Path, db_type: str) -> list[str]:
+def _restore_cmd(tmp_path: Path, db_type: str, force: bool = False) -> list[str]:
     bench_dir = tmp_path / "benches" / "b1"
     bench_dir.mkdir(parents=True, exist_ok=True)
     config = BenchConfig(
@@ -32,18 +32,24 @@ def _restore_cmd(tmp_path: Path, db_type: str) -> list[str]:
     )
     site = Site(SiteConfig(name="s.localhost", apps=[]), Bench(config, bench_dir))
     with patch("pilot.core.site.run_command") as rc:
-        site.restore("/tmp/backup.sql.gz")
+        site.restore("/tmp/backup.sql.gz", force=force)
     return rc.call_args.args[0]
 
 
-def test_restore_passes_source_mariadb_on_postgres_bench(tmp_path: Path) -> None:
-    cmd = _restore_cmd(tmp_path, "postgres")
+def test_restore_passes_source_mariadb_on_postgres_conversion(tmp_path: Path) -> None:
+    cmd = _restore_cmd(tmp_path, "postgres", force=True)
     assert "--source-mariadb-host" in cmd
     assert cmd[cmd.index("--source-mariadb-host") + 1] == "mariahost"
     assert cmd[cmd.index("--source-mariadb-port") + 1] == "3308"
     assert cmd[cmd.index("--source-mariadb-root-username") + 1] == "root"
 
 
+def test_restore_omits_source_mariadb_without_force(tmp_path: Path) -> None:
+    # a plain postgres->postgres restore must not expose MariaDB creds in the process list
+    cmd = _restore_cmd(tmp_path, "postgres", force=False)
+    assert "--source-mariadb-host" not in cmd
+
+
 def test_restore_omits_source_mariadb_on_mariadb_bench(tmp_path: Path) -> None:
-    cmd = _restore_cmd(tmp_path, "mariadb")
+    cmd = _restore_cmd(tmp_path, "mariadb", force=True)
     assert "--source-mariadb-host" not in cmd

--- a/tests/test_site_restore.py
+++ b/tests/test_site_restore.py
@@ -1,0 +1,49 @@
+"""Site.restore passes the bench's MariaDB connection so a MariaDB backup on a
+PostgreSQL bench can be staged for pgloader conversion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from pilot.config.app_config import AppConfig
+from pilot.config.bench_config import BenchConfig
+from pilot.config.mariadb_config import MariaDBConfig
+from pilot.config.postgres_config import PostgresConfig
+from pilot.config.redis_config import RedisConfig
+from pilot.config.site_config import SiteConfig
+from pilot.config.worker_config import WorkerConfig, WorkerGroup
+from pilot.core.bench import Bench
+from pilot.core.site import Site
+
+
+def _restore_cmd(tmp_path: Path, db_type: str) -> list[str]:
+    bench_dir = tmp_path / "benches" / "b1"
+    bench_dir.mkdir(parents=True, exist_ok=True)
+    config = BenchConfig(
+        name="b1",
+        python_version="3.14",
+        apps=[AppConfig(name="frappe", repo="https://github.com/frappe/frappe", branch="version-16")],
+        mariadb=MariaDBConfig(host="mariahost", port=3308, admin_user="root", root_password="mpw"),
+        postgres=PostgresConfig(admin_user="postgres", root_password="ppw"),
+        redis=RedisConfig(cache_port=13000, queue_port=11000),
+        workers=WorkerConfig(groups=[WorkerGroup(queues=["default"], count=1)]),
+        db_type=db_type,
+    )
+    site = Site(SiteConfig(name="s.localhost", apps=[]), Bench(config, bench_dir))
+    with patch("pilot.core.site.run_command") as rc:
+        site.restore("/tmp/backup.sql.gz")
+    return rc.call_args.args[0]
+
+
+def test_restore_passes_source_mariadb_on_postgres_bench(tmp_path: Path) -> None:
+    cmd = _restore_cmd(tmp_path, "postgres")
+    assert "--source-mariadb-host" in cmd
+    assert cmd[cmd.index("--source-mariadb-host") + 1] == "mariahost"
+    assert cmd[cmd.index("--source-mariadb-port") + 1] == "3308"
+    assert cmd[cmd.index("--source-mariadb-root-username") + 1] == "root"
+
+
+def test_restore_omits_source_mariadb_on_mariadb_bench(tmp_path: Path) -> None:
+    cmd = _restore_cmd(tmp_path, "mariadb")
+    assert "--source-mariadb-host" not in cmd

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,4 +1,5 @@
 """Tests for admin.backend.tasks — TaskRunner and TaskReader."""
+
 from __future__ import annotations
 
 import json
@@ -52,6 +53,18 @@ def test_build_argv_install_app(tmp_path: Path) -> None:
     assert str(tmp_path) in argv
     assert "mysite.localhost" in argv
     assert "erpnext" in argv
+
+
+def test_build_argv_new_site_from_backup_adds_force_on_convert(tmp_path: Path) -> None:
+    runner = TaskRunner(tmp_path)
+    argv = runner._build_argv("new-site-from-backup", {"name": "s.localhost", "db_file": "/b.sql.gz", "convert": True})
+    assert "--force" in argv
+
+
+def test_build_argv_new_site_from_backup_no_force_by_default(tmp_path: Path) -> None:
+    runner = TaskRunner(tmp_path)
+    argv = runner._build_argv("new-site-from-backup", {"name": "s.localhost", "db_file": "/b.sql.gz"})
+    assert "--force" not in argv
 
 
 def test_build_argv_uninstall_app(tmp_path: Path) -> None:
@@ -258,21 +271,25 @@ def test_read_output_returns_all_lines_when_fewer_than_limit(tmp_path: Path) -> 
 
 def test_collapse_cr_no_cr() -> None:
     from admin.backend.tasks.manager.task_reader import _collapse_cr
+
     assert _collapse_cr("hello world") == "hello world"
 
 
 def test_collapse_cr_takes_last_segment() -> None:
     from admin.backend.tasks.manager.task_reader import _collapse_cr
+
     assert _collapse_cr("[50%]\r[60%]\r[70%]") == "[70%]"
 
 
 def test_collapse_cr_leading_cr() -> None:
     from admin.backend.tasks.manager.task_reader import _collapse_cr
+
     assert _collapse_cr("\rUpdating [93%]") == "Updating [93%]"
 
 
 def test_collapse_cr_trailing_cr_ignored() -> None:
     from admin.backend.tasks.manager.task_reader import _collapse_cr
+
     assert _collapse_cr("[100%]\r") == "[100%]"
 
 
@@ -280,6 +297,7 @@ def test_collapse_cr_crlf_keeps_text() -> None:
     # dpkg/apt emit CRLF line endings without a TTY; the \r must not blank the
     # line out (this is what produced a wall of empty rows in the setup wizard).
     from admin.backend.tasks.manager.task_reader import _collapse_cr
+
     assert _collapse_cr("Unpacking package\r") == "Unpacking package"
 
 
@@ -287,11 +305,13 @@ def test_collapse_cr_cleared_progress_padding() -> None:
     # apt clears a progress line by overwriting it with spaces after a \r; the
     # padding must collapse away to the last real segment, not leak spaces.
     from admin.backend.tasks.manager.task_reader import _collapse_cr
+
     assert _collapse_cr("Fetching\r        ") == "Fetching"
 
 
 def test_collapse_cr_all_whitespace_segments() -> None:
     from admin.backend.tasks.manager.task_reader import _collapse_cr
+
     assert _collapse_cr("   \r   ") == ""
 
 
@@ -367,10 +387,5 @@ def test_task_retention_limit(tmp_path: Path) -> None:
     assert not oldest_dir.exists()
 
     # Completed tasks on disk should now equal TASK_RETENTION_LIMIT
-    remaining_completed = [
-        entry
-        for entry in tasks_dir.iterdir()
-        if entry.is_dir() and (entry / "status").exists()
-        and (entry / "status").read_text().strip() != "running"
-    ]
+    remaining_completed = [entry for entry in tasks_dir.iterdir() if entry.is_dir() and (entry / "status").exists() and (entry / "status").read_text().strip() != "running"]
     assert len(remaining_completed) == TASK_RETENTION_LIMIT

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -67,6 +67,15 @@ def test_build_argv_new_site_from_backup_no_force_by_default(tmp_path: Path) -> 
     assert "--force" not in argv
 
 
+def test_build_argv_admin_password_uses_equals_form(tmp_path: Path) -> None:
+    # a token_urlsafe password can start with '-'; the '=' form stops argparse
+    # from reading it as a flag ("expected one argument").
+    runner = TaskRunner(tmp_path)
+    argv = runner._build_argv("new-site", {"name": "s.localhost", "admin_password": "-xY_z"})
+    assert "--admin-password=-xY_z" in argv
+    assert "--admin-password" not in argv
+
+
 def test_build_argv_uninstall_app(tmp_path: Path) -> None:
     runner = TaskRunner(tmp_path)
     argv = runner._build_argv("uninstall-app", {"site": "mysite.localhost", "app": "erpnext"})


### PR DESCRIPTION
## What
Restoring a MariaDB backup onto a PostgreSQL bench now converts it via `pgloader` (handled by the framework converter, frappe/frappe#40431).

## How
- **Provisioning** — installs `pgloader` + `mariadb-client` during Postgres provisioning (x86_64 Linux only; best-effort).
- **Restore** — wires the bench's MariaDB creds into `bench restore` as the pgloader staging server, and threads a `--force` confirmation flag through restore.
- **Admin upload** — detects a MariaDB dump uploaded to a Postgres site; hard-blocks on non-x86_64-Linux, otherwise prompts to confirm the (experimental) conversion and discards the orphaned upload on cancel.

## Depends on
- frappe/frappe#40431 (framework converter)
- Complements frappe/frappe#40338 and frappe/frappe#40395

🤖 Generated with [Claude Code](https://claude.com/claude-code)