### PR TITLE
feat: add bench diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Each bench lives on a single dataset (`<pool>/<bench>`) holding both its files a
 | `bench start` | Start all processes (web, workers, Redis, admin UI) |
 | `bench stop` | Stop a running bench from another terminal |
 | `bench restart` | Restart all processes — supervisor, systemd, or OpenRC (production only) |
+| `bench diagnostics` | Run health checks for resources, processes, Redis, database reachability, and workers |
 | `bench get-app <repo>` | Clone and install an app |
 | `bench new-site <name>` | Create a site |
 | `bench rename-site <old> <new>` | Rename a site (checks the hostname is free across all benches) |

--- a/admin/backend/app.py
+++ b/admin/backend/app.py
@@ -14,6 +14,7 @@ from .views.apps import apps_bp
 from .views.benches import benches_bp
 from .views.dashboard import dashboard_bp
 from .views.database import database_bp
+from .views.diagnostics import diagnostics_bp
 from .views.git import git_bp
 from .views.logs import logs_bp
 from .views.processes import processes_bp
@@ -217,6 +218,7 @@ def create_app(bench_root: Path) -> Flask:
     app.register_blueprint(processes_bp, url_prefix="/api/processes")
     app.register_blueprint(logs_bp, url_prefix="/api/logs")
     app.register_blueprint(database_bp, url_prefix="/api/database")
+    app.register_blueprint(diagnostics_bp, url_prefix="/api/diagnostics")
     app.register_blueprint(tasks_bp, url_prefix="/api/tasks")
     app.register_blueprint(settings_bp, url_prefix="/api/settings")
     app.register_blueprint(updates_bp, url_prefix="/api/updates")

--- a/admin/backend/views/diagnostics.py
+++ b/admin/backend/views/diagnostics.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+
+from flask import Blueprint, current_app, jsonify
+
+from pilot.config.toml_store import BenchTomlStore
+from pilot.core.bench import Bench
+from pilot.core.diagnostics import DiagnosticReport, DiagnosticRunner
+
+diagnostics_bp = Blueprint("diagnostics", __name__)
+
+
+@diagnostics_bp.route("/")
+def index():
+    bench_root = current_app.config["BENCH_ROOT"]
+    try:
+        config = BenchTomlStore.for_bench(bench_root).read()
+        checks = DiagnosticRunner(Bench(config, bench_root)).run()
+    except Exception as error:
+        return jsonify({"error": str(error)}), 500
+    return jsonify(json.loads(DiagnosticReport(config.name, checks).to_json()))

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -337,6 +337,25 @@ Lists every bench found under `benches/`, with its runtime status (running/stopp
 
 ---
 
+## `bench diagnostics`
+
+Runs read-only health checks for the active bench.
+
+```bash
+bench diagnostics
+bench diagnostics --json
+```
+
+Checks cover bench structure, generated config files, site config JSON, core
+runtime dependencies, CPU load, disk space, Linux memory, process state, Redis
+ports, database reachability, workers, and Chromium availability for PDF
+generation. The command does not install packages, start services, modify
+configuration, or run migrations.
+
+The Admin backend exposes the same report at `GET /api/diagnostics/`.
+
+---
+
 ## `bench stop`
 
 Stops a running bench. `ProcessManagerFactory.detect_running()` picks the right manager (dev runner, systemd, or supervisor), then stops the workload and the admin service. Does **not** rely on `pids/bench.pid` — a dev bench with no PID file is stopped by killing the port-bound processes. Works across terminal sessions.

--- a/pilot/commands/diagnostics.py
+++ b/pilot/commands/diagnostics.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import argparse
+
+from pilot.commands.base import Command
+
+
+class DiagnosticsCommand(Command):
+    name = "diagnostics"
+    help = "Run health checks for the bench."
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--json", action="store_true", help="Print diagnostics as JSON.")
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace, bench):
+        return cls(bench, json_output=args.json)
+
+    def __init__(self, bench, json_output: bool = False) -> None:
+        self.bench = bench
+        self.json_output = json_output
+
+    def run(self) -> None:
+        from pilot.core.diagnostics import DiagnosticReport, DiagnosticRunner
+
+        report = DiagnosticReport(self.bench.config.name, DiagnosticRunner(self.bench).run())
+        if self.json_output:
+            print(report.to_json())
+            return
+        self._print(report)
+
+    def _print(self, report: DiagnosticReport) -> None:
+        print(f"Diagnostics for {report.bench_name}\n")
+        current_group = ""
+        for check in report.checks:
+            if check.group != current_group:
+                current_group = check.group
+                print(_group_title(current_group))
+            print(f"  {_badge(check.status)} {check.name}: {check.detail}")
+            if check.hint:
+                print(f"      {check.hint}")
+        print("\nResult: " + ("issues found" if report.failed else "all checks passed"))
+
+
+def _group_title(group: str) -> str:
+    return f"{group.capitalize()}:"
+
+
+def _badge(status: str) -> str:
+    icons = {"ok": _green("OK"), "warn": _yellow("WARN"), "fail": _red("FAIL"), "skip": _dim("SKIP")}
+    return icons.get(status, status.upper())
+
+
+def _green(text: str) -> str:
+    return f"\033[32m{text}\033[0m"
+
+
+def _yellow(text: str) -> str:
+    return f"\033[33m{text}\033[0m"
+
+
+def _red(text: str) -> str:
+    return f"\033[31m{text}\033[0m"
+
+
+def _dim(text: str) -> str:
+    return f"\033[90m{text}\033[0m"

