### PR TITLE
fix(marketplace): In case of different versions allow upgrades

### DIFF
--- a/admin/backend/readers/app_reader.py
+++ b/admin/backend/readers/app_reader.py
@@ -39,42 +39,6 @@ class AppReader:
     def read_one(self, app_name: str) -> AppInfo:
         return self._read_app(app_name)
 
-    def check_remote_updates(self, app_names: list[str]) -> dict[str, bool]:
-        """Run git ls-remote concurrently for each app. Returns {app_name: has_update}.
-
-        ls-remote only exchanges ref pointers with the remote — no object download —
-        so it completes in ~1-2s per app regardless of repo size.
-        """
-        from concurrent.futures import ThreadPoolExecutor, as_completed
-
-        def _check(name: str) -> tuple[str, bool]:
-            app_path = self._bench_root / "apps" / name
-            git_dir = app_path / ".git"
-            if not git_dir.exists():
-                return name, False
-            branch = self._git_branch(git_dir)
-            if not branch:
-                return name, False
-            result = subprocess.run(
-                ["git", "ls-remote", "origin", f"refs/heads/{branch}"],
-                cwd=str(app_path), capture_output=True, text=True, timeout=15,
-            )
-            for line in result.stdout.splitlines():
-                parts = line.split("\t", 1)
-                if len(parts) == 2:
-                    remote_sha = parts[0].strip()
-                    local_sha = self._git_full_sha(git_dir)
-                    return name, bool(remote_sha and local_sha and remote_sha != local_sha)
-            return name, False
-
-        updates: dict[str, bool] = {}
-        with ThreadPoolExecutor(max_workers=8) as pool:
-            futures = {pool.submit(_check, name): name for name in app_names}
-            for fut in as_completed(futures):
-                name, has_update = fut.result()
-                updates[name] = has_update
-        return updates
-
     def list_commits(self, app_name: str, depth: int = 10) -> list[dict]:
         """Shallow-fetch the remote branch tip and return new commits not in HEAD.
 

--- a/admin/backend/tasks/jobs/fetch_app_updates_task.py
+++ b/admin/backend/tasks/jobs/fetch_app_updates_task.py
@@ -1,7 +1,7 @@
 import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING
 
-from admin.backend.readers.app_reader import AppReader
 from pilot.core.marketplace import Marketplace
 
 from .base_task import BaseTask
@@ -21,32 +21,22 @@ class FetchAppUpdatesTask(BaseTask):
         # Index the registry by name once so each app is an O(1) lookup.
         self._marketplace_by_name = {app["name"]: app for app in Marketplace.registry()}
 
-    @staticmethod
-    def _is_on_target_revision(bench_app: "App", target: dict) -> bool:
-        target_type, ref = target["target_type"], target["target"]
-        if target_type == "tag":
-            return bench_app.installed_tag == ref
-        if target_type == "commit":
-            return bool(bench_app.installed_hash) and bench_app.installed_hash.startswith(ref)
-        return False
-
-    def _is_pinned_by_marketplace(self, name: str) -> bool:
-        """Whether the marketplace pins this app to a fixed revision it is still on.
-
-        A commit/tag target pins the app only while it is actually checked out at
-        that revision. If the marketplace now points at a different tag/commit than
-        the app's current one, the update is allowed so it can move forward. Branch
-        targets are always updatable.
-        """
+    def _matching_target(self, name: str, bench_app: "App") -> dict | None:
+        """The marketplace target whose version equals this app's installed version, if any."""
         app = self._marketplace_by_name.get(name)
-        if not app:
-            return False
-        bench_app = self.bench.app(name)
-        if bench_app.config.repo != app["repo"]:
-            return False
-
+        if not app or bench_app.config.repo != app["repo"]:
+            return None
         version = bench_app.installed_version
-        return any(target["version"] == version and self._is_on_target_revision(bench_app, target) for target in app["targets"])
+        return next((t for t in app["targets"] if t["version"] == version), None)
+
+    def _check_update(self, name: str, bench_app: "App") -> bool:
+        target = self._matching_target(name, bench_app)
+        if target and target["target_type"] in ("tag", "commit"):
+            # Marketplace entries only ever advance, so a different pin is
+            # always a forward one — comparing against it locally is exact,
+            # no network round trip needed.
+            return not bench_app.is_on_revision(target)
+        return bench_app.has_remote_update()
 
     def run(self) -> None:
         # No trailing "done" step: Sites.vue reads output[-1] as the JSON result,
@@ -54,8 +44,13 @@ class FetchAppUpdatesTask(BaseTask):
         self._step("fetch", "Check for app updates")
         apps_dir = self.bench_root / "apps"
         app_names = [d.name for d in sorted(apps_dir.iterdir()) if d.is_dir() and (d / ".git").exists()]
-        apps_to_check = [name for name in app_names if not self._is_pinned_by_marketplace(name)]
-        updates = AppReader(self.bench_root).check_remote_updates(apps_to_check)
+
+        updates: dict[str, bool] = {}
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = {pool.submit(self._check_update, name, self.bench.app(name)): name for name in app_names}
+            for future in as_completed(futures):
+                updates[futures[future]] = future.result()
+
         print(json.dumps(updates), flush=True)
 
 

--- a/admin/backend/tasks/jobs/fetch_app_updates_task.py
+++ b/admin/backend/tasks/jobs/fetch_app_updates_task.py
@@ -1,9 +1,13 @@
 import json
+from typing import TYPE_CHECKING
 
 from admin.backend.readers.app_reader import AppReader
 from pilot.core.marketplace import Marketplace
 
 from .base_task import BaseTask
+
+if TYPE_CHECKING:
+    from pilot.core.app import App
 
 
 class FetchAppUpdatesTask(BaseTask):
@@ -17,12 +21,22 @@ class FetchAppUpdatesTask(BaseTask):
         # Index the registry by name once so each app is an O(1) lookup.
         self._marketplace_by_name = {app["name"]: app for app in Marketplace.registry()}
 
