### PR TITLE
Fix e2e UI tests broken by the admin frontend redesign

### DIFF
--- a/pilot/core/git_providers.py
+++ b/pilot/core/git_providers.py
@@ -163,12 +163,14 @@ class GitHubProvider(GitProvider):
     api_base = "https://api.github.com"
 
     def _headers(self) -> dict:
-        return {
-            "Authorization": f"Bearer {self.token}",
+        headers = {
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
             "User-Agent": "bench-cli",
         }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
 
     def validate(self) -> dict:
         data, _ = self._get_json(f"{self.api_base}/user", self._headers())

--- a/tests/e2e/flows/admin.py
+++ b/tests/e2e/flows/admin.py
@@ -21,7 +21,7 @@ def login(page: Page, base_url: str, password: str) -> None:
     page.context.clear_cookies()
     page.goto(f"{base_url}/")
     page.get_by_placeholder("Password").fill(password)
-    page.get_by_role("button", name="Login").click()
+    page.get_by_role("button", name="Continue").click()
     # Landed on the Sites page once the header action is mounted.
     expect(page.get_by_role("button", name="New site")).to_be_visible(timeout=30_000)
 
@@ -31,7 +31,7 @@ def create_site(page: Page, base_url: str, site_name: str, db_type: str = "") ->
     page.get_by_role("button", name="New site").click()
 
     dialog = page.get_by_role("dialog")
-    dialog.get_by_label("Site Name").fill(site_name)
+    dialog.get_by_label("Site name").fill(site_name)
     if db_type == "sqlite":
         dialog.get_by_role("button", name="SQLite").click()
 
@@ -44,23 +44,60 @@ def create_site(page: Page, base_url: str, site_name: str, db_type: str = "") ->
 
 
 def install_custom_app(page: Page, base_url: str, site_name: str, repo: str, branch: str) -> None:
-    """Install an app from a public git repository via the custom-app flow. Using
-    an explicit repo/branch keeps the test independent of marketplace registry
-    contents."""
-    _open_site_tab(page, base_url, site_name, "apps")
-    page.get_by_role("button", name="Install App").click()
+    """Install an app from a public git repository. Using an explicit repo/branch
+    keeps the test independent of marketplace registry contents.
+
+    Adding a repo to the bench and installing it onto a site are two separate
+    background tasks in the marketplace flow (AddAppFromGithubDialog.vue then
+    InstallAppDialog.vue), so this drives both in turn.
+    """
+    page.goto(f"{base_url}/marketplace?site={site_name}")
+    # "Add from GitHub" only renders once a custom app already exists on the
+    # bench; the always-present entry point for the first one is this link.
+    page.get_by_role("button", name="Building your own? Install from GitHub").click()
 
     dialog = page.get_by_role("dialog")
-    dialog.get_by_role("button", name="Install a custom app").click()
     dialog.get_by_label("Repository URL").fill(repo)
-    dialog.get_by_label("Branch").fill(branch)
+    dialog.get_by_role("button", name="Fetch branches").click()
 
-    task_id = run_task_action(
+    branch_box = dialog.get_by_role("combobox", name="Branch")
+    expect(branch_box).to_be_visible(timeout=30_000)
+    branch_box.click()
+    # The option list is portalled to <body>, outside the dialog's DOM subtree
+    # (same as the wizard's Select), so it must be page-scoped, not dialog-scoped.
+    page.get_by_role("option", name=branch, exact=True).click()
+
+    # Selecting a branch resolves the app name in the background; "Add App"
+    # only enables once that succeeds. Capture the resolved name (it may differ
+    # from the repo URL) so the marketplace card can be found afterwards.
+    add_button = dialog.get_by_role("button", name="Add App")
+    expect(add_button).to_be_enabled(timeout=30_000)
+    # A leading icon sits before this text node, so its content is " Found
+    # <name>" (not anchored at the start) - match unanchored and split instead.
+    found_text = dialog.get_by_text(re.compile(r"Found \S")).inner_text()
+    app_name = found_text.split("Found ", 1)[1].strip()
+
+    add_task_id = run_task_action(page, "/api/apps/add", lambda: add_button.click())
+    wait_for_task(page.request, base_url, add_task_id)
+
+    # Adding lands on the task's detail page; the newly-cloned app now shows up
+    # under "Custom Apps" back on the marketplace, ready to install.
+    page.goto(f"{base_url}/marketplace?site={site_name}")
+    card = (
+        page.locator("div")
+        .filter(has_text=re.compile(rf"\b{re.escape(app_name)}\b", re.IGNORECASE))
+        .filter(has=page.get_by_role("button", name="Install"))
+        .last
+    )
+    card.get_by_role("button", name="Install").click()
+
+    install_dialog = page.get_by_role("dialog")
+    install_task_id = run_task_action(
         page,
         "/api/sites/",
-        lambda: dialog.get_by_role("button", name="Install", exact=True).click(),
+        lambda: install_dialog.get_by_role("button", name="Install", exact=True).click(),
     )
-    wait_for_task(page.request, base_url, task_id)
+    wait_for_task(page.request, base_url, install_task_id)
 
 
 def uninstall_app(page: Page, base_url: str, site_name: str, app_name: str) -> None:
@@ -88,15 +125,17 @@ def uninstall_app(page: Page, base_url: str, site_name: str, app_name: str) -> N
 
 
 def drop_site(page: Page, base_url: str, site_name: str) -> None:
-    _open_site_tab(page, base_url, site_name, "actions")
-    page.get_by_role("button", name="Drop Site").click()
+    # Drop lives in the site's Danger section, part of the "settings" tab (there
+    # is no standalone "actions" tab anymore).
+    _open_site_tab(page, base_url, site_name, "settings")
+    page.get_by_role("button", name="Drop site").click()
 
     dialog = page.get_by_role("dialog")
-    dialog.get_by_label("Type the site name to confirm").fill(site_name)
+    dialog.get_by_label(f"Type {site_name} to confirm").fill(site_name)
     task_id = run_task_action(
         page,
         "/api/sites/",
-        lambda: dialog.get_by_role("button", name="Drop Site").click(),
+        lambda: dialog.get_by_role("button", name="Delete site").click(),
     )
     wait_for_task(page.request, base_url, task_id)
 
@@ -120,7 +159,7 @@ def site_exists(page: Page, base_url: str, site_name: str) -> bool:
 
 
 def _open_site_tab(page: Page, base_url: str, site_name: str, tab: str) -> None:
-    # The tab is selected from the URL hash on mount, so navigating is the most
-    # deterministic way to land on it.
-    page.goto(f"{base_url}/sites/{site_name}#{tab}")
+    # The tab is a router path param (/sites/:name/:tab?), not a URL hash, so
+    # navigating straight to it is the most deterministic way to land there.
+    page.goto(f"{base_url}/sites/{site_name}/{tab}")
     expect(page.get_by_text(site_name, exact=False).first).to_be_visible(timeout=30_000)

--- a/tests/e2e/flows/wizard.py
+++ b/tests/e2e/flows/wizard.py
@@ -60,26 +60,23 @@ def complete_dev_wizard(
     page.get_by_role("button", name="Next").click()
 
     # ── Step 2: Database ────────────────────────────────────────────────────────
+    # MariaDB and PostgreSQL share one set of fields: an engine-agnostic
+    # "Deployment mode" select and generic "Root username" / "Root user password"
+    # fields (Setup.vue's showDeploymentMode/showRootUsername).
     _choose_select(page, "Database engine", "PostgreSQL" if db_type == "postgres" else "MariaDB")
-    if db_type == "postgres":
-        # The dedicated/shared choice only renders where supported (systemd Linux).
-        if page.get_by_role("combobox", name="PostgreSQL setup").is_visible():
-            _choose_select(
-                page,
-                "PostgreSQL setup",
-                "Dedicated cluster" if db_mode == "dedicated" else "Shared system PostgreSQL",
-            )
-        page.get_by_label("PostgreSQL superuser").fill(postgres_admin_user)
-        page.get_by_label("PostgreSQL password").fill(postgres_password)
-    else:
-        # The shared/dedicated choice only renders on Linux.
-        if page.get_by_role("combobox", name="MariaDB setup").is_visible():
-            _choose_select(
-                page,
-                "MariaDB setup",
-                "Dedicated instance" if db_mode == "dedicated" else "Shared system MariaDB",
-            )
-        page.get_by_label("MariaDB root password").fill(mariadb_password)
+    # The dedicated/shared choice only renders where supported (Linux; PostgreSQL
+    # additionally needs systemd, i.e. not Alpine).
+    if page.get_by_role("combobox", name="Deployment mode").is_visible():
+        _choose_select(
+            page,
+            "Deployment mode",
+            "Dedicated Instance" if db_mode == "dedicated" else "Shared Instance",
+        )
+    # Root username only renders when it isn't implied (dedicated instances and
+    # fresh installs default to root/postgres).
+    if page.get_by_label("Root username").is_visible():
+        page.get_by_label("Root username").fill(postgres_admin_user if db_type == "postgres" else "root")
+    page.get_by_label("Root user password").fill(postgres_password if db_type == "postgres" else mariadb_password)
     page.get_by_role("button", name="Next").click()
     # A wrong password surfaces inline and keeps us on this step.
     expect(page.get_by_text("Incorrect MariaDB credentials.")).to_be_hidden()

--- a/tests/e2e/harness/bench.py
+++ b/tests/e2e/harness/bench.py
@@ -55,7 +55,9 @@ class Bench:
         # `bench new` no longer pre-generates an admin password (it's set in the
         # wizard's first step and persisted to bench.toml by /api/setup/save).
         # So the harness chooses it, the wizard enters it, and login reuses it.
-        self._admin_password = admin_password or secrets.token_urlsafe(12)
+        # A bare token_urlsafe() isn't guaranteed to satisfy the wizard's password
+        # policy (upper + lower + digit + symbol) — fixed affixes guarantee it.
+        self._admin_password = admin_password or f"Aa1!{secrets.token_urlsafe(12)}"
         self._proc: subprocess.Popen | None = None
         self._info: dict | None = None
 

--- a/tests/test_git_providers.py
+++ b/tests/test_git_providers.py
@@ -8,10 +8,19 @@ import pytest
 
 from pilot.core.git_providers import (
     GitCredentialStore,
+    GitHubProvider,
     GitProviderError,
     parse_github_owner_repo,
     resolve_app_name_from_repo,
 )
+
+
+def test_github_provider_omits_auth_header_without_token() -> None:
+    assert "Authorization" not in GitHubProvider(token="")._headers()
+
+
+def test_github_provider_sends_auth_header_with_token() -> None:
+    assert GitHubProvider(token="ghp_token")._headers()["Authorization"] == "Bearer ghp_token"
 
 
 def test_credential_store_round_trip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- The redesign that renamed `frontend2` to `frontend` (replacing the whole admin UI) landed after the e2e flow helpers were last updated, breaking every step of the lifecycle test: wizard, login, site creation, custom app install/uninstall, and drop site.
- Along the way, found and fixed a real product bug: `GitHubProvider` always sent an empty `Authorization: Bearer ` header when no PAT was connected, which GitHub rejects as bad credentials (401) instead of treating as anonymous — so any new user's first "install a public app from GitHub" attempt failed with a misleading "access token has expired or been revoked" error.

## Changes
- `tests/e2e/flows/wizard.py`: drive the unified deployment-mode/root-credentials fields (shared by MariaDB/PostgreSQL) instead of the old per-engine fields.
- `tests/e2e/flows/admin.py`: login button is "Continue"; site tabs are a router path, not a hash; drop-site lives in Settings → Danger with a site-name-typed confirm; custom app install is now a two-step marketplace flow (add to bench, then install onto a site).
- `tests/e2e/harness/bench.py`: generate an admin password that always satisfies the wizard's password policy (upper+lower+digit+symbol).
- `pilot/core/git_providers.py`: only attach the GitHub `Authorization` header when a token is actually set.
- `tests/test_git_providers.py`: regression tests for the header fix.

## Test plan
- [x] Ran the full e2e lifecycle locally against the current frontend build (dedicated MariaDB, `E2E_BUILD_ADMIN=1`, `E2E_EXTRA_APP=1`): wizard → login → create site → install app → uninstall app → drop site — all 6 steps pass.
- [x] `pytest tests/test_git_providers.py` passes, including the two new regression tests.
- [x] Broader unit suite (`pytest tests/ --ignore=tests/e2e --ignore=tests/integration`) shows no regressions from this change (769 passed; remaining failures are pre-existing environment gaps unrelated to this branch — missing `boto3` in this venv, and a personal domain-provider extension leaking into a couple of unit tests on this dev machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YVkNkFaqde2rzkyqaM6ym