--- a/pilot/core/diagnostics.py
+++ b/pilot/core/diagnostics.py
@@ -129,14 +129,17 @@ class DiagnosticRunner:
         workers = [p for p in self.bench.pids_path.glob("worker*.pid")] if self.bench.pids_path.exists() else []
         if workers:
             live = sum(1 for path in workers if self._pid_alive(path))
-            status = "ok" if live else "fail"
+            status = "ok" if live == len(workers) else "warn" if live else "fail"
             return [DiagnosticCheck("workers", "worker pids", status, f"{live}/{len(workers)} worker pid files are live")]
         if self.bench.config.production.use_companion_manager:
             return [DiagnosticCheck("workers", "workers", "skip", "workers run inside the companion web process")]
         return [DiagnosticCheck("workers", "worker pids", "warn", "no worker pid files found", "Start the bench and re-run diagnostics.")]
 
     def _disk_check(self) -> DiagnosticCheck:
-        usage = shutil.disk_usage(self.bench.path)
+        try:
+            usage = shutil.disk_usage(self.bench.path)
+        except OSError as exc:
+            return DiagnosticCheck("resources", "disk", "fail", f"could not read disk usage: {exc}")
         free_gb = usage.free / 1024**3
         used_pct = (usage.used / usage.total) * 100 if usage.total else 0
         detail = f"{free_gb:.1f} GB free, {used_pct:.0f}% used at {self.bench.path}"

--- a/pilot/core/diagnostics.py
+++ b/pilot/core/diagnostics.py
@@ -185,9 +185,11 @@ class DiagnosticRunner:
         return DiagnosticCheck(group, name, "fail", f"{host}:{port} is not reachable")
 
     def _socket_check(self, group: str, name: str, path: Path) -> DiagnosticCheck:
-        if path.exists():
-            return DiagnosticCheck(group, name, "ok", str(path))
-        return DiagnosticCheck(group, name, "fail", f"missing: {path}", "Start the database service.")
+        if not path.exists():
+            return DiagnosticCheck(group, name, "fail", f"missing: {path}", "Start the database service.")
+        if self._unix_socket_open(path):
+            return DiagnosticCheck(group, name, "ok", f"{path} is reachable")
+        return DiagnosticCheck(group, name, "fail", f"{path} is not accepting connections", "Restart the database service.")
 
     def _executable_check(self, group: str, name: str, executable: str, hint: str) -> DiagnosticCheck:
         path = shutil.which(executable)
@@ -248,6 +250,18 @@ class DiagnosticRunner:
         try:
             with socket.create_connection((host, port), timeout=0.5):
                 return True
+        except OSError:
+            return False
+
+    def _unix_socket_open(self, path: Path) -> bool:
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(0.5)
+            try:
+                sock.connect(str(path))
+                return True
+            finally:
+                sock.close()
         except OSError:
             return False
 

--- a/pilot/core/diagnostics.py
+++ b/pilot/core/diagnostics.py
@@ -215,14 +215,31 @@ class DiagnosticRunner:
             return False
 
     def _linux_memory(self) -> dict[str, int]:
-        path = Path("/proc/meminfo")
+        path = self._meminfo_path()
         if not path.exists():
             return {}
-        fields = {}
-        for line in path.read_text().splitlines():
+        fields: dict[str, int] = {}
+        try:
+            lines = path.read_text().splitlines()
+        except OSError:
+            return {}
+        for line in lines:
+            if ":" not in line:
+                continue
             key, value = line.split(":", 1)