-    def _is_pinned_by_marketplace(self, name: str) -> bool:
-        """Whether the marketplace pins this app to a non-branch target.
+    @staticmethod
+    def _is_on_target_revision(bench_app: "App", target: dict) -> bool:
+        target_type, ref = target["target_type"], target["target"]
+        if target_type == "tag":
+            return bench_app.installed_tag == ref
+        if target_type == "commit":
+            return bool(bench_app.installed_hash) and bench_app.installed_hash.startswith(ref)
+        return False
 
-        The target matching the app's installed version decides: a commit/tag
-        target means the marketplace intends a fixed revision, so offering a
-        branch update would move the app off it. Only branch targets are updatable.
+    def _is_pinned_by_marketplace(self, name: str) -> bool:
+        """Whether the marketplace pins this app to a fixed revision it is still on.
+
+        A commit/tag target pins the app only while it is actually checked out at
+        that revision. If the marketplace now points at a different tag/commit than
+        the app's current one, the update is allowed so it can move forward. Branch
+        targets are always updatable.
         """
         app = self._marketplace_by_name.get(name)
         if not app:
@@ -30,11 +44,9 @@ class FetchAppUpdatesTask(BaseTask):
         bench_app = self.bench.app(name)
         if bench_app.config.repo != app["repo"]:
             return False
+
         version = bench_app.installed_version
-        return any(
-            target["version"] == version and target["target_type"] != "branch"
-            for target in app["targets"]
-        )
+        return any(target["version"] == version and self._is_on_target_revision(bench_app, target) for target in app["targets"])
 
     def run(self) -> None:
         # No trailing "done" step: Sites.vue reads output[-1] as the JSON result,

--- a/admin/backend/tasks/jobs/fetch_app_updates_task.py
+++ b/admin/backend/tasks/jobs/fetch_app_updates_task.py
@@ -30,12 +30,15 @@ class FetchAppUpdatesTask(BaseTask):
         return next((t for t in app["targets"] if t["version"] == version), None)
 
     def _check_update(self, name: str, bench_app: "App") -> bool:
+        from pilot.core.app import RevisionPin
+
         target = self._matching_target(name, bench_app)
-        if target and target["target_type"] in ("tag", "commit"):
+        pin = RevisionPin.from_marketplace_target(target) if target else None
+        if pin is not None:
             # Marketplace entries only ever advance, so a different pin is
             # always a forward one — comparing against it locally is exact,
             # no network round trip needed.
-            return not bench_app.is_on_revision(target)
+            return not bench_app.is_on_revision(pin)
         return bench_app.has_remote_update()
 
     def run(self) -> None:

--- a/pilot/commands/update.py
+++ b/pilot/commands/update.py
@@ -11,6 +11,7 @@ from pilot.commands.base import Command
 from pilot.exceptions import CommandError, MigrateError
 
 if TYPE_CHECKING:
+    from pilot.core.app import App
     from pilot.core.bench import Bench
 
 
@@ -103,6 +104,7 @@ class UpdateCommand(Command):
 
     def _snapshot(self):
         from datetime import datetime
+
         from pilot.managers.snapshot_orchestrator import get_orchestrator
 
         self.tag = datetime.now().strftime("%Y%m%d-%H%M%S")  # Dynamically set tag for rollbacks
@@ -170,15 +172,33 @@ class UpdateCommand(Command):
                 pass
 
     def _update_apps(self) -> None:
+        from pilot.core.marketplace import Marketplace
+
+        marketplace_by_name = {entry["name"]: entry for entry in Marketplace.registry()}
+
         for app in self.bench.apps():
             if self._apps_filter is not None and app.config.name not in self._apps_filter:
                 continue
             print(f"Updating {app.config.name}...")
             try:
-                app.update()
+                app.update(target=self._marketplace_target(app, marketplace_by_name))
             except CommandError as e:
                 print(f"  Error updating {app.config.name}: {e}", file=sys.stderr)
                 raise MigrateError(f"Failed to update {app.config.name}")
+
+    @staticmethod
+    def _marketplace_target(app: App, marketplace_by_name: dict) -> dict | None:
+        """The marketplace's currently advertised target for this app, if any.
+
+        Matched by the app's installed version against the registry entry's
+        targets — this is the marketplace's next intended pin, not
+        necessarily the one the app was originally installed at.
+        """
+        entry = marketplace_by_name.get(app.config.name)
+        if not entry or app.config.repo != entry.get("repo"):
+            return None
+        version = app.installed_version
+        return next((t for t in entry.get("targets", []) if t["version"] == version), None)
 
     def _reinstall_apps(self) -> None:
         from pilot.managers.python_env_manager import PythonEnvManager

--- a/pilot/commands/update.py
+++ b/pilot/commands/update.py
@@ -11,7 +11,7 @@ from pilot.commands.base import Command
 from pilot.exceptions import CommandError, MigrateError
 
 if TYPE_CHECKING:
-    from pilot.core.app import App
+    from pilot.core.app import App, RevisionPin
     from pilot.core.bench import Bench
 
 
@@ -181,24 +181,32 @@ class UpdateCommand(Command):
                 continue
             print(f"Updating {app.config.name}...")
             try:
-                app.update(target=self._marketplace_target(app, marketplace_by_name))
+                app.update(pin=self._marketplace_pin(app, marketplace_by_name))
             except CommandError as e:
                 print(f"  Error updating {app.config.name}: {e}", file=sys.stderr)
                 raise MigrateError(f"Failed to update {app.config.name}")
 
     @staticmethod
-    def _marketplace_target(app: App, marketplace_by_name: dict) -> dict | None:
-        """The marketplace's currently advertised target for this app, if any.
+    def _marketplace_pin(app: "App", marketplace_by_name: dict) -> "RevisionPin | None":
+        """The marketplace's currently advertised revision pin for this app, if any.
 
         Matched by the app's installed version against the registry entry's
         targets — this is the marketplace's next intended pin, not
-        necessarily the one the app was originally installed at.
+        necessarily the one the app was originally installed at. None for a
+        branch target, an app not in the marketplace, or a repo mismatch
+        (e.g. a fork) — those keep following the tracked branch.
         """
         entry = marketplace_by_name.get(app.config.name)
         if not entry or app.config.repo != entry.get("repo"):
             return None
         version = app.installed_version
-        return next((t for t in entry.get("targets", []) if t["version"] == version), None)
+        target = next((t for t in entry.get("targets", []) if t["version"] == version), None)
+        if target is None:
+            return None
+
+        from pilot.core.app import RevisionPin
+
+        return RevisionPin.from_marketplace_target(target)
 
     def _reinstall_apps(self) -> None:
         from pilot.managers.python_env_manager import PythonEnvManager

--- a/pilot/core/app.py
+++ b/pilot/core/app.py
@@ -229,8 +229,23 @@ class App:
         )
 
     def _checkout_pinned_target(self, pin: RevisionPin) -> None:
-        run_command(["git", "-C", str(self.path), "fetch", "--depth", "1", "origin", pin.ref])
-        run_command(["git", "-C", str(self.path), "checkout", "FETCH_HEAD"])
+        if pin.kind == "tag":
+            run_command(["git", "-C", str(self.path), "fetch", "--depth", "1", "origin", pin.ref])
+            run_command(["git", "-C", str(self.path), "checkout", "FETCH_HEAD"])
+        else:
+            self._checkout_pinned_commit(pin.ref)
+
+    def _checkout_pinned_commit(self, sha: str) -> None:
+        """Check out a specific commit SHA."""
+        try:
+            run_command(["git", "-C", str(self.path), "fetch", "--depth", "1", "origin", sha])
+            run_command(["git", "-C", str(self.path), "checkout", "FETCH_HEAD"])
+            return
+        except CommandError:
+            pass
+        unshallow_flag = ["--unshallow"] if self._is_shallow else []
+        run_command(["git", "-C", str(self.path), "fetch", *unshallow_flag, "origin", self.config.branch])
+        run_command(["git", "-C", str(self.path), "checkout", sha])
 
     @property
     def module_name(self) -> str:

--- a/pilot/core/app.py
+++ b/pilot/core/app.py
@@ -49,6 +49,48 @@ class App:
         )
         return result.stdout.strip() if result.returncode == 0 else ""
 
+    def is_on_revision(self, target: dict) -> bool:
+        """Whether this app is currently checked out at a marketplace target's pinned revision.
+
+        Only tag/commit targets pin a fixed revision; a branch target has no
+        single revision to be "on", so it's always False.
+        """
+        target_type, ref = target["target_type"], target["target"]
+        if target_type == "tag":
+            return self.installed_tag == ref
+        if target_type == "commit":
+            return bool(self.installed_hash) and self.installed_hash.startswith(ref)
+        return False
+
+    def has_remote_update(self) -> bool:
+        """Whether the tracked branch has commits on origin not yet pulled locally.
+
+        Runs `git ls-remote` — ref pointers only, no object download — so it
+        completes in ~1-2s regardless of repo size. An app not on a branch
+        (detached HEAD, e.g. a tag/commit checkout) has no moving remote tip
+        to compare against, so this always reports no update; use
+        `is_on_revision` against the marketplace target instead.
+        """
+        import subprocess
+
+        branch = self.config.branch
+        if not branch:
+            return False
+        result = subprocess.run(
+            ["git", "ls-remote", "origin", f"refs/heads/{branch}"],
+            cwd=str(self.path),
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        for line in result.stdout.splitlines():
+            parts = line.split("\t", 1)
+            if len(parts) == 2:
+                remote_sha = parts[0].strip()
+                local_sha = self.installed_hash
+                return bool(remote_sha and local_sha and remote_sha != local_sha)
+        return False
+
     @property
     def is_cloned(self) -> bool:
         # The clone may live under the configured name or, after get-app
@@ -139,7 +181,19 @@ class App:
             return 1
         return max(1, cpus // 2)
 
-    def update(self) -> None:
+    def update(self, target: dict | None = None) -> None:
+        """Pull the latest code.
+
+        If `target` is a marketplace tag/commit pin, the app is moved to
+        exactly that advertised revision — not the branch tip or the repo's
+        overall latest tag/commit. Marketplace entries only ever advance, so
+        no ancestry check is needed here; the registry is the source of truth.
+        Otherwise this pulls the tracked branch's tip, as before.
+        """
+        if target and target.get("target_type") in ("tag", "commit"):
+            self._checkout_pinned_target(target)
+            return
+
         cmd = ["git", "-c", f"pack.threads={self._pack_threads()}", "-C", str(self.path), "fetch", "origin", self.config.branch]
         if self._is_shallow:
             cmd.append("--depth=1")
@@ -154,6 +208,10 @@ class App:
                 f"origin/{self.config.branch}",
             ]
         )
+
+    def _checkout_pinned_target(self, target: dict) -> None:
+        run_command(["git", "-C", str(self.path), "fetch", "--depth", "1", "origin", target["target"]])
+        run_command(["git", "-C", str(self.path), "checkout", "FETCH_HEAD"])
 
     @property
     def module_name(self) -> str:

--- a/pilot/core/app.py
+++ b/pilot/core/app.py
@@ -26,6 +26,30 @@ class App:
         return installed_app_version(self.bench.env_path, self.config.name)
 
     @property
