### PR TITLE
Install admin Python deps during upgrade

### DIFF
--- a/pilot/commands/upgrade.py
+++ b/pilot/commands/upgrade.py
@@ -37,6 +37,11 @@ class UpgradeCommand(Command):
         print("Pulling latest bench-cli...")
         run_command(["git", "-C", str(cli_root), "pull"], stream_output=True)
 
+        print("Installing admin Python dependencies...")
+        from pilot.managers.admin_env_manager import AdminEnvManager
+
+        AdminEnvManager(cli_root).install_python_deps()
+
         print("Downloading latest admin frontend...")
         if not download_admin_frontend(cli_root):
             print("  Download failed. Run 'bench build-admin' to build from source.")

--- a/pilot/managers/admin_env_manager.py
+++ b/pilot/managers/admin_env_manager.py
@@ -32,17 +32,22 @@ class AdminEnvManager:
 
     def ensure(self) -> None:
         """Create the admin venv and install admin dependencies if not already done."""
-        self._ensure_venv()
+        if self._ensure_venv():
+            self.install_python_deps()
         self._ensure_frontend_deps()
 
-    def _ensure_venv(self) -> None:
+    def _ensure_venv(self) -> bool:
         if self.python.exists():
-            return
+            return False
         print("Setting up admin environment (one-time)...")
         print("  Creating virtual environment...", end=" ", flush=True)
         subprocess.run([self.uv, "venv", str(self.venv_path)], check=True)
         print("done")
+        return True
 
+    def install_python_deps(self) -> None:
+        """Install any missing admin Python dependencies into the admin venv."""
+        self._ensure_venv()
         deps = self._read_admin_deps()
         if not deps:
             print("  No admin dependencies specified, skipping installation.")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -626,6 +626,20 @@ def test_requirements_installs_js_for_app_with_package_json(tmp_path: Path) -> N
 # ── UpdateCommand ─────────────────────────────────────────────────────────────
 
 
+def test_upgrade_command_installs_admin_python_deps() -> None:
+    from pilot.commands.upgrade import UpgradeCommand
+
+    with patch("pilot.commands.admin._cli_root", return_value=Path("/tmp/pilot")), \
+         patch("pilot.utils.run_command") as mock_run_command, \
+         patch("pilot.commands.admin.download_admin_frontend", return_value=True), \
+         patch("pilot.managers.admin_env_manager.AdminEnvManager") as mock_admin_env:
+        UpgradeCommand().run()
+
+    mock_run_command.assert_called_once_with(["git", "-C", "/tmp/pilot", "pull"], stream_output=True)
+    mock_admin_env.assert_called_once_with(Path("/tmp/pilot"))
+    mock_admin_env.return_value.install_python_deps.assert_called_once_with()
+
+
 def test_update_command_runs_all_steps(tmp_path: Path) -> None:
     from pilot.commands.update import UpdateCommand
 


### PR DESCRIPTION
Ensures bench upgrade refreshes the admin app Python dependencies after pulling latest code.\n\nTested:\n- python3 -m compileall -q pilot admin/backend\n- python3 smoke test for UpgradeCommand admin dependency refresh