-            fields[key] = int(value.strip().split()[0])
-        return {"available": fields.get("MemAvailable", 0)}
+            parts = value.strip().split()
+            if not parts:
+                continue
+            try:
+                fields[key] = int(parts[0])
+            except ValueError:
+                continue
+        if "MemAvailable" not in fields:
+            return {}
+        return {"available": fields["MemAvailable"]}
+
+    def _meminfo_path(self) -> Path:
+        return Path("/proc/meminfo")
 
     def _tcp_open(self, host: str, port: int) -> bool:
         try:

--- a/pilot/core/diagnostics.py
+++ b/pilot/core/diagnostics.py
@@ -69,7 +69,11 @@ class DiagnosticRunner:
     def _site_checks(self) -> list[DiagnosticCheck]:
         if not self.bench.sites_path.exists():
             return [DiagnosticCheck("sites", "sites", "fail", f"missing: {self.bench.sites_path}", "Run bench init.")]
-        site_dirs = [p for p in sorted(self.bench.sites_path.iterdir()) if (p / "site_config.json").exists()]
+        try:
+            entries = sorted(self.bench.sites_path.iterdir())
+        except OSError as exc:
+            return [DiagnosticCheck("sites", "sites", "fail", f"could not read sites directory: {exc}")]
+        site_dirs = [p for p in entries if (p / "site_config.json").exists()]
         if not site_dirs:
             return [DiagnosticCheck("sites", "sites", "warn", "no sites found", "Create one with bench new-site <name>.")]
         checks = [DiagnosticCheck("sites", "site count", "ok", f"{len(site_dirs)} site(s) found")]