+    def installed_hash(self) -> str:
+        """Full SHA of the app's current HEAD, or '' if it can't be resolved."""
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "-C", str(self.path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+
+    @property
+    def installed_tag(self) -> str:
+        """Tag checked out exactly at HEAD, or '' if HEAD isn't on a tag."""
+        import subprocess
+
+        result = subprocess.run(
+            ["git", "-C", str(self.path), "describe", "--tags", "--exact-match"],
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+
+    @property
     def is_cloned(self) -> bool:
         # The clone may live under the configured name or, after get-app
         # normalised it, under the importable module name (e.g. india-compliance

--- a/pilot/core/app.py
+++ b/pilot/core/app.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pilot.config.app_config import AppConfig
 from pilot.exceptions import BenchError, CommandError
@@ -9,6 +10,29 @@ from pilot.utils import installed_app_version, run_command
 
 if TYPE_CHECKING:
     from pilot.core.bench import Bench
+
+
+@dataclass(frozen=True)
+class RevisionPin:
+    """A fixed revision (tag or commit) an app should be checked out at.
+
+    Keeps App's public methods decoupled from the shape of any particular
+    source's data (e.g. the marketplace registry's raw target dicts) —
+    callers translate their own data into this before calling into App.
+    A branch is not a fixed revision, so it has no RevisionPin; pass None
+    to mean "no pin, follow the tracked branch" instead.
+    """
+
+    kind: Literal["tag", "commit"]
+    ref: str
+
+    @classmethod
+    def from_marketplace_target(cls, target: dict) -> "RevisionPin | None":
+        """Build a pin from a registry target dict, or None for a branch target."""
+        kind = target.get("target_type")
+        if kind not in ("tag", "commit"):
+            return None
+        return cls(kind=kind, ref=target["target"])
 
 
 class App:
@@ -49,18 +73,13 @@ class App:
         )
         return result.stdout.strip() if result.returncode == 0 else ""
 
-    def is_on_revision(self, target: dict) -> bool:
-        """Whether this app is currently checked out at a marketplace target's pinned revision.
-
-        Only tag/commit targets pin a fixed revision; a branch target has no
-        single revision to be "on", so it's always False.
-        """
-        target_type, ref = target["target_type"], target["target"]
-        if target_type == "tag":
-            return self.installed_tag == ref
-        if target_type == "commit":
-            return bool(self.installed_hash) and self.installed_hash.startswith(ref)
-        return False
+    def is_on_revision(self, pin: RevisionPin) -> bool:
+        """Whether this app is currently checked out at a pinned revision."""
+        if pin.kind == "tag":
+            return self.installed_tag == pin.ref
+        
+        hash = self.installed_hash
+        return bool(hash) and hash.startswith(pin.ref)
 
     def has_remote_update(self) -> bool:
         """Whether the tracked branch has commits on origin not yet pulled locally.
@@ -181,17 +200,17 @@ class App:
             return 1
         return max(1, cpus // 2)
 
-    def update(self, target: dict | None = None) -> None:
+    def update(self, pin: RevisionPin | None = None) -> None:
         """Pull the latest code.
 
-        If `target` is a marketplace tag/commit pin, the app is moved to
-        exactly that advertised revision — not the branch tip or the repo's
-        overall latest tag/commit. Marketplace entries only ever advance, so
-        no ancestry check is needed here; the registry is the source of truth.
-        Otherwise this pulls the tracked branch's tip, as before.
+        If `pin` is given, the app is moved to exactly that revision — not
+        the branch tip or the repo's overall latest tag/commit. A pin's
+        source (e.g. the marketplace registry) only ever advances, so no
+        ancestry check is needed here; it's the source of truth. Otherwise
+        this pulls the tracked branch's tip, as before.
         """
-        if target and target.get("target_type") in ("tag", "commit"):
-            self._checkout_pinned_target(target)
+        if pin is not None:
+            self._checkout_pinned_target(pin)
             return
 
         cmd = ["git", "-c", f"pack.threads={self._pack_threads()}", "-C", str(self.path), "fetch", "origin", self.config.branch]
@@ -209,8 +228,8 @@ class App:
             ]
         )
 
-    def _checkout_pinned_target(self, target: dict) -> None:
-        run_command(["git", "-C", str(self.path), "fetch", "--depth", "1", "origin", target["target"]])
+    def _checkout_pinned_target(self, pin: RevisionPin) -> None:
+        run_command(["git", "-C", str(self.path), "fetch", "--depth", "1", "origin", pin.ref])
         run_command(["git", "-C", str(self.path), "checkout", "FETCH_HEAD"])
 
     @property

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -682,6 +682,87 @@ def test_update_command_update_apps_raises_on_command_error(tmp_path: Path) -> N
             cmd._update_apps()
 
 
+def test_update_command_marketplace_target_matched_by_version(tmp_path: Path) -> None:
+    from pilot.commands.update import UpdateCommand
+
+    bench = make_bench(tmp_path)
+    cmd = UpdateCommand(bench, skip_confirm=True)
+    app = MagicMock()
+    app.config.name = "helpdesk"
+    app.config.repo = "https://github.com/frappe/helpdesk"
+    app.installed_version = "1.0.0"
+    registry = {
+        "helpdesk": {
+            "repo": "https://github.com/frappe/helpdesk",
+            "targets": [{"version": "1.0.0", "target_type": "tag", "target": "v1.0.0"}],
+        },
+    }
+
+    target = cmd._marketplace_target(app, registry)
+
+    assert target == {"version": "1.0.0", "target_type": "tag", "target": "v1.0.0"}
+
+
+def test_update_command_marketplace_target_none_on_repo_mismatch(tmp_path: Path) -> None:
+    from pilot.commands.update import UpdateCommand
+
+    bench = make_bench(tmp_path)
+    cmd = UpdateCommand(bench, skip_confirm=True)
+    app = MagicMock()
+    app.config.name = "helpdesk"
+    app.config.repo = "https://github.com/someone/helpdesk"  # a fork
+    app.installed_version = "1.0.0"
+    registry = {
+        "helpdesk": {
+            "repo": "https://github.com/frappe/helpdesk",
+            "targets": [{"version": "1.0.0", "target_type": "tag", "target": "v1.0.0"}],
+        },
+    }
+
+    assert cmd._marketplace_target(app, registry) is None
+
+
+def test_update_command_marketplace_target_none_when_not_in_registry(tmp_path: Path) -> None:
+    from pilot.commands.update import UpdateCommand
+
+    bench = make_bench(tmp_path)
+    cmd = UpdateCommand(bench, skip_confirm=True)
+    app = MagicMock()
+    app.config.name = "frappe"
+    app.config.repo = "https://github.com/frappe/frappe"
+    app.installed_version = "16.0.0"
+
+    assert cmd._marketplace_target(app, {}) is None
+
+
+def test_update_command_passes_marketplace_target_to_app_update(tmp_path: Path) -> None:
+    import subprocess
+    from pilot.commands.update import UpdateCommand
+    from pilot.core.marketplace import Marketplace
+
+    bench = make_bench(tmp_path)
+    bench.create_directories()
+    app_dir = bench.apps_path / "helpdesk"
+    app_dir.mkdir()
+    subprocess.run(["git", "init", "-q", str(app_dir)], check=True)
+    subprocess.run(["git", "-C", str(app_dir), "remote", "add", "origin", "https://github.com/frappe/helpdesk"], check=True)
+
+    registry = [{
+        "name": "helpdesk",
+        "repo": "https://github.com/frappe/helpdesk",
+        "targets": [{"version": "1.0.0", "target_type": "tag", "target": "v2.0.0"}],
+    }]
+
+    cmd = UpdateCommand(bench, skip_confirm=True)
+
+    with patch.object(Marketplace, "registry", return_value=registry), \
+            patch("pilot.core.app.App.installed_version", new_callable=lambda: property(lambda self: "1.0.0")), \
+            patch("pilot.core.app.App.update") as mock_update:
+        cmd._update_apps()
+
+    mock_update.assert_called_once_with(target={"version": "1.0.0", "target_type": "tag", "target": "v2.0.0"})
+
+
 def test_update_command_migrate_sites_raises_on_failure(tmp_path: Path) -> None:
     from pilot.commands.update import UpdateCommand
     from pilot.exceptions import CommandError, MigrateError

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -682,8 +682,9 @@ def test_update_command_update_apps_raises_on_command_error(tmp_path: Path) -> N
             cmd._update_apps()
 
 
-def test_update_command_marketplace_target_matched_by_version(tmp_path: Path) -> None:
+def test_update_command_marketplace_pin_matched_by_version(tmp_path: Path) -> None:
     from pilot.commands.update import UpdateCommand
+    from pilot.core.app import RevisionPin
 
     bench = make_bench(tmp_path)
     cmd = UpdateCommand(bench, skip_confirm=True)
@@ -698,12 +699,12 @@ def test_update_command_marketplace_target_matched_by_version(tmp_path: Path) ->
         },
     }
 
-    target = cmd._marketplace_target(app, registry)
+    pin = cmd._marketplace_pin(app, registry)
 
-    assert target == {"version": "1.0.0", "target_type": "tag", "target": "v1.0.0"}
+    assert pin == RevisionPin(kind="tag", ref="v1.0.0")
 
 
-def test_update_command_marketplace_target_none_on_repo_mismatch(tmp_path: Path) -> None:
+def test_update_command_marketplace_pin_none_on_repo_mismatch(tmp_path: Path) -> None:
     from pilot.commands.update import UpdateCommand
 
     bench = make_bench(tmp_path)
@@ -719,10 +720,10 @@ def test_update_command_marketplace_target_none_on_repo_mismatch(tmp_path: Path)
         },
     }
 
-    assert cmd._marketplace_target(app, registry) is None
+    assert cmd._marketplace_pin(app, registry) is None
 
 
-def test_update_command_marketplace_target_none_when_not_in_registry(tmp_path: Path) -> None:
+def test_update_command_marketplace_pin_none_when_not_in_registry(tmp_path: Path) -> None:
     from pilot.commands.update import UpdateCommand
 
     bench = make_bench(tmp_path)
@@ -732,12 +733,32 @@ def test_update_command_marketplace_target_none_when_not_in_registry(tmp_path: P
     app.config.repo = "https://github.com/frappe/frappe"
     app.installed_version = "16.0.0"
 
-    assert cmd._marketplace_target(app, {}) is None
+    assert cmd._marketplace_pin(app, {}) is None
 
 
-def test_update_command_passes_marketplace_target_to_app_update(tmp_path: Path) -> None:
+def test_update_command_marketplace_pin_none_for_branch_target(tmp_path: Path) -> None:
+    from pilot.commands.update import UpdateCommand
+
+    bench = make_bench(tmp_path)
+    cmd = UpdateCommand(bench, skip_confirm=True)
+    app = MagicMock()
+    app.config.name = "hrms"
+    app.config.repo = "https://github.com/frappe/hrms"
+    app.installed_version = "3.0.0"
+    registry = {
+        "hrms": {
+            "repo": "https://github.com/frappe/hrms",
+            "targets": [{"version": "3.0.0", "target_type": "branch", "target": "main"}],
+        },
+    }
+
+    assert cmd._marketplace_pin(app, registry) is None
+
+
+def test_update_command_passes_marketplace_pin_to_app_update(tmp_path: Path) -> None:
     import subprocess
     from pilot.commands.update import UpdateCommand
+    from pilot.core.app import RevisionPin
     from pilot.core.marketplace import Marketplace
 
     bench = make_bench(tmp_path)
@@ -760,7 +781,7 @@ def test_update_command_passes_marketplace_target_to_app_update(tmp_path: Path) 
             patch("pilot.core.app.App.update") as mock_update:
         cmd._update_apps()
 
-    mock_update.assert_called_once_with(target={"version": "1.0.0", "target_type": "tag", "target": "v2.0.0"})
+    mock_update.assert_called_once_with(pin=RevisionPin(kind="tag", ref="v2.0.0"))
 
 
 def test_update_command_migrate_sites_raises_on_failure(tmp_path: Path) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,6 +62,160 @@ def test_app_is_cloned_returns_true_when_git_directory_exists(tmp_path: Path) ->
     assert app.is_cloned is True
 
 
+def _init_git_repo(path: Path) -> None:
+    import subprocess
+
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "t@t.com"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "t"], check=True)
+
+
+def _commit(path: Path, message: str) -> None:
+    import subprocess
+
+    (path / "f").write_text(message)
+    subprocess.run(["git", "-C", str(path), "add", "f"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-q", "-m", message], check=True)
+
+
+def _tag(path: Path, tag: str) -> None:
+    import subprocess
+
+    subprocess.run(["git", "-C", str(path), "tag", tag], check=True)
+
+
+def test_app_is_on_revision_tag_matches(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    app = App(AppConfig(name="myapp", repo="r", branch=""), bench)
+    app.path.mkdir(parents=True)
+    _init_git_repo(app.path)
+    _commit(app.path, "c1")
+    _tag(app.path, "v1.0.0")
+
+    assert app.is_on_revision({"target_type": "tag", "target": "v1.0.0"}) is True
+
+
+def test_app_is_on_revision_tag_mismatch(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    app = App(AppConfig(name="myapp", repo="r", branch=""), bench)
+    app.path.mkdir(parents=True)
+    _init_git_repo(app.path)
+    _commit(app.path, "c1")
+    _tag(app.path, "v1.0.0")
+
+    # Marketplace has since moved to a newer tag the app hasn't been updated to.
+    assert app.is_on_revision({"target_type": "tag", "target": "v2.0.0"}) is False
+
+
+def test_app_is_on_revision_no_tag_at_head(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    app = App(AppConfig(name="myapp", repo="r", branch=""), bench)
+    app.path.mkdir(parents=True)
+    _init_git_repo(app.path)
+    _commit(app.path, "c1")  # HEAD has no tag
+
+    assert app.is_on_revision({"target_type": "tag", "target": "v1.0.0"}) is False
+
+
+def test_app_is_on_revision_commit_prefix_matches(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    app = App(AppConfig(name="myapp", repo="r", branch=""), bench)
+    app.path.mkdir(parents=True)
+    _init_git_repo(app.path)
+    _commit(app.path, "c1")
+    full_sha = app.installed_hash
+
+    # Registry may store an abbreviated hash; a full HEAD sha starting with it counts.
+    assert app.is_on_revision({"target_type": "commit", "target": full_sha[:8]}) is True
+
+
+def test_app_is_on_revision_commit_mismatch(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    app = App(AppConfig(name="myapp", repo="r", branch=""), bench)
+    app.path.mkdir(parents=True)
+    _init_git_repo(app.path)
+    _commit(app.path, "c1")
+
+    assert app.is_on_revision({"target_type": "commit", "target": "0" * 40}) is False
+
+
+def test_app_is_on_revision_branch_target_always_false(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    app = App(AppConfig(name="myapp", repo="r", branch="main"), bench)
+    app.path.mkdir(parents=True)
+    _init_git_repo(app.path)
+    _commit(app.path, "c1")
+
+    # A branch has no single fixed revision to be "on" — always updatable.
+    assert app.is_on_revision({"target_type": "branch", "target": "main"}) is False
+
+
+def test_app_has_remote_update_false_without_tracked_branch(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    app = App(AppConfig(name="myapp", repo="r", branch=""), bench)
+    app.path.mkdir(parents=True)
+    _init_git_repo(app.path)
+    _commit(app.path, "c1")
+
+    # No configured remote at all — must not crash, and detached HEAD has
+    # no branch tip to compare against.
+    assert app.has_remote_update() is False
+
+
+def _clone_at_tag(remote: Path, clone_dir: Path, tag: str, shallow: bool = True) -> None:
+    import subprocess
+
+    subprocess.run(["git", "clone", "-q", str(remote), str(clone_dir)], check=True)
+    if shallow:
+        subprocess.run(["git", "-C", str(clone_dir), "fetch", "-q", "origin", tag, "--depth", "1"], check=True)
+    subprocess.run(["git", "-C", str(clone_dir), "checkout", "-q", tag], check=True)
+
+
+def test_app_update_with_tag_target_checks_out_advertised_tag_not_latest(tmp_path: Path) -> None:
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    _init_git_repo(remote)
+    _commit(remote, "c1")
+    _tag(remote, "v1.0.0")
+    _commit(remote, "c2")
+    _tag(remote, "v2.0.0")  # the repo's actual latest tag
+    _commit(remote, "c3")
+    _tag(remote, "v3.0.0")  # marketplace hasn't advertised this one yet
+
+    bench = make_bench(tmp_path)
+    app = App(AppConfig(name="myapp", repo="r", branch=""), bench)
+    _clone_at_tag(remote, app.path, "v1.0.0")
+
+    # Marketplace's next advertised pin is v2.0.0 — not the repo's true latest (v3.0.0).
+    app.update(target={"target_type": "tag", "target": "v2.0.0"})
+
+    assert app.is_on_revision({"target_type": "tag", "target": "v2.0.0"}) is True
+    assert app.is_on_revision({"target_type": "tag", "target": "v3.0.0"}) is False
+
+
+def test_app_update_with_commit_target_checks_out_advertised_commit(tmp_path: Path) -> None:
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    _init_git_repo(remote)
+    _commit(remote, "c1")
+    _tag(remote, "v1.0.0")
+    _commit(remote, "c2")
+
+    bench = make_bench(tmp_path)
+    app = App(AppConfig(name="myapp", repo="r", branch=""), bench)
+    _clone_at_tag(remote, app.path, "v1.0.0")
+
+    import subprocess
+
+    target_sha = subprocess.run(
+        ["git", "-C", str(remote), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    app.update(target={"target_type": "commit", "target": target_sha})
+
+    assert app.installed_hash == target_sha
+
+
 def test_app_path_is_under_apps_directory(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
     app_config = AppConfig(name="frappe", repo="https://example.com", branch="main")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8,7 +8,7 @@ from pilot.config.mariadb_config import MariaDBConfig
 from pilot.config.redis_config import RedisConfig
 from pilot.config.site_config import SiteConfig
 from pilot.config.worker_config import WorkerConfig, WorkerGroup
-from pilot.core.app import App
+from pilot.core.app import App, RevisionPin
 from pilot.core.bench import Bench
 from pilot.core.site import Site
 from pilot.managers.process_manager import ProcessManager
@@ -84,6 +84,21 @@ def _tag(path: Path, tag: str) -> None:
     subprocess.run(["git", "-C", str(path), "tag", tag], check=True)
 
 
+def test_revision_pin_from_marketplace_target_tag() -> None:
+    pin = RevisionPin.from_marketplace_target({"target_type": "tag", "target": "v1.0.0"})
+    assert pin == RevisionPin(kind="tag", ref="v1.0.0")
+
+
+def test_revision_pin_from_marketplace_target_commit() -> None:
+    pin = RevisionPin.from_marketplace_target({"target_type": "commit", "target": "abc123"})
+    assert pin == RevisionPin(kind="commit", ref="abc123")
+
+
+def test_revision_pin_from_marketplace_target_branch_is_none() -> None:
+    # A branch is not a fixed revision to pin to — no RevisionPin for it.
+    assert RevisionPin.from_marketplace_target({"target_type": "branch", "target": "main"}) is None
+
+
 def test_app_is_on_revision_tag_matches(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
     app = App(AppConfig(name="myapp", repo="r", branch=""), bench)
@@ -92,7 +107,7 @@ def test_app_is_on_revision_tag_matches(tmp_path: Path) -> None:
     _commit(app.path, "c1")
     _tag(app.path, "v1.0.0")
 
-    assert app.is_on_revision({"target_type": "tag", "target": "v1.0.0"}) is True
+    assert app.is_on_revision(RevisionPin(kind="tag", ref="v1.0.0")) is True
 
 
 def test_app_is_on_revision_tag_mismatch(tmp_path: Path) -> None:
@@ -104,7 +119,7 @@ def test_app_is_on_revision_tag_mismatch(tmp_path: Path) -> None:
     _tag(app.path, "v1.0.0")
 
     # Marketplace has since moved to a newer tag the app hasn't been updated to.
-    assert app.is_on_revision({"target_type": "tag", "target": "v2.0.0"}) is False
+    assert app.is_on_revision(RevisionPin(kind="tag", ref="v2.0.0")) is False
 
 
 def test_app_is_on_revision_no_tag_at_head(tmp_path: Path) -> None:
@@ -114,7 +129,7 @@ def test_app_is_on_revision_no_tag_at_head(tmp_path: Path) -> None:
     _init_git_repo(app.path)
     _commit(app.path, "c1")  # HEAD has no tag
 
-    assert app.is_on_revision({"target_type": "tag", "target": "v1.0.0"}) is False
+    assert app.is_on_revision(RevisionPin(kind="tag", ref="v1.0.0")) is False
 
 
 def test_app_is_on_revision_commit_prefix_matches(tmp_path: Path) -> None:
@@ -126,7 +141,7 @@ def test_app_is_on_revision_commit_prefix_matches(tmp_path: Path) -> None:
     full_sha = app.installed_hash
 
     # Registry may store an abbreviated hash; a full HEAD sha starting with it counts.
-    assert app.is_on_revision({"target_type": "commit", "target": full_sha[:8]}) is True
+    assert app.is_on_revision(RevisionPin(kind="commit", ref=full_sha[:8])) is True
 
 
 def test_app_is_on_revision_commit_mismatch(tmp_path: Path) -> None:
@@ -136,18 +151,7 @@ def test_app_is_on_revision_commit_mismatch(tmp_path: Path) -> None:
     _init_git_repo(app.path)
     _commit(app.path, "c1")
 
-    assert app.is_on_revision({"target_type": "commit", "target": "0" * 40}) is False
-
-
-def test_app_is_on_revision_branch_target_always_false(tmp_path: Path) -> None:
-    bench = make_bench(tmp_path)
-    app = App(AppConfig(name="myapp", repo="r", branch="main"), bench)
-    app.path.mkdir(parents=True)
-    _init_git_repo(app.path)
-    _commit(app.path, "c1")
-
-    # A branch has no single fixed revision to be "on" — always updatable.
-    assert app.is_on_revision({"target_type": "branch", "target": "main"}) is False
+    assert app.is_on_revision(RevisionPin(kind="commit", ref="0" * 40)) is False
 
 
 def test_app_has_remote_update_false_without_tracked_branch(tmp_path: Path) -> None:
@@ -187,10 +191,10 @@ def test_app_update_with_tag_target_checks_out_advertised_tag_not_latest(tmp_pat
     _clone_at_tag(remote, app.path, "v1.0.0")
 
     # Marketplace's next advertised pin is v2.0.0 — not the repo's true latest (v3.0.0).
-    app.update(target={"target_type": "tag", "target": "v2.0.0"})
+    app.update(pin=RevisionPin(kind="tag", ref="v2.0.0"))
 
-    assert app.is_on_revision({"target_type": "tag", "target": "v2.0.0"}) is True
-    assert app.is_on_revision({"target_type": "tag", "target": "v3.0.0"}) is False
+    assert app.is_on_revision(RevisionPin(kind="tag", ref="v2.0.0")) is True
+    assert app.is_on_revision(RevisionPin(kind="tag", ref="v3.0.0")) is False
 
 
 def test_app_update_with_commit_target_checks_out_advertised_commit(tmp_path: Path) -> None:
@@ -211,7 +215,7 @@ def test_app_update_with_commit_target_checks_out_advertised_commit(tmp_path: Pa
         ["git", "-C", str(remote), "rev-parse", "HEAD"], capture_output=True, text=True, check=True
     ).stdout.strip()
 
-    app.update(target={"target_type": "commit", "target": target_sha})
+    app.update(pin=RevisionPin(kind="commit", ref=target_sha))
 
     assert app.installed_hash == target_sha
 

--- a/tests/test_fetch_app_updates_task.py
+++ b/tests/test_fetch_app_updates_task.py
@@ -1,9 +1,10 @@
 """Tests for admin.backend.tasks.jobs.fetch_app_updates_task.
 
-Covers the marketplace pinning logic: an app is excluded from the update
-check only while it sits on the fixed (tag/commit) revision the marketplace
-pins it to. A branch target, a moved tag/commit, a repo/version mismatch, or
-a non-marketplace app all stay updatable.
+Covers the marketplace-aware update check: a tag/commit-pinned app resolves
+purely locally by comparing against the marketplace's advertised revision —
+no network needed, and a moved pin is always treated as a forward update
+since marketplace entries only ever advance. Everything else falls back to
+a network-based branch-tip check via App.has_remote_update.
 """
 from __future__ import annotations
 
@@ -11,65 +12,38 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from admin.backend.readers.app_reader import AppReader
 from admin.backend.tasks.jobs.fetch_app_updates_task import FetchAppUpdatesTask
 from pilot.core.marketplace import Marketplace
 
 
-def app_mock(repo: str, version: str = "", installed_hash: str = "", installed_tag: str = "") -> MagicMock:
+def app_mock(
+    repo: str,
+    version: str = "",
+    installed_hash: str = "",
+    installed_tag: str = "",
+    has_remote_update: bool = False,
+) -> MagicMock:
     app = MagicMock()
     app.config.repo = repo
     app.installed_version = version
     app.installed_hash = installed_hash
     app.installed_tag = installed_tag
+    app.has_remote_update.return_value = has_remote_update
+
+    def is_on_revision(target: dict) -> bool:
+        if target["target_type"] == "tag":
+            return installed_tag == target["target"]
+        if target["target_type"] == "commit":
+            return bool(installed_hash) and installed_hash.startswith(target["target"])
+        return False
+
+    app.is_on_revision.side_effect = is_on_revision
     return app
 
 
 def make_task(registry: list[dict], bench: MagicMock, bench_root: Path) -> FetchAppUpdatesTask:
     with patch.object(Marketplace, "registry", return_value=registry):
         return FetchAppUpdatesTask(bench, bench_root, MagicMock())
-
-
-# ── _is_on_target_revision ───────────────────────────────────────────────────
-
-
-def test_on_target_revision_tag_matches() -> None:
-    app = app_mock("r", installed_tag="v1.0.0")
-    assert FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "tag", "target": "v1.0.0"})
-
-
-def test_on_target_revision_tag_differs() -> None:
-    app = app_mock("r", installed_tag="v0.9.0")
-    assert not FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "tag", "target": "v1.0.0"})
-
-
-def test_on_target_revision_no_tag_at_head() -> None:
-    app = app_mock("r", installed_hash="deadbeef", installed_tag="")
-    assert not FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "tag", "target": "v1.0.0"})
-
-
-def test_on_target_revision_commit_prefix_matches() -> None:
-    # Registry may store an abbreviated hash; a full HEAD sha that starts with it counts.
-    app = app_mock("r", installed_hash="abc123def456")
-    assert FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "commit", "target": "abc123"})
-
-
-def test_on_target_revision_commit_differs() -> None:
-    app = app_mock("r", installed_hash="999999aaaa")
-    assert not FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "commit", "target": "abc123"})
-
-
-def test_on_target_revision_commit_empty_head() -> None:
-    app = app_mock("r", installed_hash="")
-    assert not FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "commit", "target": "abc123"})
-
-
-def test_on_target_revision_branch_never_pins() -> None:
-    app = app_mock("r", installed_hash="abc123", installed_tag="main")
-    assert not FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "branch", "target": "main"})
-
-
-# ── _is_pinned_by_marketplace ────────────────────────────────────────────────
 
 
 TAG_REGISTRY = [
@@ -89,63 +63,37 @@ BRANCH_REGISTRY = [
 ]
 
 
-def _task(registry: list[dict], name: str, app: MagicMock, tmp_path: Path) -> FetchAppUpdatesTask:
-    bench = MagicMock()
-    bench.app.side_effect = lambda n: app if n == name else MagicMock()
-    return make_task(registry, bench, tmp_path)
+# ── _matching_target ─────────────────────────────────────────────────────────
 
 
-def test_pinned_when_on_pinned_tag(tmp_path: Path) -> None:
-    app = app_mock("https://github.com/frappe/helpdesk", "1.0.0", installed_tag="v1.0.0")
-    task = _task(TAG_REGISTRY, "helpdesk", app, tmp_path)
-    assert task._is_pinned_by_marketplace("helpdesk") is True
-
-
-def test_not_pinned_when_tag_moved(tmp_path: Path) -> None:
-    # Marketplace points at v1.0.0 but the app sits on v0.9.0 — allow the upgrade.
-    app = app_mock("https://github.com/frappe/helpdesk", "1.0.0", installed_tag="v0.9.0")
-    task = _task(TAG_REGISTRY, "helpdesk", app, tmp_path)
-    assert task._is_pinned_by_marketplace("helpdesk") is False
-
-
-def test_pinned_when_on_pinned_commit(tmp_path: Path) -> None:
-    app = app_mock("https://github.com/frappe/payments", "2.0.0", installed_hash="abc123def456")
-    task = _task(COMMIT_REGISTRY, "payments", app, tmp_path)
-    assert task._is_pinned_by_marketplace("payments") is True
-
-
-def test_not_pinned_when_commit_moved(tmp_path: Path) -> None:
-    app = app_mock("https://github.com/frappe/payments", "2.0.0", installed_hash="fedcba987654")
-    task = _task(COMMIT_REGISTRY, "payments", app, tmp_path)
-    assert task._is_pinned_by_marketplace("payments") is False
-
-
-def test_branch_target_never_pinned(tmp_path: Path) -> None:
-    app = app_mock("https://github.com/frappe/hrms", "3.0.0", installed_hash="deadbeef")
-    task = _task(BRANCH_REGISTRY, "hrms", app, tmp_path)
-    assert task._is_pinned_by_marketplace("hrms") is False
-
-
-def test_not_pinned_when_version_mismatch(tmp_path: Path) -> None:
-    # Installed version doesn't match the pinned target's version — not that target.
-    app = app_mock("https://github.com/frappe/helpdesk", "9.9.9", installed_tag="v1.0.0")
-    task = _task(TAG_REGISTRY, "helpdesk", app, tmp_path)
-    assert task._is_pinned_by_marketplace("helpdesk") is False
-
-
-def test_not_pinned_when_repo_mismatch(tmp_path: Path) -> None:
-    # A fork with a different repo URL isn't the marketplace's app.
-    app = app_mock("https://github.com/someone/helpdesk", "1.0.0", installed_tag="v1.0.0")
-    task = _task(TAG_REGISTRY, "helpdesk", app, tmp_path)
-    assert task._is_pinned_by_marketplace("helpdesk") is False
-
-
-def test_unknown_app_not_pinned_without_touching_git(tmp_path: Path) -> None:
-    # Apps absent from the registry must short-circuit before the (costly) bench.app() call.
+def test_matching_target_found_by_version(tmp_path: Path) -> None:
     bench = MagicMock()
     task = make_task(TAG_REGISTRY, bench, tmp_path)
-    assert task._is_pinned_by_marketplace("frappe") is False
-    bench.app.assert_not_called()
+    app = app_mock("https://github.com/frappe/helpdesk", "1.0.0")
+    target = task._matching_target("helpdesk", app)
+    assert target == {"version": "1.0.0", "target_type": "tag", "target": "v1.0.0"}
+
+
+def test_matching_target_none_when_app_not_in_marketplace(tmp_path: Path) -> None:
+    bench = MagicMock()
+    task = make_task(TAG_REGISTRY, bench, tmp_path)
+    app = app_mock("https://github.com/frappe/frappe", "1.0.0")
+    assert task._matching_target("frappe", app) is None
+
+
+def test_matching_target_none_on_repo_mismatch(tmp_path: Path) -> None:
+    # A fork with a different repo URL isn't the marketplace's app.
+    bench = MagicMock()
+    task = make_task(TAG_REGISTRY, bench, tmp_path)
+    app = app_mock("https://github.com/someone/helpdesk", "1.0.0")
+    assert task._matching_target("helpdesk", app) is None
+
+
+def test_matching_target_none_on_version_mismatch(tmp_path: Path) -> None:
+    bench = MagicMock()
+    task = make_task(TAG_REGISTRY, bench, tmp_path)
+    app = app_mock("https://github.com/frappe/helpdesk", "9.9.9")
+    assert task._matching_target("helpdesk", app) is None
 
 
 # ── run ──────────────────────────────────────────────────────────────────────
@@ -156,56 +104,127 @@ def _make_git_apps(bench_root: Path, names: list[str]) -> None:
         (bench_root / "apps" / name / ".git").mkdir(parents=True)
 
 
-def test_run_excludes_pinned_and_reports_the_rest(tmp_path: Path, capsys) -> None:
-    _make_git_apps(tmp_path, ["erpnext", "payments", "helpdesk"])
-    registry = COMMIT_REGISTRY + BRANCH_REGISTRY  # payments (commit) + hrms (unused here)
+def test_run_pinned_tag_app_reports_no_update_without_network(tmp_path: Path, capsys) -> None:
+    _make_git_apps(tmp_path, ["helpdesk"])
+    app = app_mock("https://github.com/frappe/helpdesk", "1.0.0", installed_tag="v1.0.0")
+    bench = MagicMock()
+    bench.app.side_effect = lambda n: app
+
+    with patch.object(Marketplace, "registry", return_value=TAG_REGISTRY):
+        task = FetchAppUpdatesTask(bench, tmp_path, MagicMock())
+        task.run()
+
+    app.has_remote_update.assert_not_called()  # resolved purely from local state
+    result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert result == {"helpdesk": False}
+
+
+def test_run_reports_update_when_marketplace_tag_moved(tmp_path: Path, capsys) -> None:
+    # App is still on v1.0.0 (the version it was installed at) but the
+    # marketplace's target for that version has since moved to a new tag —
+    # entries only ever advance, so this is always offered as an update,
+    # without any network call.
+    _make_git_apps(tmp_path, ["helpdesk"])
+    app = app_mock("https://github.com/frappe/helpdesk", "1.0.0", installed_tag="v0.9.0")
+    bench = MagicMock()
+    bench.app.side_effect = lambda n: app
+
+    with patch.object(Marketplace, "registry", return_value=TAG_REGISTRY):
+        task = FetchAppUpdatesTask(bench, tmp_path, MagicMock())
+        task.run()
+
+    app.has_remote_update.assert_not_called()
+    result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert result == {"helpdesk": True}
+
+
+def test_run_pinned_commit_app_reports_no_update_without_network(tmp_path: Path, capsys) -> None:
+    _make_git_apps(tmp_path, ["payments"])
+    app = app_mock("https://github.com/frappe/payments", "2.0.0", installed_hash="abc123def456")
+    bench = MagicMock()
+    bench.app.side_effect = lambda n: app
+
+    with patch.object(Marketplace, "registry", return_value=COMMIT_REGISTRY):
+        task = FetchAppUpdatesTask(bench, tmp_path, MagicMock())
+        task.run()
+
+    app.has_remote_update.assert_not_called()
+    result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert result == {"payments": False}
+
+
+def test_run_reports_update_when_marketplace_commit_moved(tmp_path: Path, capsys) -> None:
+    _make_git_apps(tmp_path, ["payments"])
+    app = app_mock("https://github.com/frappe/payments", "2.0.0", installed_hash="deadbeef00")
+    bench = MagicMock()
+    bench.app.side_effect = lambda n: app
+
+    with patch.object(Marketplace, "registry", return_value=COMMIT_REGISTRY):
+        task = FetchAppUpdatesTask(bench, tmp_path, MagicMock())
+        task.run()
+
+    app.has_remote_update.assert_not_called()
+    result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert result == {"payments": True}
+
+
+def test_run_branch_target_falls_back_to_remote_check(tmp_path: Path, capsys) -> None:
+    _make_git_apps(tmp_path, ["hrms"])
+    app = app_mock("https://github.com/frappe/hrms", "3.0.0", has_remote_update=True)
+    bench = MagicMock()
+    bench.app.side_effect = lambda n: app
+
+    with patch.object(Marketplace, "registry", return_value=BRANCH_REGISTRY):
+        task = FetchAppUpdatesTask(bench, tmp_path, MagicMock())
+        task.run()
+
+    app.has_remote_update.assert_called_once()
+    result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert result == {"hrms": True}
+
+
+def test_run_app_not_in_marketplace_falls_back_to_remote_check(tmp_path: Path, capsys) -> None:
+    _make_git_apps(tmp_path, ["frappe"])
+    app = app_mock("https://github.com/frappe/frappe", "16.0.0", has_remote_update=False)
+    bench = MagicMock()
+    bench.app.side_effect = lambda n: app
+
+    with patch.object(Marketplace, "registry", return_value=[]):
+        task = FetchAppUpdatesTask(bench, tmp_path, MagicMock())
+        task.run()
+
+    app.has_remote_update.assert_called_once()
+    result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert result == {"frappe": False}
+
+
+def test_run_mixed_apps_combine_local_and_remote_results(tmp_path: Path, capsys) -> None:
+    _make_git_apps(tmp_path, ["helpdesk", "hrms"])
     apps = {
-        "erpnext": app_mock("https://github.com/frappe/erpnext", "15.0.0"),          # not in registry
-        "payments": app_mock("https://github.com/frappe/payments", "2.0.0", installed_hash="abc123def"),  # on pinned commit
-        "helpdesk": app_mock("https://github.com/frappe/helpdesk", "1.0.0", installed_hash="x"),           # not in registry
+        "helpdesk": app_mock("https://github.com/frappe/helpdesk", "1.0.0", installed_tag="v1.0.0"),  # pinned, local
+        "hrms": app_mock("https://github.com/frappe/hrms", "3.0.0", has_remote_update=True),  # branch, remote
     }
     bench = MagicMock()
     bench.app.side_effect = lambda n: apps[n]
 
-    check = MagicMock(side_effect=lambda names: {n: False for n in names})
-    with patch.object(Marketplace, "registry", return_value=registry), \
-            patch.object(AppReader, "check_remote_updates", check):
+    with patch.object(Marketplace, "registry", return_value=TAG_REGISTRY + BRANCH_REGISTRY):
         task = FetchAppUpdatesTask(bench, tmp_path, MagicMock())
         task.run()
 
-    checked = set(check.call_args.args[0])
-    assert checked == {"erpnext", "helpdesk"}  # payments excluded (pinned)
-
+    apps["helpdesk"].has_remote_update.assert_not_called()
+    apps["hrms"].has_remote_update.assert_called_once()
     result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
-    assert set(result) == {"erpnext", "helpdesk"}
-
-
-def test_run_includes_app_whose_pinned_commit_moved(tmp_path: Path, capsys) -> None:
-    _make_git_apps(tmp_path, ["payments"])
-    apps = {"payments": app_mock("https://github.com/frappe/payments", "2.0.0", installed_hash="different")}
-    bench = MagicMock()
-    bench.app.side_effect = lambda n: apps[n]
-
-    check = MagicMock(side_effect=lambda names: {n: True for n in names})
-    with patch.object(Marketplace, "registry", return_value=COMMIT_REGISTRY), \
-            patch.object(AppReader, "check_remote_updates", check):
-        task = FetchAppUpdatesTask(bench, tmp_path, MagicMock())
-        task.run()
-
-    assert set(check.call_args.args[0]) == {"payments"}
-    result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
-    assert result == {"payments": True}
+    assert result == {"helpdesk": False, "hrms": True}
 
 
 def test_run_ignores_non_git_dirs(tmp_path: Path, capsys) -> None:
     (tmp_path / "apps" / "erpnext" / ".git").mkdir(parents=True)
     (tmp_path / "apps" / "not_an_app").mkdir(parents=True)  # no .git
+    app = app_mock("r", "1.0.0", has_remote_update=False)
     bench = MagicMock()
-    bench.app.side_effect = lambda n: app_mock("r", "1.0.0")
+    bench.app.side_effect = lambda n: app
 
-    check = MagicMock(side_effect=lambda names: {n: False for n in names})
-    with patch.object(Marketplace, "registry", return_value=[]), \
-            patch.object(AppReader, "check_remote_updates", check):
+    with patch.object(Marketplace, "registry", return_value=[]):
         FetchAppUpdatesTask(bench, tmp_path, MagicMock()).run()
 
-    assert set(check.call_args.args[0]) == {"erpnext"}
+    bench.app.assert_called_once_with("erpnext")

--- a/tests/test_fetch_app_updates_task.py
+++ b/tests/test_fetch_app_updates_task.py
@@ -1,0 +1,211 @@
+"""Tests for admin.backend.tasks.jobs.fetch_app_updates_task.
+
+Covers the marketplace pinning logic: an app is excluded from the update
+check only while it sits on the fixed (tag/commit) revision the marketplace
+pins it to. A branch target, a moved tag/commit, a repo/version mismatch, or
+a non-marketplace app all stay updatable.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from admin.backend.readers.app_reader import AppReader
+from admin.backend.tasks.jobs.fetch_app_updates_task import FetchAppUpdatesTask
+from pilot.core.marketplace import Marketplace
+
+
+def app_mock(repo: str, version: str = "", installed_hash: str = "", installed_tag: str = "") -> MagicMock:
+    app = MagicMock()
+    app.config.repo = repo
+    app.installed_version = version
+    app.installed_hash = installed_hash
+    app.installed_tag = installed_tag
+    return app
+
+
+def make_task(registry: list[dict], bench: MagicMock, bench_root: Path) -> FetchAppUpdatesTask:
+    with patch.object(Marketplace, "registry", return_value=registry):
+        return FetchAppUpdatesTask(bench, bench_root, MagicMock())
+
+
+# ── _is_on_target_revision ───────────────────────────────────────────────────
+
+
+def test_on_target_revision_tag_matches() -> None:
+    app = app_mock("r", installed_tag="v1.0.0")
+    assert FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "tag", "target": "v1.0.0"})
+
+
+def test_on_target_revision_tag_differs() -> None:
+    app = app_mock("r", installed_tag="v0.9.0")
+    assert not FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "tag", "target": "v1.0.0"})
+
+
+def test_on_target_revision_no_tag_at_head() -> None:
+    app = app_mock("r", installed_hash="deadbeef", installed_tag="")
+    assert not FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "tag", "target": "v1.0.0"})
+
+
+def test_on_target_revision_commit_prefix_matches() -> None:
+    # Registry may store an abbreviated hash; a full HEAD sha that starts with it counts.
+    app = app_mock("r", installed_hash="abc123def456")
+    assert FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "commit", "target": "abc123"})
+
+
+def test_on_target_revision_commit_differs() -> None:
+    app = app_mock("r", installed_hash="999999aaaa")
+    assert not FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "commit", "target": "abc123"})
+
+
+def test_on_target_revision_commit_empty_head() -> None:
+    app = app_mock("r", installed_hash="")
+    assert not FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "commit", "target": "abc123"})
+
+
+def test_on_target_revision_branch_never_pins() -> None:
+    app = app_mock("r", installed_hash="abc123", installed_tag="main")
+    assert not FetchAppUpdatesTask._is_on_target_revision(app, {"target_type": "branch", "target": "main"})
+
+
+# ── _is_pinned_by_marketplace ────────────────────────────────────────────────
+
+
+TAG_REGISTRY = [
+    {"name": "helpdesk", "repo": "https://github.com/frappe/helpdesk", "targets": [
+        {"version": "1.0.0", "target_type": "tag", "target": "v1.0.0"},
+    ]},
+]
+COMMIT_REGISTRY = [
+    {"name": "payments", "repo": "https://github.com/frappe/payments", "targets": [
+        {"version": "2.0.0", "target_type": "commit", "target": "abc123"},
+    ]},
+]
+BRANCH_REGISTRY = [
+    {"name": "hrms", "repo": "https://github.com/frappe/hrms", "targets": [
+        {"version": "3.0.0", "target_type": "branch", "target": "main"},
+    ]},
+]
+
+
+def _task(registry: list[dict], name: str, app: MagicMock, tmp_path: Path) -> FetchAppUpdatesTask:
+    bench = MagicMock()
+    bench.app.side_effect = lambda n: app if n == name else MagicMock()
+    return make_task(registry, bench, tmp_path)
+
+
+def test_pinned_when_on_pinned_tag(tmp_path: Path) -> None:
+    app = app_mock("https://github.com/frappe/helpdesk", "1.0.0", installed_tag="v1.0.0")
+    task = _task(TAG_REGISTRY, "helpdesk", app, tmp_path)
+    assert task._is_pinned_by_marketplace("helpdesk") is True
+
+
+def test_not_pinned_when_tag_moved(tmp_path: Path) -> None:
+    # Marketplace points at v1.0.0 but the app sits on v0.9.0 — allow the upgrade.
+    app = app_mock("https://github.com/frappe/helpdesk", "1.0.0", installed_tag="v0.9.0")
+    task = _task(TAG_REGISTRY, "helpdesk", app, tmp_path)
+    assert task._is_pinned_by_marketplace("helpdesk") is False
+
+
+def test_pinned_when_on_pinned_commit(tmp_path: Path) -> None:
+    app = app_mock("https://github.com/frappe/payments", "2.0.0", installed_hash="abc123def456")
+    task = _task(COMMIT_REGISTRY, "payments", app, tmp_path)
+    assert task._is_pinned_by_marketplace("payments") is True
+
+
+def test_not_pinned_when_commit_moved(tmp_path: Path) -> None:
+    app = app_mock("https://github.com/frappe/payments", "2.0.0", installed_hash="fedcba987654")
+    task = _task(COMMIT_REGISTRY, "payments", app, tmp_path)
+    assert task._is_pinned_by_marketplace("payments") is False
+
+
+def test_branch_target_never_pinned(tmp_path: Path) -> None:
+    app = app_mock("https://github.com/frappe/hrms", "3.0.0", installed_hash="deadbeef")
+    task = _task(BRANCH_REGISTRY, "hrms", app, tmp_path)
+    assert task._is_pinned_by_marketplace("hrms") is False
+
+
+def test_not_pinned_when_version_mismatch(tmp_path: Path) -> None:
+    # Installed version doesn't match the pinned target's version — not that target.
+    app = app_mock("https://github.com/frappe/helpdesk", "9.9.9", installed_tag="v1.0.0")
+    task = _task(TAG_REGISTRY, "helpdesk", app, tmp_path)
+    assert task._is_pinned_by_marketplace("helpdesk") is False
+
+
+def test_not_pinned_when_repo_mismatch(tmp_path: Path) -> None:
+    # A fork with a different repo URL isn't the marketplace's app.
+    app = app_mock("https://github.com/someone/helpdesk", "1.0.0", installed_tag="v1.0.0")
+    task = _task(TAG_REGISTRY, "helpdesk", app, tmp_path)
+    assert task._is_pinned_by_marketplace("helpdesk") is False
+
+
+def test_unknown_app_not_pinned_without_touching_git(tmp_path: Path) -> None:
+    # Apps absent from the registry must short-circuit before the (costly) bench.app() call.
+    bench = MagicMock()
+    task = make_task(TAG_REGISTRY, bench, tmp_path)
+    assert task._is_pinned_by_marketplace("frappe") is False
+    bench.app.assert_not_called()
+
+
+# ── run ──────────────────────────────────────────────────────────────────────
+
+
+def _make_git_apps(bench_root: Path, names: list[str]) -> None:
+    for name in names:
+        (bench_root / "apps" / name / ".git").mkdir(parents=True)
+
+
+def test_run_excludes_pinned_and_reports_the_rest(tmp_path: Path, capsys) -> None:
+    _make_git_apps(tmp_path, ["erpnext", "payments", "helpdesk"])
+    registry = COMMIT_REGISTRY + BRANCH_REGISTRY  # payments (commit) + hrms (unused here)
+    apps = {
+        "erpnext": app_mock("https://github.com/frappe/erpnext", "15.0.0"),          # not in registry
+        "payments": app_mock("https://github.com/frappe/payments", "2.0.0", installed_hash="abc123def"),  # on pinned commit
+        "helpdesk": app_mock("https://github.com/frappe/helpdesk", "1.0.0", installed_hash="x"),           # not in registry
+    }
+    bench = MagicMock()
+    bench.app.side_effect = lambda n: apps[n]
+
+    check = MagicMock(side_effect=lambda names: {n: False for n in names})
+    with patch.object(Marketplace, "registry", return_value=registry), \
+            patch.object(AppReader, "check_remote_updates", check):
+        task = FetchAppUpdatesTask(bench, tmp_path, MagicMock())
+        task.run()
+
+    checked = set(check.call_args.args[0])
+    assert checked == {"erpnext", "helpdesk"}  # payments excluded (pinned)
+
+    result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert set(result) == {"erpnext", "helpdesk"}
+
+
+def test_run_includes_app_whose_pinned_commit_moved(tmp_path: Path, capsys) -> None:
+    _make_git_apps(tmp_path, ["payments"])
+    apps = {"payments": app_mock("https://github.com/frappe/payments", "2.0.0", installed_hash="different")}
+    bench = MagicMock()
+    bench.app.side_effect = lambda n: apps[n]
+
+    check = MagicMock(side_effect=lambda names: {n: True for n in names})
+    with patch.object(Marketplace, "registry", return_value=COMMIT_REGISTRY), \
+            patch.object(AppReader, "check_remote_updates", check):
+        task = FetchAppUpdatesTask(bench, tmp_path, MagicMock())
+        task.run()
+
+    assert set(check.call_args.args[0]) == {"payments"}
+    result = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert result == {"payments": True}
+
+
+def test_run_ignores_non_git_dirs(tmp_path: Path, capsys) -> None:
+    (tmp_path / "apps" / "erpnext" / ".git").mkdir(parents=True)
+    (tmp_path / "apps" / "not_an_app").mkdir(parents=True)  # no .git
+    bench = MagicMock()
+    bench.app.side_effect = lambda n: app_mock("r", "1.0.0")
+
+    check = MagicMock(side_effect=lambda names: {n: False for n in names})
+    with patch.object(Marketplace, "registry", return_value=[]), \
+            patch.object(AppReader, "check_remote_updates", check):
+        FetchAppUpdatesTask(bench, tmp_path, MagicMock()).run()
+
+    assert set(check.call_args.args[0]) == {"erpnext"}

--- a/tests/test_fetch_app_updates_task.py
+++ b/tests/test_fetch_app_updates_task.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from admin.backend.tasks.jobs.fetch_app_updates_task import FetchAppUpdatesTask
+from pilot.core.app import RevisionPin
 from pilot.core.marketplace import Marketplace
 
 
@@ -30,12 +31,10 @@ def app_mock(
     app.installed_tag = installed_tag
     app.has_remote_update.return_value = has_remote_update
 
-    def is_on_revision(target: dict) -> bool:
-        if target["target_type"] == "tag":
-            return installed_tag == target["target"]
-        if target["target_type"] == "commit":
-            return bool(installed_hash) and installed_hash.startswith(target["target"])
-        return False
+    def is_on_revision(pin: RevisionPin) -> bool:
+        if pin.kind == "tag":
+            return installed_tag == pin.ref
+        return bool(installed_hash) and installed_hash.startswith(pin.ref)
 
     app.is_on_revision.side_effect = is_on_revision
     return app


### PR DESCRIPTION
Allow version upgrades in case the commits do not match with the marketplace target.

### Case
- Marketplace app released a new commit.
- Synced it with the registry.
- Users should be allowed to upgrade. [Only to the advertised tag]
