### PR TITLE
App validation

### DIFF
--- a/pilot/commands/get_app.py
+++ b/pilot/commands/get_app.py
@@ -5,7 +5,6 @@ import sys
 from typing import TYPE_CHECKING
 
 from pilot.commands.base import Command
-from pilot.core.app_validator import Validator
 
 if TYPE_CHECKING:
     from pilot.core.bench import Bench
@@ -100,6 +99,7 @@ class GetAppCommand(Command):
     def _validate(self) -> None:
         import shutil
 
+        from pilot.core.app_validator import Validator
         from pilot.exceptions import AppValidationError
 
         try:

--- a/pilot/commands/get_app.py
+++ b/pilot/commands/get_app.py
@@ -5,6 +5,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from pilot.commands.base import Command
+from pilot.core.app_validator import Validator
 
 if TYPE_CHECKING:
     from pilot.core.bench import Bench
@@ -41,8 +42,8 @@ class GetAppCommand(Command):
     def run(self) -> None:
         self._clone()
         self._normalize_folder()
-        self._install()
         self._validate()
+        self._install()
         self._register()
         self._build()
         print(f"\n'{self.name}' installed successfully.")
@@ -97,28 +98,16 @@ class GetAppCommand(Command):
             apps_txt.write_text("\n".join(existing + [self.name]) + "\n")
 
     def _validate(self) -> None:
-        import subprocess
+        import shutil
 
-        from pilot.exceptions import BenchError
+        from pilot.exceptions import AppValidationError
 
-        python = str(self.bench.env_path / "bin" / "python")
-        result = subprocess.run(
-            [python, "-c", f"import {self.name}"],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            # Roll back: remove from apps dir so a broken app doesn't crash workers.
-            import shutil
-
+        try:
+            Validator(self.app).validate()
+        except AppValidationError:
+            # Roll back: remove the clone so a broken app is never pip-installed.
             shutil.rmtree(self.app.path, ignore_errors=True)
-            raise BenchError(
-                f"App '{self.name}' installed but its Python package "
-                f"could not be imported.\n"
-                f"  This usually means the app's package name does not match\n"
-                f"  its declared name (check pyproject.toml / hooks.py app_name).\n"
-                f"  Error: {result.stderr.strip()}"
-            )
+            raise
 
     def _build(self) -> None:
         from pilot.managers.python_env_manager import PythonEnvManager

--- a/pilot/core/app_validator.py
+++ b/pilot/core/app_validator.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import ast
+import json
+import subprocess
 import sys
 import tomllib
 import typing
+from functools import cached_property
 from pathlib import Path
 
 from pilot.exceptions import AppValidationError
@@ -51,7 +54,7 @@ class Validator:
             {
                 self._top_level_package(module)
                 for _, module in self._all_imports()
-                if self._is_external(module) and self._top_level_package(module) not in declared
+                if self._is_external(module) and self._distribution_name(module).casefold() not in declared
             }
         )
         if missing:
@@ -72,19 +75,76 @@ class Validator:
     def _top_level_package(module: str) -> str:
         return module.split(".")[0]
 