--- a/pilot/core/diagnostics.py
+++ b/pilot/core/diagnostics.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pilot.core.bench import Bench
+
+
+@dataclass
+class DiagnosticCheck:
+    group: str
+    name: str
+    status: str
+    detail: str
+    hint: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        data = {"group": self.group, "name": self.name, "status": self.status, "detail": self.detail}
+        if self.hint:
+            data["hint"] = self.hint
+        return data
+
+
+class DiagnosticRunner:
+    def __init__(self, bench: "Bench") -> None:
+        self.bench = bench
+
+    def run(self) -> list[DiagnosticCheck]:
+        checks: list[DiagnosticCheck] = []
+        checks.extend(self._bench_checks())
+        checks.extend(self._configuration_checks())
+        checks.extend(self._site_checks())
+        checks.extend(self._dependency_checks())
+        checks.extend(self._resource_checks())
+        checks.extend(self._process_checks())
+        checks.extend(self._redis_checks())
+        checks.extend(self._database_checks())
+        checks.extend(self._worker_checks())
+        return checks
+
+    def _bench_checks(self) -> list[DiagnosticCheck]:
+        return [
+            self._path_check("bench", "bench.toml", self.bench.path / "bench.toml", "Run bench new <name>."),
+            self._path_check("bench", "python env", self.bench.python, "Run bench init."),
+            self._path_check("bench", "apps directory", self.bench.apps_path, "Run bench init."),
+            self._path_check("bench", "sites directory", self.bench.sites_path, "Run bench init."),
+            self._path_check("bench", "config directory", self.bench.config_path, "Run bench setup config."),
+        ]
+
+    def _configuration_checks(self) -> list[DiagnosticCheck]:
+        checks = [
+            self._path_check("config", "common site config", self.bench.sites_path / "common_site_config.json", "Run bench setup config."),
+            self._path_check("config", "procfile", self.bench.config_path / "Procfile", "Run bench setup config."),
+        ]
+        if self.bench.config.admin.enabled and not self.bench.config.admin.password:
+            checks.append(DiagnosticCheck("config", "admin password", "fail", "admin is enabled without a password", "Run bench set-admin-password."))
+        elif self.bench.config.admin.enabled:
+            checks.append(DiagnosticCheck("config", "admin password", "ok", "configured"))
+        else:
+            checks.append(DiagnosticCheck("config", "admin", "warn", "admin UI is disabled"))
+        return checks
+
+    def _site_checks(self) -> list[DiagnosticCheck]:
+        if not self.bench.sites_path.exists():
+            return [DiagnosticCheck("sites", "sites", "fail", f"missing: {self.bench.sites_path}", "Run bench init.")]
+        site_dirs = [p for p in sorted(self.bench.sites_path.iterdir()) if (p / "site_config.json").exists()]
+        if not site_dirs:
+            return [DiagnosticCheck("sites", "sites", "warn", "no sites found", "Create one with bench new-site <name>.")]
+        checks = [DiagnosticCheck("sites", "site count", "ok", f"{len(site_dirs)} site(s) found")]
+        checks.extend(self._site_config_check(site_dir) for site_dir in site_dirs)
+        return checks
+
+    def _dependency_checks(self) -> list[DiagnosticCheck]:
+        checks = [
+            self._executable_check("dependencies", "redis-server", "redis-server", "Install Redis or run bench init."),
+            self._executable_check("dependencies", "node", "node", "Install Node.js or run bench init."),
+        ]
+        checks.append(self._chromium_check())
+        return checks
+
+    def _resource_checks(self) -> list[DiagnosticCheck]:
+        return [
+            self._cpu_check(),
+            self._disk_check(),
+            self._memory_check(),
+        ]
+
+    def _process_checks(self) -> list[DiagnosticCheck]:
+        from pilot.managers.process_manager import ProcessManager
+
+        try:
+            manager = ProcessManager.detect_running(self.bench)
+            workload = manager.is_running()
+            admin = manager.is_admin_running()
+        except Exception as exc:
+            return [DiagnosticCheck("process", "process manager", "fail", str(exc))]
+        if workload:
+            return [DiagnosticCheck("process", "bench workload", "ok", "workload is running")]
+        if admin:
+            return [DiagnosticCheck("process", "admin", "warn", "admin is running, workload is stopped", "Run bench start or setup production.")]
+        return [DiagnosticCheck("process", "bench workload", "fail", "bench is not running", "Run bench start.")]
+
+    def _redis_checks(self) -> list[DiagnosticCheck]:
+        redis = self.bench.config.redis
+        return [
+            self._port_check("redis", "cache", "127.0.0.1", redis.cache_port),
+            self._port_check("redis", "queue", "127.0.0.1", redis.queue_port),
+        ]
+
+    def _database_checks(self) -> list[DiagnosticCheck]:
+        db_type = self.bench.config.db_type
+        if db_type == "sqlite":
+            return [DiagnosticCheck("database", "sqlite", "skip", "sqlite has no shared database server")]
+        if db_type == "postgres":
+            pg = self.bench.config.postgres
+            return [self._port_check("database", "postgres", pg.host, pg.port)]
+        mdb = self.bench.config.mariadb
+        if mdb.socket_path:
+            return [self._socket_check("database", "mariadb socket", Path(mdb.socket_path))]
+        return [self._port_check("database", "mariadb", mdb.host, mdb.port)]
+
+    def _worker_checks(self) -> list[DiagnosticCheck]:
+        workers = [p for p in self.bench.pids_path.glob("worker*.pid")] if self.bench.pids_path.exists() else []
+        if workers:
+            live = sum(1 for path in workers if self._pid_alive(path))
+            status = "ok" if live else "fail"
+            return [DiagnosticCheck("workers", "worker pids", status, f"{live}/{len(workers)} worker pid files are live")]
+        if self.bench.config.production.use_companion_manager:
+            return [DiagnosticCheck("workers", "workers", "skip", "workers run inside the companion web process")]
+        return [DiagnosticCheck("workers", "worker pids", "warn", "no worker pid files found", "Start the bench and re-run diagnostics.")]
+
+    def _disk_check(self) -> DiagnosticCheck:
+        usage = shutil.disk_usage(self.bench.path)
+        free_gb = usage.free / 1024**3
+        used_pct = (usage.used / usage.total) * 100 if usage.total else 0
+        detail = f"{free_gb:.1f} GB free, {used_pct:.0f}% used at {self.bench.path}"
+        if free_gb < 1:
+            return DiagnosticCheck("resources", "disk", "fail", detail, "Free disk space before running migrations or backups.")
+        if free_gb < 5:
+            return DiagnosticCheck("resources", "disk", "warn", detail, "Keep at least 5 GB free for updates and backups.")
+        return DiagnosticCheck("resources", "disk", "ok", detail)
+
+    def _cpu_check(self) -> DiagnosticCheck:
+        try:
+            load_1m = os.getloadavg()[0]
+        except (AttributeError, OSError):
+            return DiagnosticCheck("resources", "cpu load", "skip", "load average is not available")
+        cpu_count = os.cpu_count() or 1
+        detail = f"1m load {load_1m:.2f} across {cpu_count} CPU(s)"
+        if load_1m > cpu_count * 2:
+            return DiagnosticCheck("resources", "cpu load", "fail", detail, "Server is heavily loaded.")
+        if load_1m > cpu_count:
+            return DiagnosticCheck("resources", "cpu load", "warn", detail, "CPU pressure may slow requests and jobs.")
+        return DiagnosticCheck("resources", "cpu load", "ok", detail)
+
+    def _memory_check(self) -> DiagnosticCheck:
+        memory = self._linux_memory()
+        if not memory:
+            return DiagnosticCheck("resources", "memory", "skip", "memory check is only available on Linux")
+        available_gb = memory["available"] / 1024**2
+        detail = f"{available_gb:.1f} GB available"
+        if available_gb < 0.5:
+            return DiagnosticCheck("resources", "memory", "fail", detail, "Free memory or add swap before starting workers.")
+        if available_gb < 1:
+            return DiagnosticCheck("resources", "memory", "warn", detail, "Low memory can make builds and migrations unreliable.")
+        return DiagnosticCheck("resources", "memory", "ok", detail)
+
+    def _path_check(self, group: str, name: str, path: Path, hint: str) -> DiagnosticCheck:
+        if path.exists():
+            return DiagnosticCheck(group, name, "ok", str(path))
+        return DiagnosticCheck(group, name, "fail", f"missing: {path}", hint)
+
+    def _port_check(self, group: str, name: str, host: str, port: int) -> DiagnosticCheck:
+        if self._tcp_open(host, port):
+            return DiagnosticCheck(group, name, "ok", f"{host}:{port} is reachable")
+        return DiagnosticCheck(group, name, "fail", f"{host}:{port} is not reachable")
+
+    def _socket_check(self, group: str, name: str, path: Path) -> DiagnosticCheck:
+        if path.exists():
+            return DiagnosticCheck(group, name, "ok", str(path))
+        return DiagnosticCheck(group, name, "fail", f"missing: {path}", "Start the database service.")
+
+    def _executable_check(self, group: str, name: str, executable: str, hint: str) -> DiagnosticCheck:
+        path = shutil.which(executable)
+        if path:
+            return DiagnosticCheck(group, name, "ok", path)
+        return DiagnosticCheck(group, name, "fail", f"{executable} not found in PATH", hint)
+
+    def _chromium_check(self) -> DiagnosticCheck:
+        candidates = ["chromium", "chromium-browser", "google-chrome", "google-chrome-stable"]
+        found = next((path for name in candidates if (path := shutil.which(name))), "")
+        if found:
+            return DiagnosticCheck("dependencies", "chromium", "ok", found)
+        return DiagnosticCheck("dependencies", "chromium", "warn", "not found in PATH", "PDF generation may fail until Chromium is installed.")
+
+    def _site_config_check(self, site_dir: Path) -> DiagnosticCheck:
+        path = site_dir / "site_config.json"
+        try:
+            json.loads(path.read_text())
+        except Exception as exc:
+            return DiagnosticCheck("sites", site_dir.name, "fail", f"invalid site_config.json: {exc}")
+        return DiagnosticCheck("sites", site_dir.name, "ok", "site_config.json is valid")
+
+    def _pid_alive(self, path: Path) -> bool:
+        try:
+            os.kill(int(path.read_text().strip()), 0)
+            return True
+        except (ValueError, ProcessLookupError, PermissionError, OSError):
+            return False
+
+    def _linux_memory(self) -> dict[str, int]:
+        path = Path("/proc/meminfo")
+        if not path.exists():
+            return {}
+        fields = {}
+        for line in path.read_text().splitlines():
+            key, value = line.split(":", 1)
+            fields[key] = int(value.strip().split()[0])
+        return {"available": fields.get("MemAvailable", 0)}
+
+    def _tcp_open(self, host: str, port: int) -> bool:
+        try:
+            with socket.create_connection((host, port), timeout=0.5):
+                return True
+        except OSError:
+            return False
+
+
+class DiagnosticReport:
+    def __init__(self, bench_name: str, checks: list[DiagnosticCheck]) -> None:
+        self.bench_name = bench_name
+        self.checks = checks
+
+    @property
+    def failed(self) -> bool:
+        return any(check.status == "fail" for check in self.checks)
+
+    def to_json(self) -> str:
+        data = {"bench": self.bench_name, "checks": [check.to_dict() for check in self.checks]}
+        return json.dumps(data, indent=2)

--- a/tests/test_admin_diagnostics.py
+++ b/tests/test_admin_diagnostics.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from pilot.config.bench_toml_builder import BenchTomlBuilder
+from pilot.core.diagnostics import DiagnosticCheck
+
+
+def _client(bench_root: Path):
+    from admin.backend.app import create_app
+    from pilot.commands.generate_session import ensure_jwt_secret, issue_token
+
+    bench_root.mkdir(parents=True, exist_ok=True)
+    (bench_root / "bench.toml").write_text(
+        BenchTomlBuilder("diag", {"admin_enabled": True, "admin_password": "secret"}).render()
+    )
+    secret = ensure_jwt_secret(bench_root / "bench.toml")
+    app = create_app(bench_root)
+    app.config["TESTING"] = True
+    client = app.test_client()
+    client.set_cookie("sid", issue_token(secret))
+    return client
+
+
+def test_api_diagnostics_returns_report(tmp_path: Path) -> None:
+    client = _client(tmp_path / "benches" / "diag")
+    checks = [DiagnosticCheck("bench", "bench.toml", "ok", "present")]
+
+    with patch("admin.backend.views.diagnostics.DiagnosticRunner.run", return_value=checks):
+        response = client.get("/api/diagnostics/")
+
+    payload = response.get_json()
+    assert payload["bench"] == "diag"
+    assert payload["checks"][0]["name"] == "bench.toml"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -79,6 +79,18 @@ def test_diagnostics_worker_pid_check(tmp_path: Path, monkeypatch) -> None:
     assert checks[0].detail == "1/1 worker pid files are live"
 
 