+    def _distribution_name(self, module: str) -> str:
+        """Map an import's top-level name to its installed distribution name.
+
+        `import bs4` and `pip install beautifulsoup4` refer to the same
+        package under different names. Reads that mapping from packages
+        already installed in the bench's own env (frappe and every app
+        installed before this one) rather than a hand-maintained alias
+        list — the app being validated isn't installed yet, so its own
+        distribution metadata doesn't exist to consult.
+        """
+        root = self._top_level_package(module)
+        return self._bench_import_to_distribution.get(root, root)
+
+    @cached_property
+    def _bench_import_to_distribution(self) -> dict[str, str]:
+        bench_python = self.app.bench.python
+        if not bench_python.exists():
+            return {}
+        result = subprocess.run(
+            [str(bench_python), "-c", "import importlib.metadata, json; print(json.dumps(importlib.metadata.packages_distributions()))"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return {}
+        return {module: names[0].replace("-", "_") for module, names in json.loads(result.stdout).items()}
+
     @staticmethod
     def _imported_modules(path: Path) -> list[str]:
         try:
             tree = ast.parse(path.read_text(), filename=str(path))
         except (SyntaxError, OSError):
             return []
+        guarded = Validator._optional_import_ids(tree)
         modules = []
         for node in ast.walk(tree):
+            if id(node) in guarded:
+                continue
             if isinstance(node, ast.Import):
                 modules.extend(alias.name for alias in node.names)
             elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
                 modules.append(node.module)
         return modules
+
+    @staticmethod
+    def _optional_import_ids(tree: ast.AST) -> set[int]:
+        """Node ids of imports inside a `try: ... except ImportError: ...` block.
+
+        Apps commonly guard an optional dependency this way; such an import
+        isn't a hard requirement, so it shouldn't be flagged as broken or
+        undeclared.
+        """
+        guarded: set[int] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Try) or not Validator._catches_import_error(node):
+                continue
+            for block in (node.body, *(handler.body for handler in node.handlers)):
+                for stmt in block:
+                    guarded.update(id(n) for n in ast.walk(stmt))
+        return guarded
+
+    @staticmethod
+    def _catches_import_error(node: ast.Try) -> bool:
+        for handler in node.handlers:
+            if handler.type is None:
+                return True
+            types = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+            if any(isinstance(t, ast.Name) and t.id in ("ImportError", "ModuleNotFoundError") for t in types):
+                return True
+        return False
 
     def _resolves(self, module: str) -> bool:
         parts = module.split(".")
@@ -96,18 +156,26 @@ class Validator:
         return root != self.app.module_name and root not in sys.stdlib_module_names
 
     def _declared_dependencies(self) -> set[str]:
-        pyproject = self.app.path / "pyproject.toml"
+        names = self._dependencies_declared_in(self.app.path)
+        names.add("frappe")
+        # Apps run inside the frappe framework's own environment, so any
+        # dependency frappe itself declares (e.g. pypika) is already
+        # installed and usable without every app redeclaring it.
+        names |= self._dependencies_declared_in(self.app.bench.apps_path / "frappe")
+        return names
+
+    @staticmethod
+    def _dependencies_declared_in(app_path: Path) -> set[str]:
+        pyproject = app_path / "pyproject.toml"
         try:
             data = tomllib.loads(pyproject.read_text())
         except (tomllib.TOMLDecodeError, OSError):
             return set()
-        names = {self._dependency_name(dep) for dep in data.get("project", {}).get("dependencies", [])}
-        names.add("frappe")
-        return names
+        return {Validator._dependency_name(dep) for dep in data.get("project", {}).get("dependencies", [])}
 
     @staticmethod
     def _dependency_name(requirement: str) -> str:
         import re
 
         name = re.split(r"[<>=!~\[; ]", requirement, maxsplit=1)[0]
-        return name.strip().replace("-", "_")
+        return name.strip().replace("-", "_").casefold()

--- a/pilot/core/app_validator.py
+++ b/pilot/core/app_validator.py
@@ -122,7 +122,10 @@ class Validator:
         )
         if result.returncode != 0:
             return {}
-        return {module: names[0].replace("-", "_") for module, names in json.loads(result.stdout).items()}
+        try:
+            return {module: names[0].replace("-", "_") for module, names in json.loads(result.stdout).items()}
+        except (json.JSONDecodeError, IndexError):
+            return {}
 
     @staticmethod
     def _imported_modules(path: Path) -> list[str]:

--- a/pilot/core/app_validator.py
+++ b/pilot/core/app_validator.py
@@ -69,7 +69,7 @@ class Validator:
         return list(self.module_path.rglob("*.py"))
 
     def _is_internal(self, module: str) -> bool:
-        return module.startswith(self.app.module_name)
+        return module == self.app.module_name or module.startswith(self.app.module_name + ".")
 
     @staticmethod
     def _top_level_package(module: str) -> str:

--- a/pilot/core/app_validator.py
+++ b/pilot/core/app_validator.py
@@ -26,6 +26,7 @@ class Validator:
 
     def validate(self) -> None:
         self.validate_repo_structure()
+        self.validate_syntax()
         self.validate_internal_imports()
         self.validate_external_imports()
 
@@ -36,6 +37,27 @@ class Validator:
             raise AppValidationError(f"'{self.app.config.name}' has no '{self.app.module_name}' package directory.")
         if not (self.module_path / "hooks.py").exists():
             raise AppValidationError(f"'{self.app.config.name}' is missing {self.app.module_name}/hooks.py.")