+def test_diagnostics_worker_pid_check_warns_for_partial_failure(tmp_path: Path, monkeypatch) -> None:
+    bench = make_initialized_bench(tmp_path)
+    (bench.pids_path / "worker_default_1.pid").write_text("123")
+    (bench.pids_path / "worker_default_2.pid").write_text("456")
+    monkeypatch.setattr(DiagnosticRunner, "_pid_alive", lambda self, path: path.name.endswith("_1.pid"))
+
+    check = DiagnosticRunner(bench)._worker_checks()[0]
+
+    assert check.status == "warn"
+    assert check.detail == "1/2 worker pid files are live"
+
+
 def test_diagnostics_validates_site_configs(tmp_path: Path) -> None:
     bench = make_initialized_bench(tmp_path)
     site = bench.sites_path / "site.localhost"
@@ -128,6 +140,20 @@ def test_diagnostics_cpu_load_warns_under_pressure(tmp_path: Path, monkeypatch) 
     check = DiagnosticRunner(bench)._cpu_check()
 
     assert check.status == "warn"
+
+
+def test_diagnostics_disk_check_reports_usage_errors(tmp_path: Path, monkeypatch) -> None:
+    bench = make_initialized_bench(tmp_path)
+
+    def fail(path):
+        raise OSError("not mounted")
+
+    monkeypatch.setattr("shutil.disk_usage", fail)
+
+    check = DiagnosticRunner(bench)._disk_check()
+
+    assert check.status == "fail"
+    assert "not mounted" in check.detail
 
 
 def test_diagnostics_memory_parser_ignores_malformed_lines(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from pilot.commands.diagnostics import DiagnosticsCommand
+from pilot.config.app_config import AppConfig
+from pilot.config.bench_config import BenchConfig
+from pilot.config.mariadb_config import MariaDBConfig
+from pilot.config.redis_config import RedisConfig
+from pilot.config.worker_config import WorkerConfig, WorkerGroup
+from pilot.core.bench import Bench
+from pilot.core.diagnostics import DiagnosticReport, DiagnosticRunner
+
+
+def make_bench(tmp_path: Path) -> Bench:
+    config = BenchConfig(
+        name="diag-bench",
+        python_version="3.14",
+        apps=[AppConfig(name="frappe", repo="https://github.com/frappe/frappe", branch="version-16")],
+        mariadb=MariaDBConfig(root_password="root"),
+        redis=RedisConfig(cache_port=13000, queue_port=11000),
+        workers=WorkerConfig(groups=[WorkerGroup(queues=["default"], count=1)]),
+    )
+    return Bench(config, tmp_path)
+
+
+def make_initialized_bench(tmp_path: Path) -> Bench:
+    bench = make_bench(tmp_path)
+    for path in [bench.apps_path, bench.sites_path, bench.config_path, bench.python.parent, bench.pids_path]:
+        path.mkdir(parents=True, exist_ok=True)
+    (bench.path / "bench.toml").write_text("[bench]\nname = \"diag-bench\"\n")
+    (bench.sites_path / "common_site_config.json").write_text("{}")
+    (bench.config_path / "Procfile").write_text("web: run\n")
+    bench.python.write_text("")
+    return bench
+
+
+def test_diagnostics_reports_missing_bench_paths(tmp_path: Path, monkeypatch) -> None:
+    bench = make_bench(tmp_path)
+    monkeypatch.setattr(DiagnosticRunner, "_resource_checks", lambda self: [])
+    monkeypatch.setattr(DiagnosticRunner, "_process_checks", lambda self: [])
+    monkeypatch.setattr(DiagnosticRunner, "_redis_checks", lambda self: [])
+    monkeypatch.setattr(DiagnosticRunner, "_database_checks", lambda self: [])
+    monkeypatch.setattr(DiagnosticRunner, "_worker_checks", lambda self: [])
+    monkeypatch.setattr(DiagnosticRunner, "_dependency_checks", lambda self: [])
+
+    checks = DiagnosticRunner(bench).run()
+
+    assert any(check.name == "bench.toml" and check.status == "fail" for check in checks)
+    assert any(check.name == "python env" and check.status == "fail" for check in checks)
+    assert any(check.name == "sites" and check.status == "fail" for check in checks)
+
+
+def test_diagnostics_marks_ports_reachable(tmp_path: Path, monkeypatch) -> None:
+    bench = make_initialized_bench(tmp_path)
+    monkeypatch.setattr(DiagnosticRunner, "_resource_checks", lambda self: [])
+    monkeypatch.setattr(DiagnosticRunner, "_process_checks", lambda self: [])
+    monkeypatch.setattr(DiagnosticRunner, "_worker_checks", lambda self: [])
+    monkeypatch.setattr(DiagnosticRunner, "_tcp_open", lambda self, host, port: port in {13000, 11000})
+
+    checks = DiagnosticRunner(bench).run()
+
+    cache = next(check for check in checks if check.group == "redis" and check.name == "cache")
+    database = next(check for check in checks if check.group == "database")
+    assert cache.status == "ok"
+    assert database.status == "fail"
+
+
+def test_diagnostics_worker_pid_check(tmp_path: Path, monkeypatch) -> None:
+    bench = make_initialized_bench(tmp_path)
+    (bench.pids_path / "worker_default_1.pid").write_text("123")
+    monkeypatch.setattr(DiagnosticRunner, "_pid_alive", lambda self, path: True)
+
+    checks = DiagnosticRunner(bench)._worker_checks()
+
+    assert checks[0].status == "ok"
+    assert checks[0].detail == "1/1 worker pid files are live"
+
+
+def test_diagnostics_validates_site_configs(tmp_path: Path) -> None:
+    bench = make_initialized_bench(tmp_path)
+    site = bench.sites_path / "site.localhost"
+    site.mkdir()
+    (site / "site_config.json").write_text("{")
+
+    checks = DiagnosticRunner(bench)._site_checks()
+
+    assert any(check.name == "site count" and check.status == "ok" for check in checks)
+    assert any(check.name == "site.localhost" and check.status == "fail" for check in checks)
+
+
+def test_diagnostics_warns_when_no_sites_exist(tmp_path: Path) -> None:
+    bench = make_initialized_bench(tmp_path)
+
+    checks = DiagnosticRunner(bench)._site_checks()
+
+    assert checks[0].status == "warn"
+    assert "no sites" in checks[0].detail
+
+
+def test_diagnostics_checks_chromium_dependency(tmp_path: Path, monkeypatch) -> None:
+    bench = make_initialized_bench(tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/chromium" if name == "chromium" else None)
+
+    check = DiagnosticRunner(bench)._chromium_check()
+
+    assert check.status == "ok"
+    assert check.detail == "/usr/bin/chromium"
+
+
+def test_diagnostics_warns_when_chromium_missing(tmp_path: Path, monkeypatch) -> None:
+    bench = make_initialized_bench(tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: None)
+
+    check = DiagnosticRunner(bench)._chromium_check()
+
+    assert check.status == "warn"
+    assert "PDF generation" in check.hint
+
+
+def test_diagnostics_cpu_load_warns_under_pressure(tmp_path: Path, monkeypatch) -> None:
+    bench = make_initialized_bench(tmp_path)
+    monkeypatch.setattr("os.getloadavg", lambda: (2.5, 2.0, 1.0))
+    monkeypatch.setattr("os.cpu_count", lambda: 2)
+
+    check = DiagnosticRunner(bench)._cpu_check()
+
+    assert check.status == "warn"
+
+
+def test_diagnostic_report_json(tmp_path: Path) -> None:
+    bench = make_initialized_bench(tmp_path)
+    check = DiagnosticRunner(bench)._path_check("bench", "bench.toml", bench.path / "bench.toml", "")
+    payload = json.loads(DiagnosticReport(bench.config.name, [check]).to_json())
+
+    assert payload["bench"] == "diag-bench"
+    assert payload["checks"][0]["status"] == "ok"
+
+
+def test_diagnostics_command_prints_json(tmp_path: Path, monkeypatch, capsys) -> None:
+    bench = make_initialized_bench(tmp_path)
+    monkeypatch.setattr(DiagnosticRunner, "run", lambda self: [])
+
+    DiagnosticsCommand(bench, json_output=True).run()
+
+    assert json.loads(capsys.readouterr().out)["bench"] == "diag-bench"
+
+
+def test_diagnostics_command_prints_summary(tmp_path: Path, monkeypatch, capsys) -> None:
+    bench = make_initialized_bench(tmp_path)
+    check = MagicMock(group="bench", status="ok", name="bench.toml", detail="present", hint="")
+    monkeypatch.setattr(DiagnosticRunner, "run", lambda self: [check])
+
+    DiagnosticsCommand(bench).run()
+
+    output = capsys.readouterr().out
+    assert "Diagnostics for diag-bench" in output
+    assert "Result: all checks passed" in output

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -113,6 +113,23 @@ def test_diagnostics_warns_when_no_sites_exist(tmp_path: Path) -> None:
     assert "no sites" in checks[0].detail
 
 
+def test_diagnostics_site_checks_report_directory_errors(tmp_path: Path, monkeypatch) -> None:
+    bench = make_initialized_bench(tmp_path)
+    original_iterdir = Path.iterdir
+
+    def fail(path):
+        if path == bench.sites_path:
+            raise OSError("permission denied")
+        return original_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", fail)
+
+    check = DiagnosticRunner(bench)._site_checks()[0]
+
+    assert check.status == "fail"
+    assert "permission denied" in check.detail
+
+
 def test_diagnostics_socket_check_requires_connectivity(tmp_path: Path, monkeypatch) -> None:
     bench = make_initialized_bench(tmp_path)
     socket_path = tmp_path / "mariadb.sock"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -130,6 +130,24 @@ def test_diagnostics_cpu_load_warns_under_pressure(tmp_path: Path, monkeypatch) 
     assert check.status == "warn"
 
 
+def test_diagnostics_memory_parser_ignores_malformed_lines(tmp_path: Path, monkeypatch) -> None:
+    bench = make_initialized_bench(tmp_path)
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text("broken\nMemTotal:\nMemFree: nope kB\nMemAvailable: 2048 kB\n")
+    monkeypatch.setattr(DiagnosticRunner, "_meminfo_path", lambda self: meminfo)
+
+    assert DiagnosticRunner(bench)._linux_memory() == {"available": 2048}
+
+
+def test_diagnostics_memory_parser_skips_without_available_memory(tmp_path: Path, monkeypatch) -> None:
+    bench = make_initialized_bench(tmp_path)
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text("MemTotal: 4096 kB\n")
+    monkeypatch.setattr(DiagnosticRunner, "_meminfo_path", lambda self: meminfo)
+
+    assert DiagnosticRunner(bench)._memory_check().status == "skip"
+
+
 def test_diagnostic_report_json(tmp_path: Path) -> None:
     bench = make_initialized_bench(tmp_path)
     check = DiagnosticRunner(bench)._path_check("bench", "bench.toml", bench.path / "bench.toml", "")

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import socket
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -110,6 +111,34 @@ def test_diagnostics_warns_when_no_sites_exist(tmp_path: Path) -> None:
 
     assert checks[0].status == "warn"
     assert "no sites" in checks[0].detail
+
+
+def test_diagnostics_socket_check_requires_connectivity(tmp_path: Path, monkeypatch) -> None:
+    bench = make_initialized_bench(tmp_path)
+    socket_path = tmp_path / "mariadb.sock"
+    socket_path.write_text("")
+    monkeypatch.setattr(DiagnosticRunner, "_unix_socket_open", lambda self, path: False)
+
+    check = DiagnosticRunner(bench)._socket_check("database", "mariadb socket", socket_path)
+
+    assert check.status == "fail"
+    assert "not accepting connections" in check.detail
+
+
+def test_diagnostics_socket_check_accepts_reachable_socket(tmp_path: Path) -> None:
+    bench = make_initialized_bench(tmp_path)
+    socket_path = Path("diag-test.sock").resolve()
+    socket_path.unlink(missing_ok=True)
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(str(socket_path))
+    server.listen(1)
+    try:
+        check = DiagnosticRunner(bench)._socket_check("database", "mariadb socket", socket_path)
+    finally:
+        server.close()
+        socket_path.unlink(missing_ok=True)
+
+    assert check.status == "ok"
 
 
 def test_diagnostics_checks_chromium_dependency(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add a read-only bench diagnostics command with human-readable and JSON output
- check bench structure, generated config, site config JSON, runtime dependencies, resources, process state, Redis, database reachability, workers, and Chromium availability
- expose the same diagnostics report via GET /api/diagnostics/
- document the command and add unit/API coverage

## Tests
- uv run --extra test --extra admin pytest -q tests/test_cli.py tests/test_commands.py tests/test_diagnostics.py tests/test_admin_diagnostics.py
- uv run --extra test --extra admin pytest -q tests --ignore=tests/e2e -k "not test_memory_usage_breakdown_sums_to_total"