+
+    def validate_syntax(self) -> None:
+        broken = [
+            f"{path.relative_to(self.app.path)}: {error}"
+            for path in self._python_files()
+            for error in self._syntax_errors(path)
+        ]
+        if broken:
+            raise AppValidationError(
+                f"'{self.app.config.name}' has Python syntax errors:\n" + "\n".join(f"  {b}" for b in broken)
+            )
+
+    @staticmethod
+    def _syntax_errors(path: Path) -> list[str]:
+        try:
+            ast.parse(path.read_text(), filename=str(path))
+        except SyntaxError as exc:
+            return [f"line {exc.lineno}: {exc.msg}"]
+        except OSError:
+            return []
+        return []
 
     def validate_internal_imports(self) -> None:
         broken = [

--- a/pilot/core/app_validator.py
+++ b/pilot/core/app_validator.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import ast
+import sys
+import tomllib
+import typing
+from pathlib import Path
+
+from pilot.exceptions import AppValidationError
+
+if typing.TYPE_CHECKING:
+    from pilot.core.app import App
+
+
+class Validator:
+    """Statically validates a cloned app before it's installed into the bench
+    env, so a broken app is rejected up front instead of after `pip install`
+    has already touched the environment."""
+
+    def __init__(self, app: "App"):
+        self.app = app
+        self.module_path = app.path / app.module_name
+
+    def validate(self) -> None:
+        self.validate_repo_structure()
+        self.validate_internal_imports()
+        self.validate_external_imports()
+
+    def validate_repo_structure(self) -> None:
+        if not (self.app.path / "pyproject.toml").exists():
+            raise AppValidationError(f"'{self.app.config.name}' has no pyproject.toml.")
+        if not self.module_path.is_dir():
+            raise AppValidationError(f"'{self.app.config.name}' has no '{self.app.module_name}' package directory.")
+        if not (self.module_path / "hooks.py").exists():
+            raise AppValidationError(f"'{self.app.config.name}' is missing {self.app.module_name}/hooks.py.")
+
+    def validate_internal_imports(self) -> None:
+        broken = [
+            f"{path.relative_to(self.app.path)}: {module}"
+            for path, module in self._all_imports()
+            if self._is_internal(module) and not self._resolves(module)
+        ]
+        if broken:
+            raise AppValidationError(
+                f"'{self.app.config.name}' has broken internal imports:\n" + "\n".join(f"  {b}" for b in broken)
+            )
+
+    def validate_external_imports(self) -> None:
+        declared = self._declared_dependencies()
+        missing = sorted(
+            {
+                self._top_level_package(module)
+                for _, module in self._all_imports()
+                if self._is_external(module) and self._top_level_package(module) not in declared
+            }
+        )
+        if missing:
+            raise AppValidationError(
+                f"'{self.app.config.name}' imports packages not declared as dependencies: {', '.join(missing)}"
+            )
+
+    def _all_imports(self) -> list[tuple[Path, str]]:
+        return [(path, module) for path in self._python_files() for module in self._imported_modules(path)]
+
+    def _python_files(self) -> list[Path]:
+        return list(self.module_path.rglob("*.py"))
+
+    def _is_internal(self, module: str) -> bool:
+        return module.startswith(self.app.module_name)
+
+    @staticmethod
+    def _top_level_package(module: str) -> str:
+        return module.split(".")[0]
+
+    @staticmethod
+    def _imported_modules(path: Path) -> list[str]:
+        try:
+            tree = ast.parse(path.read_text(), filename=str(path))
+        except (SyntaxError, OSError):
+            return []
+        modules = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                modules.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+                modules.append(node.module)
+        return modules
+
+    def _resolves(self, module: str) -> bool:
+        parts = module.split(".")
+        candidate = self.app.path.joinpath(*parts)
+        return candidate.with_suffix(".py").exists() or (candidate / "__init__.py").exists()
+
+    def _is_external(self, module: str) -> bool:
+        root = self._top_level_package(module)
+        return root != self.app.module_name and root not in sys.stdlib_module_names
+
+    def _declared_dependencies(self) -> set[str]:
+        pyproject = self.app.path / "pyproject.toml"
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except (tomllib.TOMLDecodeError, OSError):
+            return set()
+        names = {self._dependency_name(dep) for dep in data.get("project", {}).get("dependencies", [])}
+        names.add("frappe")
+        return names
+
+    @staticmethod
+    def _dependency_name(requirement: str) -> str:
+        import re
+
+        name = re.split(r"[<>=!~\[; ]", requirement, maxsplit=1)[0]
+        return name.strip().replace("-", "_")

--- a/pilot/core/app_validator.py
+++ b/pilot/core/app_validator.py
@@ -121,19 +121,19 @@ class Validator:
 
     @staticmethod
     def _optional_import_ids(tree: ast.AST) -> set[int]:
-        """Node ids of imports inside a `try: ... except ImportError: ...` block.
+        """Node ids of imports inside the `try:` body of a `try/except ImportError` block.
 
         Apps commonly guard an optional dependency this way; such an import
         isn't a hard requirement, so it shouldn't be flagged as broken or
-        undeclared.
+        undeclared. The except handler's body is left unguarded — a broken
+        import shipped there is still a real bug.
         """
         guarded: set[int] = set()
         for node in ast.walk(tree):
             if not isinstance(node, ast.Try) or not Validator._catches_import_error(node):
                 continue
-            for block in (node.body, *(handler.body for handler in node.handlers)):
-                for stmt in block:
-                    guarded.update(id(n) for n in ast.walk(stmt))
+            for stmt in node.body:
+                guarded.update(id(n) for n in ast.walk(stmt))
         return guarded
 
     @staticmethod

--- a/pilot/exceptions.py
+++ b/pilot/exceptions.py
@@ -27,3 +27,7 @@ class VolumeError(BenchError):
 
 class MigrateError(BenchError):
     pass
+
+
+class AppValidationError(BenchError):
+    pass

--- a/pilot_zen.md
+++ b/pilot_zen.md
@@ -1,0 +1,20 @@
+## This is similar to Zen of Python
+
+## On design
+Explicit config beats implicit magic.
+One obvious way beats ten flexible ones.
+Boring and predictable ages better than clever.
+
+## On failure
+Fail loud near the bug, not silent three layers up.
+A crash today beats corrupt data tomorrow.
+Retry only what's safe to retry twice.
+
+## On ownership
+If two things can drift out of sync, one must own the truth.
+Quick workaround generally result in long running bugs.
+State that leaks past its scope becomes everyone's problem.
+
+## Developer Guide
+Code read are ten times, written once, optimise for the reader.
+Delete before you add.

--- a/tests/fixtures/testapp/pyproject.toml
+++ b/tests/fixtures/testapp/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "testapp"
+version = "0.0.1"
+description = "Minimal app used in bench-cli integration tests"
+dependencies = []
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_app_validator.py
+++ b/tests/test_app_validator.py
@@ -15,6 +15,11 @@ from pilot.exceptions import AppValidationError
 @dataclass
 class _FakeBench:
     apps_path: Path
+    env_path: Path
+
+    @property
+    def python(self) -> Path:
+        return self.env_path / "bin" / "python"
 
 
 def _make_app(bench_root: Path, name: str, pyproject: str, files: dict[str, str]) -> App:
@@ -25,8 +30,21 @@ def _make_app(bench_root: Path, name: str, pyproject: str, files: dict[str, str]
         full = app_path / relpath
         full.parent.mkdir(parents=True, exist_ok=True)
         full.write_text(content)
-    bench = _FakeBench(apps_path=bench_root / "apps")
+    bench = _FakeBench(apps_path=bench_root / "apps", env_path=bench_root / "env")
     return App(AppConfig(name=name, repo=f"https://example.com/{name}.git", branch="main"), bench)
+
+
+def _stub_bench_python(monkeypatch: pytest.MonkeyPatch, app: App, import_to_distribution: dict[str, list[str]]) -> None:
+    """Simulate the bench env's `packages_distributions()` output without spawning it."""
+    import json
+    from subprocess import CompletedProcess
+
+    app.bench.python.parent.mkdir(parents=True, exist_ok=True)
+    app.bench.python.touch()
+    monkeypatch.setattr(
+        "pilot.core.app_validator.subprocess.run",
+        lambda *a, **k: CompletedProcess(args=[], returncode=0, stdout=json.dumps(import_to_distribution)),
+    )
 
 
 def test_validate_passes_for_well_formed_app(tmp_path: Path) -> None:
@@ -45,7 +63,7 @@ def test_validate_passes_for_well_formed_app(tmp_path: Path) -> None:
 def test_validate_repo_structure_fails_without_pyproject(tmp_path: Path) -> None:
     app_path = tmp_path / "apps" / "myapp"
     app_path.mkdir(parents=True)
-    bench = _FakeBench(apps_path=tmp_path / "apps")
+    bench = _FakeBench(apps_path=tmp_path / "apps", env_path=tmp_path / "env")
     app = App(AppConfig(name="myapp", repo="https://example.com/myapp.git", branch="main"), bench)
     with pytest.raises(AppValidationError, match="pyproject.toml"):
         Validator(app).validate()
@@ -138,6 +156,97 @@ def test_validate_internal_imports_ignores_relative_imports(tmp_path: Path) -> N
         },
     )
     Validator(app).validate()
+
+
+def test_validate_passes_for_dependency_declared_by_frappe(tmp_path: Path) -> None:
+    _make_app(
+        tmp_path,
+        "frappe",
+        '[project]\nname = "frappe"\ndependencies = ["bleach>=6"]\n',
+        {"frappe/hooks.py": "app_name = 'frappe'\n"},
+    )
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "import bleach\n",
+        },
+    )
+    Validator(app).validate()
+
+
+def test_validate_passes_for_import_name_that_differs_from_distribution_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\ndependencies = ["beautifulsoup4>=4"]\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "from bs4 import BeautifulSoup\n",
+        },
+    )
+    _stub_bench_python(monkeypatch, app, {"bs4": ["beautifulsoup4"]})
+    Validator(app).validate()
+
+
+def test_validate_fails_for_import_name_mismatch_when_not_installed_in_bench_env(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\ndependencies = ["beautifulsoup4>=4"]\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "from bs4 import BeautifulSoup\n",
+        },
+    )
+    with pytest.raises(AppValidationError, match="bs4"):
+        Validator(app).validate()
+
+
+def test_validate_ignores_undeclared_import_guarded_by_import_error(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "try:\n    import numpy\nexcept ImportError:\n    numpy = None\n",
+        },
+    )
+    Validator(app).validate()
+
+
+def test_validate_ignores_broken_internal_import_guarded_by_import_error(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "try:\n    from myapp.missing_module import thing\nexcept ImportError:\n    thing = None\n",
+        },
+    )
+    Validator(app).validate()
+
+
+def test_validate_fails_for_undeclared_import_outside_try_block(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "try:\n    import numpy\nexcept ImportError:\n    numpy = None\nimport pandas\n",
+        },
+    )
+    with pytest.raises(AppValidationError) as exc_info:
+        Validator(app).validate()
+    assert "pandas" in str(exc_info.value)
+    assert "numpy" not in str(exc_info.value)
 
 
 def test_validate_external_imports_reports_all_missing_dependencies(tmp_path: Path) -> None:

--- a/tests/test_app_validator.py
+++ b/tests/test_app_validator.py
@@ -75,6 +75,20 @@ def test_validate_repo_structure_fails_without_hooks(tmp_path: Path) -> None:
         Validator(app).validate()
 
 
+def test_validate_syntax_fails_on_broken_python_file(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "def broken(:\n    pass\n",
+        },
+    )
+    with pytest.raises(AppValidationError, match="syntax errors"):
+        Validator(app).validate()
+
+
 def test_validate_internal_imports_fails_on_broken_reference(tmp_path: Path) -> None:
     app = _make_app(
         tmp_path,

--- a/tests/test_app_validator.py
+++ b/tests/test_app_validator.py
@@ -1,0 +1,154 @@
+"""Tests for Validator's pre-install static checks on a cloned app."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from pilot.config.app_config import AppConfig
+from pilot.core.app import App
+from pilot.core.app_validator import Validator
+from pilot.exceptions import AppValidationError
+
+
+@dataclass
+class _FakeBench:
+    apps_path: Path
+
+
+def _make_app(bench_root: Path, name: str, pyproject: str, files: dict[str, str]) -> App:
+    app_path = bench_root / "apps" / name
+    app_path.mkdir(parents=True)
+    (app_path / "pyproject.toml").write_text(pyproject)
+    for relpath, content in files.items():
+        full = app_path / relpath
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(content)
+    bench = _FakeBench(apps_path=bench_root / "apps")
+    return App(AppConfig(name=name, repo=f"https://example.com/{name}.git", branch="main"), bench)
+
+
+def test_validate_passes_for_well_formed_app(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\ndependencies = ["requests>=2"]\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "import requests\nfrom myapp.hooks import app_name\n",
+        },
+    )
+    Validator(app).validate()
+
+
+def test_validate_repo_structure_fails_without_pyproject(tmp_path: Path) -> None:
+    app_path = tmp_path / "apps" / "myapp"
+    app_path.mkdir(parents=True)
+    bench = _FakeBench(apps_path=tmp_path / "apps")
+    app = App(AppConfig(name="myapp", repo="https://example.com/myapp.git", branch="main"), bench)
+    with pytest.raises(AppValidationError, match="pyproject.toml"):
+        Validator(app).validate()
+
+
+def test_validate_repo_structure_fails_without_hooks(tmp_path: Path) -> None:
+    app = _make_app(tmp_path, "myapp", '[project]\nname = "myapp"\n', {"myapp/__init__.py": ""})
+    with pytest.raises(AppValidationError, match="hooks.py"):
+        Validator(app).validate()
+
+
+def test_validate_internal_imports_fails_on_broken_reference(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "from myapp.missing_module import thing\n",
+        },
+    )
+    with pytest.raises(AppValidationError, match="broken internal imports"):
+        Validator(app).validate()
+
+
+def test_validate_external_imports_fails_on_undeclared_dependency(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "import numpy\n",
+        },
+    )
+    with pytest.raises(AppValidationError, match="numpy"):
+        Validator(app).validate()
+
+
+def test_validate_passes_with_stdlib_and_frappe_imports(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "import os\nimport json\nimport frappe\n",
+        },
+    )
+    Validator(app).validate()
+
+
+def test_validate_passes_for_submodule_dependency_name(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\ndependencies = ["Pillow>=9"]\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "from PIL import Image\n",
+        },
+    )
+    with pytest.raises(AppValidationError, match="PIL"):
+        Validator(app).validate()
+
+
+def test_validate_internal_imports_passes_for_resolvable_package_import(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/sub/__init__.py": "",
+            "myapp/utils.py": "import myapp.sub\n",
+        },
+    )
+    Validator(app).validate()
+
+
+def test_validate_internal_imports_ignores_relative_imports(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/sub/__init__.py": "",
+            "myapp/sub/utils.py": "from . import missing\n",
+        },
+    )
+    Validator(app).validate()
+
+
+def test_validate_external_imports_reports_all_missing_dependencies(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "import numpy\nimport pandas\n",
+        },
+    )
+    with pytest.raises(AppValidationError, match="numpy, pandas"):
+        Validator(app).validate()

--- a/tests/test_app_validator.py
+++ b/tests/test_app_validator.py
@@ -233,6 +233,22 @@ def test_validate_ignores_broken_internal_import_guarded_by_import_error(tmp_pat
     Validator(app).validate()
 
 
+def test_validate_fails_for_broken_import_in_except_handler(tmp_path: Path) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": (
+                "try:\n    import ujson as json\nexcept ImportError:\n    from myapp.missing_module import json\n"
+            ),
+        },
+    )
+    with pytest.raises(AppValidationError, match="broken internal imports"):
+        Validator(app).validate()
+
+
 def test_validate_fails_for_undeclared_import_outside_try_block(tmp_path: Path) -> None:
     app = _make_app(
         tmp_path,


### PR DESCRIPTION
## App Validations [Pre-Install]
- Ensure internal and external imports are accounted for.
  - Internal imports are app imports like `pilot.core.bench import Bench`
  - External imports are handled by the `pyproject.toml` declarations of app + framework itself.
  - Optional imports are not hard failures
    ```python
    try:
         import something
    except ModuleNotFound:
         pass
    except ImportError:
         pass    
    ```

- Ensure the directory structure for frappe apps is sound
- Ensure get-app fails when imports are broken.

Since app validations are pre-install therefore we can't fallback to a simpler run files with import check, since the env won't have those dependencies yet since the app is not installed.
