### PR TITLE
feat: support Debian, Fedora and Arch alongside Ubuntu and Alpine

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -32,7 +32,6 @@ jobs:
           - ubuntu:24.04
           - fedora:latest
           - archlinux:latest
-          - ghcr.io/void-linux/void-glibc:latest
           - alpine:latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,41 @@
+name: Install Script Smoke Tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - install.sh
+      - scripts/smoke_install.sh
+      - .github/workflows/install-smoke.yml
+  workflow_dispatch:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint install.sh
+        run: shellcheck -s sh install.sh
+
+      - name: Lint smoke test script
+        run: shellcheck scripts/smoke_install.sh
+
+  smoke:
+    needs: shellcheck
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - debian:bookworm
+          - ubuntu:24.04
+          - fedora:latest
+          - archlinux:latest
+          - ghcr.io/void-linux/void-glibc:latest
+          - alpine:latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run install.sh inside ${{ matrix.image }}
+        run: ./scripts/smoke_install.sh "${{ matrix.image }}"

--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ A zero-dependency CLI for managing [Frappe](https://frappeframework.com) environ
 
 ## Requirements
 
-**Ubuntu 22.04+** — Python 3.11+, a user with `sudo` access  
-**Alpine 3.20+** — apk + OpenRC; `install.sh` bootstraps everything. Production runs under OpenRC (`process_manager = "openrc"`) instead of systemd  
+**Debian 12+ / Ubuntu 22.04+** — Python 3.11+, a user with `sudo` access  
+**Fedora 40+** — dnf + systemd; redis is provided by valkey  
+**Arch Linux** — pacman + systemd; redis is provided by valkey  
+**Void Linux (glibc)** — xbps; production process management not yet supported (runit)  
+**Alpine 3.20+** — apk + OpenRC; production runs under OpenRC (`process_manager = "openrc"`) instead of systemd  
 **macOS** — Python 3.11+, [Homebrew](https://brew.sh) (dev only — no `sudo` setup)
+
+Derivatives that set `ID_LIKE` in `/etc/os-release` (Linux Mint, EndeavourOS, …)
+are detected as their parent distro.
 
 ## Install
 
@@ -31,8 +37,10 @@ A zero-dependency CLI for managing [Frappe](https://frappeframework.com) environ
 curl -fsSL https://raw.githubusercontent.com/frappe/pilot/main/install.sh | bash
 ```
 
-On bare Alpine (no curl/bash preinstalled) bootstrap with busybox `wget` + `sh`
-instead — the installer apk-installs git, curl, bash, sudo and the build deps itself:
+On a bare box (no curl/bash preinstalled — e.g. a fresh Alpine or a distro
+container) bootstrap with `wget` + `sh` instead — the installer uses the
+distro's package manager to install git, curl, bash, sudo and the build deps
+itself:
 
 ```sh
 wget -qO- https://raw.githubusercontent.com/frappe/pilot/main/install.sh | sh

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ A zero-dependency CLI for managing [Frappe](https://frappeframework.com) environ
 **Debian 12+ / Ubuntu 22.04+** — Python 3.11+, a user with `sudo` access  
 **Fedora 40+** — dnf + systemd; redis is provided by valkey  
 **Arch Linux** — pacman + systemd; redis is provided by valkey  
-**Void Linux (glibc)** — xbps; production process management not yet supported (runit)  
 **Alpine 3.20+** — apk + OpenRC; production runs under OpenRC (`process_manager = "openrc"`) instead of systemd  
 **macOS** — Python 3.11+, [Homebrew](https://brew.sh) (dev only — no `sudo` setup)
 

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,17 @@
 #!/bin/sh
 set -e
 
-# POSIX sh (not bash) so a bare Alpine box can bootstrap via `wget -qO- ... | sh`
-# before bash exists. The Ubuntu one-liner still pipes to bash explicitly.
+# POSIX sh (not bash) so a bare box can bootstrap via `wget -qO- ... | sh`
+# before bash exists. The provisioned-host one-liner still pipes to bash.
+#
+# Supported distros: Debian, Ubuntu, Fedora, Arch, Void, Alpine (and their
+# derivatives via ID_LIKE). Unknown distros fall back to apt when available.
 
 # ── configuration ────────────────────────────────────────────────────────────
 INSTALL_URL="https://raw.githubusercontent.com/frappe/pilot/main/install.sh"
-REPO_URL="https://github.com/frappe/pilot"
-BRANCH_NAME="main"
+# Overridable so smoke tests can install from a local checkout.
+REPO_URL="${PILOT_REPO_URL:-https://github.com/frappe/pilot}"
+BRANCH_NAME="${PILOT_BRANCH:-main}"
 PILOT_DIR="$HOME/pilot"
 DEFAULT_USER="frappe"
 
@@ -35,30 +39,35 @@ done
 # A tty is required to prompt; without one we must run non-interactively.
 [ -e /dev/tty ] || NONINTERACTIVE=1
 
-# ── Alpine bootstrap ──────────────────────────────────────────────────────────
-# Bare Alpine ships almost nothing and uses apk + musl. Install the tools the
-# rest of this script and bench need before they're first used: git/curl/bash,
-# sudo + shadow (so the user-setup path's useradd/usermod/visudo work), a Python,
-# and the base build deps for compiling the admin venv (psutil) and frappe wheels.
-if [ -f /etc/alpine-release ] && command -v apk >/dev/null 2>&1; then
-    echo "Alpine detected — installing base dependencies via apk..."
-    if [ "$(id -u)" -eq 0 ]; then
-        APK_SUDO=""
-    elif command -v sudo >/dev/null 2>&1; then
-        APK_SUDO="sudo"
-    else
-        # Bare Alpine ships no sudo, and a non-root user can't run apk. Re-run as
-        # root first — that path installs sudo and prepares the bench user — then
-        # run the installer again as that user.
-        echo "sudo is not installed and you are not root, so apk packages cannot be"
-        echo "installed. Re-run this installer as root first, then as the bench user:"
-        echo ""
-        echo "   wget -qO- $INSTALL_URL | sh   # as root"
-        exit 1
+# ── distro detection ──────────────────────────────────────────────────────────
+detect_distro() {
+    if [ "$(uname)" = "Darwin" ]; then
+        echo macos
+        return
     fi
-    $APK_SUDO apk add --no-cache \
-        git curl bash sudo shadow python3 python3-dev build-base linux-headers tzdata
-fi
+    if [ ! -r /etc/os-release ]; then
+        echo unknown
+        return
+    fi
+    # os-release is sh syntax by spec; source it in subshells so its variables
+    # never leak into ours.
+    # shellcheck disable=SC1091
+    distro_id=$(. /etc/os-release; echo "$ID")
+    # shellcheck disable=SC1091
+    distro_like=$(. /etc/os-release; echo "${ID_LIKE:-}")
+    case "$distro_id" in
+        debian|ubuntu|fedora|arch|void|alpine) echo "$distro_id"; return ;;
+    esac
+    # Derivatives advertise their parent in ID_LIKE (e.g. Mint -> ubuntu).
+    for token in $distro_like; do
+        case "$token" in
+            debian|ubuntu|fedora|arch) echo "$token"; return ;;
+        esac
+    done
+    echo unknown
+}
+
+DISTRO="$(detect_distro)"
 
 # ── sudo wrapper ──────────────────────────────────────────────────────────────
 # Injects SUDO_PASS when provided so the script works unattended; otherwise
@@ -72,6 +81,100 @@ run_sudo() {
         sudo "$@"
     fi
 }
+
+# ── package manager primitives ────────────────────────────────────────────────
+# Unknown distros fall back to apt, mirroring the runtime in pilot/platform.py.
+pkg_update() {
+    case "$DISTRO" in
+        fedora) run_sudo dnf -y makecache ;;
+        arch)   run_sudo pacman -Sy --noconfirm --disable-download-timeout ;;
+        void)   run_sudo xbps-install -S ;;
+        alpine) run_sudo apk update ;;
+        *)      run_sudo apt-get update ;;
+    esac
+}
+
+pkg_install() {
+    case "$DISTRO" in
+        # --allowerasing: containers ship curl-minimal, which conflicts with curl.
+        fedora) run_sudo dnf install -y --allowerasing "$@" ;;
+        # -Sy: sync the package database first; stale Arch mirrors 404 otherwise.
+        # The download timeout aborts large transfers on slow links; disable it.
+        arch)   run_sudo pacman -Sy --noconfirm --needed --disable-download-timeout "$@" ;;
+        void)   run_sudo xbps-install -Sy "$@" ;;
+        alpine) run_sudo apk add --no-cache "$@" ;;
+        *)      run_sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "$@" ;;
+    esac
+}
+
+pkg_installed() {
+    case "$DISTRO" in
+        fedora) rpm -q "$1" >/dev/null 2>&1 ;;
+        arch)   pacman -Qi "$1" >/dev/null 2>&1 ;;
+        void)   xbps-query "$1" >/dev/null 2>&1 ;;
+        alpine) apk info -e "$1" >/dev/null 2>&1 ;;
+        *)      dpkg -l "$1" 2>/dev/null | grep -q '^ii' ;;
+    esac
+}
+
+# ── base dependency bootstrap ─────────────────────────────────────────────────
+# Bare images of most distros ship almost nothing. Install the tools the rest
+# of this script and bench need before they're first used: git/curl/bash, sudo
+# + user tooling (so the user-setup path's useradd/usermod/visudo work), a
+# Python, and the base build deps for compiling the admin venv (psutil) and
+# frappe wheels.
+bootstrap_needed() {
+    # Build deps are otherwise installed by bench at runtime, but Alpine needs
+    # them up front to compile the admin venv (musl wheels are not universal).
+    tools="git curl bash sudo python3"
+    [ "$DISTRO" = "alpine" ] && tools="$tools cc"
+    for tool in $tools; do
+        command -v "$tool" >/dev/null 2>&1 || return 0
+    done
+    return 1
+}
+
+bootstrap_packages() {
+    case "$DISTRO" in
+        debian|ubuntu)
+            pkg_install git curl bash sudo ca-certificates python3 python3-dev build-essential tzdata ;;
+        fedora)
+            pkg_install git curl bash sudo shadow-utils python3 python3-devel gcc gcc-c++ make tzdata ;;
+        arch)
+            pkg_install git curl bash sudo python base-devel tzdata ;;
+        void)
+            # Minimal images lack `su` (util-linux) and `tar`/`gzip` (uv installer).
+            pkg_install git curl bash sudo shadow util-linux tar gzip python3 python3-devel base-devel tzdata ;;
+        alpine)
+            pkg_install git curl bash sudo shadow python3 python3-dev build-base linux-headers tzdata ;;
+    esac
+}
+
+bootstrap() {
+    case "$DISTRO" in
+        macos|unknown) return 0 ;;
+    esac
+    # Root always bootstraps (idempotent, and bare containers need it before
+    # useradd); a normal user only when a base tool is actually missing.
+    if [ "$(id -u)" -ne 0 ]; then
+        bootstrap_needed || return 0
+        if ! command -v sudo >/dev/null 2>&1; then
+            # A non-root user can't install packages without sudo. Re-run as
+            # root first — that path installs sudo and prepares the bench user.
+            echo "sudo is not installed and you are not root, so base packages cannot"
+            echo "be installed. Re-run this installer as root first, then as the bench"
+            echo "user:"
+            echo ""
+            echo "   wget -qO- $INSTALL_URL | sh   # as root"
+            exit 1
+        fi
+    fi
+    echo "$DISTRO detected — installing base dependencies..."
+    pkg_update
+    bootstrap_packages
+}
+
+bootstrap
 
 # ── passwordless sudo configuration ──────────────────────────────────────────
 # Writes /etc/sudoers.d/<user> granting passwordless sudo. Validated with visudo
@@ -94,6 +197,15 @@ write_sudoers() {
     rm -f "$tmp"
 }
 
+# The group conventionally granted admin rights (only cosmetic here — actual
+# access comes from the sudoers.d file above).
+admin_group() {
+    case "$DISTRO" in
+        debian|ubuntu|unknown) echo sudo ;;
+        *) echo wheel ;;
+    esac
+}
+
 # ── Path A: running as root → create the bench user, then stop ───────────────
 # We do NOT switch users on the fly. We prepare the account and ask the operator
 # to re-run the installer as that user.
@@ -103,7 +215,7 @@ if [ "$(id -u)" -eq 0 ]; then
     if ! id "$BENCH_USER" >/dev/null 2>&1; then
         echo "Creating user '$BENCH_USER'..."
         useradd -m -s /bin/bash "$BENCH_USER"
-        usermod -aG sudo "$BENCH_USER" 2>/dev/null || true
+        usermod -aG "$(admin_group)" "$BENCH_USER" 2>/dev/null || true
     fi
 
     write_sudoers "$BENCH_USER"
@@ -169,7 +281,7 @@ if ! command -v sudo >/dev/null 2>&1; then
 fi
 
 echo "Bench needs passwordless sudo to install packages and manage services."
-if [ "$(uname)" = "Darwin" ]; then
+if [ "$DISTRO" = "macos" ]; then
     echo ""
     echo "NOTE: this will grant the current user '$(id -un)' passwordless sudo"
     echo "      access by writing /etc/sudoers.d/$(id -un)."
@@ -178,7 +290,7 @@ fi
 authenticate_sudo
 write_sudoers "$(id -un)"
 
-# Clone or update the repo
+# ── clone or update the repo ──────────────────────────────────────────────────
 if [ -d "$PILOT_DIR" ]; then
     echo "Updating pilot..."
     git -C "$PILOT_DIR" pull
@@ -189,37 +301,63 @@ fi
 
 chmod +x "$PILOT_DIR/bench"
 
-# Install uv if not present
+# ── uv ────────────────────────────────────────────────────────────────────────
 if ! command -v uv >/dev/null 2>&1; then
     echo "Installing uv..."
     curl -LsSf https://astral.sh/uv/install.sh | sh
     export PATH="$HOME/.local/bin:$PATH"
 fi
 
-# Install Node.js
-if ! command -v node >/dev/null 2>&1 && command -v apt-get >/dev/null 2>&1; then
-    echo "Installing Node.js..."
+# ── Node.js ───────────────────────────────────────────────────────────────────
+# NodeSource pins Node 24 on the deb/rpm distros; the rolling distros (Arch,
+# Void, Alpine) ship a current Node in their own repos — and NodeSource has no
+# musl builds anyway.
+install_node_nodesource() {
+    kind="$1"; shift
     NODE_SETUP_TMP="$(mktemp)"
-    curl -fsSL https://deb.nodesource.com/setup_24.x -o "$NODE_SETUP_TMP"
+    curl -fsSL "https://${kind}.nodesource.com/setup_24.x" -o "$NODE_SETUP_TMP"
     run_sudo bash "$NODE_SETUP_TMP"
     rm -f "$NODE_SETUP_TMP"
-    run_sudo apt-get install -y nodejs
-fi
+    run_sudo "$@"
+}
 
-# Install timezone data (required by Python's zoneinfo module on systems without system tzdata)
-if [ "$(uname)" != "Darwin" ]; then
-    if command -v apt-get >/dev/null 2>&1; then
-        if ! dpkg -l tzdata 2>/dev/null | grep -q '^ii'; then
-            echo "Installing timezone data..."
-            DEBIAN_FRONTEND=noninteractive run_sudo apt-get install -y tzdata
-        fi
-    elif command -v apk >/dev/null 2>&1; then
-        if ! apk info -e tzdata >/dev/null 2>&1; then
-            echo "Installing timezone data..."
-            run_sudo apk add --no-cache tzdata
-        fi
-    fi
-fi
+install_node() {
+    command -v node >/dev/null 2>&1 && return 0
+    case "$DISTRO" in
+        debian|ubuntu)
+            echo "Installing Node.js..."
+            install_node_nodesource deb apt-get install -y nodejs ;;
+        fedora)
+            echo "Installing Node.js..."
+            install_node_nodesource rpm dnf install -y nodejs ;;
+        arch)   echo "Installing Node.js..."; pkg_install nodejs npm ;;
+        void)   echo "Installing Node.js..."; pkg_install nodejs ;;
+        alpine) echo "Installing Node.js..."; pkg_install nodejs npm ;;
+        *)
+            # Same fallback as before this script knew about distros: NodeSource
+            # when apt exists, otherwise leave Node to the operator.
+            if command -v apt-get >/dev/null 2>&1; then
+                echo "Installing Node.js..."
+                install_node_nodesource deb apt-get install -y nodejs
+            fi ;;
+    esac
+}
+
+install_node
+
+# ── timezone data ─────────────────────────────────────────────────────────────
+# Required by Python's zoneinfo module on systems without system tzdata.
+ensure_tzdata() {
+    case "$DISTRO" in
+        macos) return 0 ;;
+        unknown) command -v apt-get >/dev/null 2>&1 || return 0 ;;
+    esac
+    pkg_installed tzdata && return 0
+    echo "Installing timezone data..."
+    pkg_install tzdata
+}
+
+ensure_tzdata
 
 # ── add bench to PATH ─────────────────────────────────────────────────────────
 add_to_path() {
@@ -283,6 +421,7 @@ print(' '.join(deps))
     if [ -z "$ADMIN_DEPS" ]; then
         ADMIN_DEPS="flask>=3.0 psutil>=5.9 pymysql>=1.1 gunicorn>=21.2"
     fi
+    # shellcheck disable=SC2086 # ADMIN_DEPS is a space-separated list
     uv pip install --python "$ADMIN_VENV/bin/python" --quiet $ADMIN_DEPS
     echo "Admin environment ready."
 fi

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -e
 # POSIX sh (not bash) so a bare box can bootstrap via `wget -qO- ... | sh`
 # before bash exists. The provisioned-host one-liner still pipes to bash.
 #
-# Supported distros: Debian, Ubuntu, Fedora, Arch, Void, Alpine (and their
+# Supported distros: Debian, Ubuntu, Fedora, Arch, Alpine (and their
 # derivatives via ID_LIKE). Unknown distros fall back to apt when available.
 
 # ── configuration ────────────────────────────────────────────────────────────
@@ -56,7 +56,7 @@ detect_distro() {
     # shellcheck disable=SC1091
     distro_like=$(. /etc/os-release; echo "${ID_LIKE:-}")
     case "$distro_id" in
-        debian|ubuntu|fedora|arch|void|alpine) echo "$distro_id"; return ;;
+        debian|ubuntu|fedora|arch|alpine) echo "$distro_id"; return ;;
     esac
     # Derivatives advertise their parent in ID_LIKE (e.g. Mint -> ubuntu).
     for token in $distro_like; do
@@ -88,7 +88,6 @@ pkg_update() {
     case "$DISTRO" in
         fedora) run_sudo dnf -y makecache ;;
         arch)   run_sudo pacman -Sy --noconfirm --disable-download-timeout ;;
-        void)   run_sudo xbps-install -S ;;
         alpine) run_sudo apk update ;;
         *)      run_sudo apt-get update ;;
     esac
@@ -101,7 +100,6 @@ pkg_install() {
         # -Sy: sync the package database first; stale Arch mirrors 404 otherwise.
         # The download timeout aborts large transfers on slow links; disable it.
         arch)   run_sudo pacman -Sy --noconfirm --needed --disable-download-timeout "$@" ;;
-        void)   run_sudo xbps-install -Sy "$@" ;;
         alpine) run_sudo apk add --no-cache "$@" ;;
         *)      run_sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "$@" ;;
     esac
@@ -111,7 +109,6 @@ pkg_installed() {
     case "$DISTRO" in
         fedora) rpm -q "$1" >/dev/null 2>&1 ;;
         arch)   pacman -Qi "$1" >/dev/null 2>&1 ;;
-        void)   xbps-query "$1" >/dev/null 2>&1 ;;
         alpine) apk info -e "$1" >/dev/null 2>&1 ;;
         *)      dpkg -l "$1" 2>/dev/null | grep -q '^ii' ;;
     esac
@@ -142,9 +139,6 @@ bootstrap_packages() {
             pkg_install git curl bash sudo shadow-utils python3 python3-devel gcc gcc-c++ make tzdata ;;
         arch)
             pkg_install git curl bash sudo python base-devel tzdata ;;
-        void)
-            # Minimal images lack `su` (util-linux) and `tar`/`gzip` (uv installer).
-            pkg_install git curl bash sudo shadow util-linux tar gzip python3 python3-devel base-devel tzdata ;;
         alpine)
             pkg_install git curl bash sudo shadow python3 python3-dev build-base linux-headers tzdata ;;
     esac
@@ -310,8 +304,8 @@ fi
 
 # ── Node.js ───────────────────────────────────────────────────────────────────
 # NodeSource pins Node 24 on the deb/rpm distros; the rolling distros (Arch,
-# Void, Alpine) ship a current Node in their own repos — and NodeSource has no
-# musl builds anyway.
+# Alpine) ship a current Node in their own repos — and NodeSource has no musl
+# builds anyway.
 install_node_nodesource() {
     kind="$1"; shift
     NODE_SETUP_TMP="$(mktemp)"
@@ -331,7 +325,6 @@ install_node() {
             echo "Installing Node.js..."
             install_node_nodesource rpm dnf install -y nodejs ;;
         arch)   echo "Installing Node.js..."; pkg_install nodejs npm ;;
-        void)   echo "Installing Node.js..."; pkg_install nodejs ;;
         alpine) echo "Installing Node.js..."; pkg_install nodejs npm ;;
         *)
             # Same fallback as before this script knew about distros: NodeSource

--- a/pilot/commands/init.py
+++ b/pilot/commands/init.py
@@ -200,7 +200,8 @@ class InitCommand(Command):
     def _install_system_packages(self) -> None:
         from pilot.managers.python_env_manager import PythonEnvManager
         from pilot.managers.redis_manager import RedisManager
-        from pilot.platform import get_package_manager, is_linux
+        from pilot.package_managers import get_package_manager
+        from pilot.platform import is_linux
 
         pkg = get_package_manager()
         if is_linux():

--- a/pilot/commands/setup/production.py
+++ b/pilot/commands/setup/production.py
@@ -315,7 +315,7 @@ class SetupProductionCommand(Command):
     def _setup_supervisor(self) -> None:
         import subprocess
 
-        from pilot.platform import get_package_manager
+        from pilot.package_managers import get_package_manager
 
         pkg = get_package_manager()
         if not pkg.is_installed("supervisor"):

--- a/pilot/managers/letsencrypt_manager.py
+++ b/pilot/managers/letsencrypt_manager.py
@@ -4,7 +4,8 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pilot.platform import _privileged, get_package_manager, is_alpine
+from pilot.package_managers import get_package_manager
+from pilot.platform import _privileged, is_alpine
 from pilot.utils import run_command
 
 if TYPE_CHECKING:

--- a/pilot/managers/mariadb_manager.py
+++ b/pilot/managers/mariadb_manager.py
@@ -5,9 +5,11 @@ from contextlib import contextmanager
 from pathlib import Path
 
 from pilot.config.mariadb_config import MariaDBConfig
+from pilot.package_managers import get_package_manager
 from pilot.platform import (
+    Distro,
     _privileged,
-    get_package_manager,
+    detect_distro,
     is_alpine,
     is_macos,
     service_command,
@@ -85,7 +87,10 @@ class MariaDBManager:
         if is_macos():
             package_manager.install(self._brew_package())
             return
-        self._setup_apt_repo()
+        # MariaDB's repo-setup script only supports apt; other distros ship a
+        # recent enough MariaDB in their own repos.
+        if detect_distro() in (Distro.DEBIAN, Distro.UBUNTU, Distro.UNKNOWN):
+            self._setup_apt_repo()
         package_manager.update()
         package_manager.install("mariadb-server", "mariadb-client")
 

--- a/pilot/managers/nginx_manager.py
+++ b/pilot/managers/nginx_manager.py
@@ -8,10 +8,10 @@ from string import Template
 from typing import TYPE_CHECKING
 
 from pilot.managers.gunicorn_manager import GunicornManager
+from pilot.package_managers import get_package_manager
 from pilot.platform import (
     _privileged,
     default_nginx_config_dir,
-    get_package_manager,
     is_alpine,
     is_linux,
     service_command,

--- a/pilot/managers/postgres_manager.py
+++ b/pilot/managers/postgres_manager.py
@@ -8,9 +8,9 @@ import time
 from pathlib import Path
 
 from pilot.config.postgres_config import PostgresConfig
+from pilot.package_managers import get_package_manager
 from pilot.platform import (
     _privileged,
-    get_package_manager,
     is_alpine,
     is_linux,
     is_macos,

--- a/pilot/managers/process_manager.py
+++ b/pilot/managers/process_manager.py
@@ -372,9 +372,11 @@ class ProcessManager:
         ]
 
     def _redis_definition(self, name: str, config_filename: str) -> ProcessDefinition:
+        from pilot.managers.redis_manager import redis_server_binary
+
         return ProcessDefinition(
             name=name,
-            command=f"redis-server {self.bench.config_path}/{config_filename}",
+            command=f"{redis_server_binary() or 'redis-server'} {self.bench.config_path}/{config_filename}",
             log_file=self.bench.logs_path / f"{name}.log",
             stop_timeout=300,
         )

--- a/pilot/managers/python_env_manager.py
+++ b/pilot/managers/python_env_manager.py
@@ -129,8 +129,8 @@ class PythonEnvManager:
         elif distro == Distro.FEDORA:
             self._install_node_nodesource("rpm", ["dnf", "install", "-y", "nodejs"])
         else:
-            # Arch/Void/Alpine repos ship current Node; nodesource has no
-            # builds for them (and none at all for musl).
+            # Arch/Alpine repos ship current Node; nodesource has no builds
+            # for them (and none at all for musl).
             get_package_manager().install("nodejs", "npm")
 
     def _install_node_nodesource(self, kind: str, install_argv: list[str]) -> None:

--- a/pilot/managers/python_env_manager.py
+++ b/pilot/managers/python_env_manager.py
@@ -9,7 +9,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pilot.exceptions import BenchError
-from pilot.platform import get_package_manager, is_alpine, is_macos, which
+from pilot.package_managers import get_package_manager
+from pilot.platform import Distro, detect_distro, is_macos, which
 from pilot.utils import get_yarn_bin, git_has_local_changes, run_command
 
 if TYPE_CHECKING:
@@ -114,15 +115,30 @@ class PythonEnvManager:
 
     def install_node(self) -> None:
         if not which("node"):
-            if is_macos():
-                run_command(["brew", "install", "node"])
-            elif is_alpine():
-                # nodesource ships no musl builds; use Alpine's own packages.
-                get_package_manager().install("nodejs", "npm")
-            else:
-                self._install_node_linux()
+            self._install_node()
         if not which("yarn"):
             self._install_yarn()
+
+    def _install_node(self) -> None:
+        if is_macos():
+            run_command(["brew", "install", "node"])
+            return
+        distro = detect_distro()
+        if distro in (Distro.DEBIAN, Distro.UBUNTU, Distro.UNKNOWN):
+            self._install_node_nodesource("deb", ["apt-get", "install", "-y", "nodejs"])
+        elif distro == Distro.FEDORA:
+            self._install_node_nodesource("rpm", ["dnf", "install", "-y", "nodejs"])
+        else:
+            # Arch/Void/Alpine repos ship current Node; nodesource has no
+            # builds for them (and none at all for musl).
+            get_package_manager().install("nodejs", "npm")
+
+    def _install_node_nodesource(self, kind: str, install_argv: list[str]) -> None:
+        run_command(
+            ["bash", "-c", f"curl -fsSL https://{kind}.nodesource.com/setup_24.x | sudo -E bash -"],
+            stream_output=True,
+        )
+        run_command(["sudo", *install_argv], stream_output=True)
 
     def _install_yarn(self) -> None:
         if is_macos():
@@ -363,9 +379,3 @@ class PythonEnvManager:
 
         raise BenchError("uv was installed but cannot be found. Add ~/.local/bin to your PATH and re-run.")
 
-    def _install_node_linux(self) -> None:
-        run_command(
-            ["bash", "-c", "curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -"],
-            stream_output=True,
-        )
-        run_command(["sudo", "apt-get", "install", "-y", "nodejs"], stream_output=True)

--- a/pilot/managers/redis_manager.py
+++ b/pilot/managers/redis_manager.py
@@ -5,10 +5,19 @@ import subprocess
 from typing import TYPE_CHECKING
 
 from pilot.config.redis_config import RedisConfig
-from pilot.platform import get_package_manager, is_macos, which
+from pilot.package_managers import get_package_manager
+from pilot.platform import is_macos, which
 
 if TYPE_CHECKING:
     from pilot.core.bench import Bench
+
+
+def redis_server_binary() -> str | None:
+    """Path to the redis server binary, or None if not installed.
+
+    Fedora and Arch ship valkey (a redis fork) whose binary keeps redis'
+    CLI and version-output format."""
+    return which("redis-server") or which("valkey-server")
 
 
 class RedisManager:
@@ -17,16 +26,17 @@ class RedisManager:
         self.bench = bench
 
     def is_installed(self) -> bool:
-        return which("redis-server") is not None
+        return redis_server_binary() is not None
 
     @staticmethod
     def installed_version() -> str:
         """Return the installed redis-server version (e.g. '7.0.11'), or '' if unavailable."""
-        if which("redis-server") is None:
+        binary = redis_server_binary()
+        if binary is None:
             return ""
         try:
             result = subprocess.run(
-                ["redis-server", "--version"],
+                [binary, "--version"],
                 capture_output=True,
                 text=True,
                 timeout=5,

--- a/pilot/managers/volume_manager.py
+++ b/pilot/managers/volume_manager.py
@@ -10,7 +10,8 @@ from pathlib import Path
 
 from pilot.config.volume_config import VolumeConfig
 from pilot.exceptions import CommandError, VolumeError
-from pilot.platform import _privileged, get_package_manager, is_alpine, service_enable_command, which as platform_which
+from pilot.package_managers import get_package_manager
+from pilot.platform import _privileged, is_alpine, service_enable_command, which as platform_which
 from pilot.utils import run_command
 
 

--- a/pilot/package_managers.py
+++ b/pilot/package_managers.py
@@ -152,41 +152,6 @@ class PacmanPackageManager(SystemPackageManager):
         subprocess.run(_privileged(["pacman", "-Sy", "--noconfirm"]))
 
 
-class XbpsPackageManager(SystemPackageManager):
-    package_aliases = {
-        "build-essential": "base-devel",
-        "python3-dev": "python3-devel",
-        "libmariadb-dev": "libmariadbclient-devel",
-        "libpq-dev": "postgresql-libs-devel",
-        "mariadb-server": "mariadb",
-        "mariadb-client": "mariadb",
-        "redis-server": "redis",
-        # Void versions its postgres packages like Alpine does.
-        "postgresql": "postgresql16",
-        "postgresql-client": "postgresql16-client",
-        "zfsutils-linux": "zfs",
-        # npm ships inside Void's nodejs package.
-        "npm": "nodejs",
-    }
-
-    def install(self, *packages: str) -> None:
-        subprocess.run(
-            _privileged(["xbps-install", "-Sy", *self._resolve(*packages)]),
-            check=True,
-        )
-
-    def is_installed(self, package: str) -> bool:
-        resolved = self._resolve(package)[0]
-        result = subprocess.run(
-            ["xbps-query", resolved],
-            capture_output=True,
-        )
-        return result.returncode == 0
-
-    def update(self):
-        subprocess.run(_privileged(["xbps-install", "-S"]))
-
-
 class BrewPackageManager(SystemPackageManager):
     def install(self, *packages: str) -> None:
         subprocess.run(
@@ -209,7 +174,6 @@ _LINUX_PACKAGE_MANAGERS: dict[Distro, type[SystemPackageManager]] = {
     Distro.ALPINE: ApkPackageManager,
     Distro.FEDORA: DnfPackageManager,
     Distro.ARCH: PacmanPackageManager,
-    Distro.VOID: XbpsPackageManager,
 }
 
 

--- a/pilot/package_managers.py
+++ b/pilot/package_managers.py
@@ -1,0 +1,221 @@
+"""System package installation for every supported platform.
+
+Call sites pass canonical Debian/apt package names; each manager's
+``package_aliases`` maps those onto its distro's own names. An alias may be
+a tuple when one canonical package corresponds to several native ones.
+"""
+
+import os
+import subprocess
+from abc import ABC, abstractmethod
+
+from pilot.platform import Distro, _privileged, detect_distro, is_macos
+
+
+class SystemPackageManager(ABC):
+    # Canonical (Debian/apt) name -> native name(s). Unmapped names pass through.
+    package_aliases: dict[str, str | tuple[str, ...]] = {}
+
+    def _resolve(self, *packages: str) -> list[str]:
+        resolved: list[str] = []
+        for package in packages:
+            alias = self.package_aliases.get(package, package)
+            names = alias if isinstance(alias, tuple) else (alias,)
+            resolved.extend(name for name in names if name not in resolved)
+        return resolved
+
+    @abstractmethod
+    def install(self, *packages: str) -> None:
+        """Install one or more system packages."""
+
+    @abstractmethod
+    def is_installed(self, package: str) -> bool:
+        """Return True if the package is already installed."""
+
+    @abstractmethod
+    def update(self) -> None:
+        """Refresh the package index."""
+
+
+class AptPackageManager(SystemPackageManager):
+    def install(self, *packages: str) -> None:
+        subprocess.run(
+            _privileged(["apt-get", "install", "-y", *packages]),
+            env={**os.environ, "DEBIAN_FRONTEND": "noninteractive"},
+            check=True,
+        )
+
+    def is_installed(self, package: str) -> bool:
+        result = subprocess.run(
+            ["dpkg", "-l", package],
+            capture_output=True,
+        )
+        return result.returncode == 0
+
+    def update(self):
+        subprocess.run(_privileged(["apt-get", "-y", "update"]))
+
+
+class ApkPackageManager(SystemPackageManager):
+    package_aliases = {
+        "build-essential": "build-base",
+        "pkg-config": "pkgconf",
+        "libmariadb-dev": "mariadb-dev",
+        "mariadb-server": "mariadb",
+        "mariadb-client": "mariadb-client",
+        "redis-server": "redis",
+        "supervisor": "supervisor",
+    }
+
+    def install(self, *packages: str) -> None:
+        subprocess.run(
+            _privileged(["apk", "add", "--no-cache", *self._resolve(*packages)]),
+            check=True,
+        )
+
+    def is_installed(self, package: str) -> bool:
+        resolved = self._resolve(package)[0]
+        result = subprocess.run(
+            ["apk", "info", "-e", resolved],
+            capture_output=True,
+        )
+        return result.returncode == 0
+
+    def update(self):
+        subprocess.run(_privileged(["apk", "update"]))
+
+
+class DnfPackageManager(SystemPackageManager):
+    package_aliases = {
+        "build-essential": ("gcc", "gcc-c++", "make"),
+        "pkg-config": "pkgconf-pkg-config",
+        "python3-dev": "python3-devel",
+        "libmariadb-dev": "mariadb-connector-c-devel",
+        "libpq-dev": "libpq-devel",
+        "mariadb-client": "mariadb",
+        # Fedora 41+ ships valkey (redis fork) instead of redis.
+        "redis-server": "valkey",
+        "postgresql": "postgresql-server",
+        "postgresql-client": "postgresql",
+        "zfsutils-linux": "zfs",
+    }
+
+    def install(self, *packages: str) -> None:
+        subprocess.run(
+            _privileged(["dnf", "install", "-y", *self._resolve(*packages)]),
+            check=True,
+        )
+
+    def is_installed(self, package: str) -> bool:
+        resolved = self._resolve(package)
+        result = subprocess.run(
+            ["rpm", "-q", *resolved],
+            capture_output=True,
+        )
+        return result.returncode == 0
+
+    def update(self):
+        subprocess.run(_privileged(["dnf", "-y", "makecache"]))
+
+
+class PacmanPackageManager(SystemPackageManager):
+    package_aliases = {
+        "build-essential": "base-devel",
+        "pkg-config": "pkgconf",
+        "python3-dev": "python",
+        "libmariadb-dev": "mariadb-libs",
+        "libpq-dev": "postgresql-libs",
+        "mariadb-server": "mariadb",
+        "mariadb-client": "mariadb-clients",
+        # Arch moved redis to the AUR in favour of valkey.
+        "redis-server": "valkey",
+        "postgresql-client": "postgresql",
+        # Only available via the third-party archzfs repository.
+        "zfsutils-linux": "zfs-utils",
+    }
+
+    def install(self, *packages: str) -> None:
+        subprocess.run(
+            _privileged(["pacman", "-S", "--noconfirm", "--needed", *self._resolve(*packages)]),
+            check=True,
+        )
+
+    def is_installed(self, package: str) -> bool:
+        resolved = self._resolve(package)
+        result = subprocess.run(
+            ["pacman", "-Qi", *resolved],
+            capture_output=True,
+        )
+        return result.returncode == 0
+
+    def update(self):
+        subprocess.run(_privileged(["pacman", "-Sy", "--noconfirm"]))
+
+
+class XbpsPackageManager(SystemPackageManager):
+    package_aliases = {
+        "build-essential": "base-devel",
+        "python3-dev": "python3-devel",
+        "libmariadb-dev": "libmariadbclient-devel",
+        "libpq-dev": "postgresql-libs-devel",
+        "mariadb-server": "mariadb",
+        "mariadb-client": "mariadb",
+        "redis-server": "redis",
+        # Void versions its postgres packages like Alpine does.
+        "postgresql": "postgresql16",
+        "postgresql-client": "postgresql16-client",
+        "zfsutils-linux": "zfs",
+        # npm ships inside Void's nodejs package.
+        "npm": "nodejs",
+    }
+
+    def install(self, *packages: str) -> None:
+        subprocess.run(
+            _privileged(["xbps-install", "-Sy", *self._resolve(*packages)]),
+            check=True,
+        )
+
+    def is_installed(self, package: str) -> bool:
+        resolved = self._resolve(package)[0]
+        result = subprocess.run(
+            ["xbps-query", resolved],
+            capture_output=True,
+        )
+        return result.returncode == 0
+
+    def update(self):
+        subprocess.run(_privileged(["xbps-install", "-S"]))
+
+
+class BrewPackageManager(SystemPackageManager):
+    def install(self, *packages: str) -> None:
+        subprocess.run(
+            ["brew", "install", *packages],
+            check=True,
+        )
+
+    def is_installed(self, package: str) -> bool:
+        result = subprocess.run(
+            ["brew", "list", "--versions", package],
+            capture_output=True,
+        )
+        return bool(result.stdout.strip())
+
+    def update(self):
+        return super().update()
+
+
+_LINUX_PACKAGE_MANAGERS: dict[Distro, type[SystemPackageManager]] = {
+    Distro.ALPINE: ApkPackageManager,
+    Distro.FEDORA: DnfPackageManager,
+    Distro.ARCH: PacmanPackageManager,
+    Distro.VOID: XbpsPackageManager,
+}
+
+
+def get_package_manager() -> SystemPackageManager:
+    if is_macos():
+        return BrewPackageManager()
+    # Debian, Ubuntu, and unknown distros all fall back to apt.
+    manager = _LINUX_PACKAGE_MANAGERS.get(detect_distro(), AptPackageManager)
+    return manager()

--- a/pilot/platform.py
+++ b/pilot/platform.py
@@ -39,7 +39,6 @@ class Distro(Enum):
     UBUNTU = "ubuntu"
     FEDORA = "fedora"
     ARCH = "arch"
-    VOID = "void"
     ALPINE = "alpine"
     UNKNOWN = "unknown"
 

--- a/pilot/platform.py
+++ b/pilot/platform.py
@@ -2,7 +2,6 @@ import os
 import platform
 import shutil
 import subprocess
-from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
 
@@ -35,20 +34,51 @@ def is_linux() -> bool:
     return detect() == Platform.LINUX
 
 
+class Distro(Enum):
+    DEBIAN = "debian"
+    UBUNTU = "ubuntu"
+    FEDORA = "fedora"
+    ARCH = "arch"
+    VOID = "void"
+    ALPINE = "alpine"
+    UNKNOWN = "unknown"
+
+
+_OS_RELEASE = Path("/etc/os-release")
+
+
+def _read_os_release() -> dict[str, str]:
+    if not _OS_RELEASE.exists():
+        return {}
+    fields = {}
+    for line in _OS_RELEASE.read_text().splitlines():
+        key, _, value = line.partition("=")
+        fields[key.strip()] = value.strip().strip('"')
+    return fields
+
+
+def detect_distro() -> Distro:
+    """Identify the Linux distribution from /etc/os-release.
+
+    Falls back to ID_LIKE so derivatives map onto their parent (e.g. Linux
+    Mint -> UBUNTU, EndeavourOS -> ARCH)."""
+    if not is_linux():
+        return Distro.UNKNOWN
+    fields = _read_os_release()
+    known = {distro.value for distro in Distro}
+    if fields.get("ID") in known:
+        return Distro(fields["ID"])
+    for token in fields.get("ID_LIKE", "").split():
+        if token in known:
+            return Distro(token)
+    return Distro.UNKNOWN
+
+
 def is_alpine() -> bool:
     """Return True on Alpine Linux (apk package manager, OpenRC, musl libc)."""
     if not is_linux():
         return False
-    if Path("/etc/alpine-release").exists():
-        return True
-    os_release = Path("/etc/os-release")
-    if not os_release.exists():
-        return False
-    for line in os_release.read_text().splitlines():
-        key, _, value = line.partition("=")
-        if key.strip() == "ID" and value.strip().strip('"') == "alpine":
-            return True
-    return False
+    return Path("/etc/alpine-release").exists() or detect_distro() == Distro.ALPINE
 
 
 def os_version() -> str:
@@ -60,12 +90,9 @@ def os_version() -> str:
     if is_macos():
         version = platform.mac_ver()[0]
         return f"macOS {version}" if version else "macOS"
-    os_release = Path("/etc/os-release")
-    if os_release.exists():
-        for line in os_release.read_text().splitlines():
-            key, _, value = line.partition("=")
-            if key.strip() == "PRETTY_NAME" and value.strip().strip('"'):
-                return value.strip().strip('"')
+    pretty_name = _read_os_release().get("PRETTY_NAME")
+    if pretty_name:
+        return pretty_name
     return f"{platform.system()} {platform.release()}".strip()
 
 
@@ -161,98 +188,3 @@ def default_nginx_config_dir() -> Path:
     return Path("/etc/nginx/conf.d")
 
 
-class SystemPackageManager(ABC):
-    # Maps the canonical (Debian/apt) package name used at call sites to the name
-    # this package manager understands. Names absent from the map pass through.
-    package_aliases: dict[str, str] = {}
-
-    def _resolve(self, *packages: str) -> list[str]:
-        return [self.package_aliases.get(package, package) for package in packages]
-
-    @abstractmethod
-    def install(self, *packages: str) -> None:
-        """Install one or more system packages."""
-
-    @abstractmethod
-    def is_installed(self, package: str) -> bool:
-        """Return True if the package is already installed."""
-
-    @abstractmethod
-    def update(self) -> None:
-        """Update package manager"""
-
-
-class AptPackageManager(SystemPackageManager):
-    def install(self, *packages: str) -> None:
-        subprocess.run(
-            ["sudo", "apt-get", "install", "-y", *packages],
-            env={"DEBIAN_FRONTEND": "noninteractive"},
-            check=True,
-        )
-
-    def is_installed(self, package: str) -> bool:
-        result = subprocess.run(
-            ["dpkg", "-l", package],
-            capture_output=True,
-        )
-        return result.returncode == 0
-
-    def update(self):
-        subprocess.run(["sudo", "apt-get", "-y", "update"])
-
-
-class ApkPackageManager(SystemPackageManager):
-    # Alpine package names differ from Debian's; map the canonical names used at
-    # call sites onto their apk equivalents.
-    package_aliases = {
-        "build-essential": "build-base",
-        "pkg-config": "pkgconf",
-        "libmariadb-dev": "mariadb-dev",
-        "mariadb-server": "mariadb",
-        "mariadb-client": "mariadb-client",
-        "redis-server": "redis",
-        "supervisor": "supervisor",
-    }
-
-    def install(self, *packages: str) -> None:
-        subprocess.run(
-            _privileged(["apk", "add", "--no-cache", *self._resolve(*packages)]),
-            check=True,
-        )
-
-    def is_installed(self, package: str) -> bool:
-        resolved = self._resolve(package)[0]
-        result = subprocess.run(
-            ["apk", "info", "-e", resolved],
-            capture_output=True,
-        )
-        return result.returncode == 0
-
-    def update(self):
-        subprocess.run(_privileged(["apk", "update"]))
-
-
-class BrewPackageManager(SystemPackageManager):
-    def install(self, *packages: str) -> None:
-        subprocess.run(
-            ["brew", "install", *packages],
-            check=True,
-        )
-
-    def is_installed(self, package: str) -> bool:
-        result = subprocess.run(
-            ["brew", "list", "--versions", package],
-            capture_output=True,
-        )
-        return bool(result.stdout.strip())
-
-    def update(self):
-        return super().update()
-
-
-def get_package_manager() -> SystemPackageManager:
-    if is_macos():
-        return BrewPackageManager()
-    if is_alpine():
-        return ApkPackageManager()
-    return AptPackageManager()

--- a/scripts/smoke_install.sh
+++ b/scripts/smoke_install.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Runs install.sh end-to-end inside a distro container: the root path (bench
+# user creation) followed by the user path (clone, uv, node, admin venv).
+#
+# Usage: scripts/smoke_install.sh <image>
+#   e.g. scripts/smoke_install.sh debian:bookworm
+#
+# The working tree (including uncommitted changes) is committed into a
+# throwaway git repo and mounted read-only, so install.sh clones exactly what
+# you are testing.
+set -euo pipefail
+
+IMAGE="${1:?usage: $0 <image>}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+mkdir "$WORK_DIR/src"
+tar -C "$REPO_ROOT" --exclude .git --exclude node_modules --exclude .admin-venv \
+    --exclude test-bench -cf - . | tar -C "$WORK_DIR/src" -xf -
+git -C "$WORK_DIR/src" init --quiet --initial-branch main
+git -C "$WORK_DIR/src" add --all
+git -C "$WORK_DIR/src" -c user.email=smoke@test -c user.name=smoke \
+    commit --quiet --message "smoke test snapshot"
+
+echo "=== smoke test: $IMAGE ==="
+# -i attaches stdin so the container shell actually reads the heredoc.
+docker run --rm -i -v "$WORK_DIR/src:/pilot-src:ro" "$IMAGE" sh -s <<'CONTAINER' | tee "$WORK_DIR/log"
+set -e
+export PILOT_REPO_URL="file:///pilot-src"
+export PILOT_BRANCH="main"
+export BENCH_YES=1
+
+# Parallel downloads can saturate the link and starve DNS on slow hosts;
+# serialize them for a deterministic test run.
+[ -f /etc/pacman.conf ] && \
+    sed -i 's/^ParallelDownloads.*/ParallelDownloads = 1/' /etc/pacman.conf
+
+echo "--- path A: root run creates the bench user ---"
+sh /pilot-src/install.sh
+
+id frappe
+test -f /etc/sudoers.d/frappe
+visudo -cf /etc/sudoers.d/frappe
+
+# The mounted repo is owned by the host uid; let git clone it regardless.
+git config --system safe.directory '*' 2>/dev/null || \
+    git config --global safe.directory '*'
+
+echo "--- path B: bench user run installs everything ---"
+su - frappe -c "PILOT_REPO_URL=$PILOT_REPO_URL PILOT_BRANCH=$PILOT_BRANCH BENCH_YES=1 sh /pilot-src/install.sh"
+
+echo "--- assertions ---"
+su - frappe -c 'test -x "$HOME/pilot/bench"'
+su - frappe -c 'test -f "$HOME/pilot/.admin-venv/bin/python"'
+su - frappe -c 'command -v node'
+su - frappe -c 'command -v git'
+su - frappe -c 'grep -q pilot "$HOME/.bashrc" "$HOME/.profile" 2>/dev/null'
+echo "--- OK ---"
+CONTAINER
+
+# Exit code alone can lie (e.g. a shell that never read the script); demand
+# proof that the assertions actually ran.
+grep -q -- "--- OK ---" "$WORK_DIR/log"
+echo "=== $IMAGE passed ==="

--- a/tests/test_package_managers.py
+++ b/tests/test_package_managers.py
@@ -1,0 +1,224 @@
+"""Tests for distro detection and system package managers."""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pilot import package_managers, platform
+from pilot.package_managers import (
+    ApkPackageManager,
+    AptPackageManager,
+    BrewPackageManager,
+    DnfPackageManager,
+    PacmanPackageManager,
+    XbpsPackageManager,
+    get_package_manager,
+)
+from pilot.platform import Distro
+
+
+def _write_os_release(tmp_path: Path, monkeypatch, content: str) -> None:
+    os_release = tmp_path / "os-release"
+    os_release.write_text(content)
+    monkeypatch.setattr(platform, "_OS_RELEASE", os_release)
+
+
+def _force_linux(monkeypatch) -> None:
+    monkeypatch.setattr(platform, "detect", lambda: platform.Platform.LINUX)
+
+
+# ── detect_distro ─────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("distro_id", ["debian", "ubuntu", "fedora", "arch", "void", "alpine"])
+def test_detect_distro_by_id(tmp_path: Path, monkeypatch, distro_id: str) -> None:
+    _force_linux(monkeypatch)
+    _write_os_release(tmp_path, monkeypatch, f'ID={distro_id}\n')
+    assert platform.detect_distro() == Distro(distro_id)
+
+
+def test_detect_distro_strips_quotes(tmp_path: Path, monkeypatch) -> None:
+    _force_linux(monkeypatch)
+    _write_os_release(tmp_path, monkeypatch, 'ID="fedora"\nPRETTY_NAME="Fedora Linux 42"\n')
+    assert platform.detect_distro() == Distro.FEDORA
+
+
+def test_detect_distro_id_like_fallback(tmp_path: Path, monkeypatch) -> None:
+    _force_linux(monkeypatch)
+    _write_os_release(tmp_path, monkeypatch, 'ID=linuxmint\nID_LIKE="ubuntu debian"\n')
+    assert platform.detect_distro() == Distro.UBUNTU
+
+
+def test_detect_distro_id_like_arch_derivative(tmp_path: Path, monkeypatch) -> None:
+    _force_linux(monkeypatch)
+    _write_os_release(tmp_path, monkeypatch, 'ID=endeavouros\nID_LIKE=arch\n')
+    assert platform.detect_distro() == Distro.ARCH
+
+
+def test_detect_distro_unknown(tmp_path: Path, monkeypatch) -> None:
+    _force_linux(monkeypatch)
+    _write_os_release(tmp_path, monkeypatch, 'ID=slackware\n')
+    assert platform.detect_distro() == Distro.UNKNOWN
+
+
+def test_detect_distro_missing_file(tmp_path: Path, monkeypatch) -> None:
+    _force_linux(monkeypatch)
+    monkeypatch.setattr(platform, "_OS_RELEASE", tmp_path / "missing")
+    assert platform.detect_distro() == Distro.UNKNOWN
+
+
+def test_detect_distro_not_linux(monkeypatch) -> None:
+    monkeypatch.setattr(platform, "detect", lambda: platform.Platform.MACOS)
+    assert platform.detect_distro() == Distro.UNKNOWN
+
+
+def test_is_alpine_from_os_release(tmp_path: Path, monkeypatch) -> None:
+    _force_linux(monkeypatch)
+    _write_os_release(tmp_path, monkeypatch, 'ID=alpine\n')
+    assert platform.detect_distro() == Distro.ALPINE
+    assert platform.is_alpine() is True
+
+
+# ── get_package_manager dispatch ──────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    ("distro", "manager_class"),
+    [
+        (Distro.DEBIAN, AptPackageManager),
+        (Distro.UBUNTU, AptPackageManager),
+        (Distro.UNKNOWN, AptPackageManager),
+        (Distro.FEDORA, DnfPackageManager),
+        (Distro.ARCH, PacmanPackageManager),
+        (Distro.VOID, XbpsPackageManager),
+        (Distro.ALPINE, ApkPackageManager),
+    ],
+)
+def test_get_package_manager_dispatch(monkeypatch, distro, manager_class) -> None:
+    monkeypatch.setattr(package_managers, "is_macos", lambda: False)
+    monkeypatch.setattr(package_managers, "detect_distro", lambda: distro)
+    assert isinstance(get_package_manager(), manager_class)
+
+
+def test_get_package_manager_macos(monkeypatch) -> None:
+    monkeypatch.setattr(package_managers, "is_macos", lambda: True)
+    assert isinstance(get_package_manager(), BrewPackageManager)
+
+
+# ── alias resolution ──────────────────────────────────────────────────────────
+
+def test_resolve_passes_unmapped_names_through() -> None:
+    assert DnfPackageManager()._resolve("nginx", "certbot") == ["nginx", "certbot"]
+
+
+def test_resolve_expands_tuple_aliases() -> None:
+    resolved = DnfPackageManager()._resolve("build-essential")
+    assert resolved == ["gcc", "gcc-c++", "make"]
+
+
+def test_resolve_deduplicates() -> None:
+    # Void maps both nodejs and npm onto the single nodejs package.
+    assert XbpsPackageManager()._resolve("nodejs", "npm") == ["nodejs"]
+
+
+def test_resolve_mariadb_single_package_on_void() -> None:
+    assert XbpsPackageManager()._resolve("mariadb-server", "mariadb-client") == ["mariadb"]
+
+
+# ── install/is_installed/update argv ──────────────────────────────────────────
+
+def _run_as_root(monkeypatch) -> None:
+    monkeypatch.setattr(platform, "is_root", lambda: True)
+
+
+@pytest.mark.parametrize(
+    ("manager", "expected"),
+    [
+        (DnfPackageManager(), ["dnf", "install", "-y", "nginx"]),
+        (PacmanPackageManager(), ["pacman", "-S", "--noconfirm", "--needed", "nginx"]),
+        (XbpsPackageManager(), ["xbps-install", "-Sy", "nginx"]),
+        (ApkPackageManager(), ["apk", "add", "--no-cache", "nginx"]),
+        (AptPackageManager(), ["apt-get", "install", "-y", "nginx"]),
+    ],
+)
+def test_install_argv(monkeypatch, manager, expected) -> None:
+    _run_as_root(monkeypatch)
+    with patch.object(package_managers.subprocess, "run") as run:
+        manager.install("nginx")
+    assert run.call_args[0][0] == expected
+
+
+@pytest.mark.parametrize(
+    ("manager", "expected"),
+    [
+        (DnfPackageManager(), ["rpm", "-q", "valkey"]),
+        (PacmanPackageManager(), ["pacman", "-Qi", "valkey"]),
+        (XbpsPackageManager(), ["xbps-query", "redis"]),
+        (ApkPackageManager(), ["apk", "info", "-e", "redis"]),
+        (AptPackageManager(), ["dpkg", "-l", "redis-server"]),
+    ],
+)
+def test_is_installed_argv(monkeypatch, manager, expected) -> None:
+    with patch.object(package_managers.subprocess, "run") as run:
+        run.return_value.returncode = 0
+        assert manager.is_installed("redis-server") is True
+    assert run.call_args[0][0] == expected
+
+
+@pytest.mark.parametrize(
+    ("manager", "expected"),
+    [
+        (DnfPackageManager(), ["dnf", "-y", "makecache"]),
+        (PacmanPackageManager(), ["pacman", "-Sy", "--noconfirm"]),
+        (XbpsPackageManager(), ["xbps-install", "-S"]),
+        (ApkPackageManager(), ["apk", "update"]),
+        (AptPackageManager(), ["apt-get", "-y", "update"]),
+    ],
+)
+def test_update_argv(monkeypatch, manager, expected) -> None:
+    _run_as_root(monkeypatch)
+    with patch.object(package_managers.subprocess, "run") as run:
+        manager.update()
+    assert run.call_args[0][0] == expected
+
+
+def test_install_uses_sudo_when_not_root(monkeypatch) -> None:
+    monkeypatch.setattr(platform, "is_root", lambda: False)
+    with patch.object(package_managers.subprocess, "run") as run:
+        DnfPackageManager().install("git")
+    assert run.call_args[0][0] == ["sudo", "dnf", "install", "-y", "git"]
+
+
+# ── node install branching ────────────────────────────────────────────────────
+
+def _node_install_commands(monkeypatch, distro: Distro) -> list[list[str]]:
+    from pilot.managers import python_env_manager as module
+
+    manager = module.PythonEnvManager(bench=None)
+    commands: list[list[str]] = []
+    monkeypatch.setattr(module, "is_macos", lambda: False)
+    monkeypatch.setattr(module, "detect_distro", lambda: distro)
+    monkeypatch.setattr(module, "run_command", lambda argv, **kwargs: commands.append(argv))
+    with patch.object(module, "get_package_manager") as gpm:
+        manager._install_node()
+        if gpm.return_value.install.called:
+            commands.append(list(gpm.return_value.install.call_args[0]))
+    return commands
+
+
+def test_install_node_debian_uses_nodesource_deb(monkeypatch) -> None:
+    commands = _node_install_commands(monkeypatch, Distro.DEBIAN)
+    assert "deb.nodesource.com" in commands[0][2]
+    assert commands[1] == ["sudo", "apt-get", "install", "-y", "nodejs"]
+
+
+def test_install_node_fedora_uses_nodesource_rpm(monkeypatch) -> None:
+    commands = _node_install_commands(monkeypatch, Distro.FEDORA)
+    assert "rpm.nodesource.com" in commands[0][2]
+    assert commands[1] == ["sudo", "dnf", "install", "-y", "nodejs"]
+
+
+@pytest.mark.parametrize("distro", [Distro.ARCH, Distro.VOID, Distro.ALPINE])
+def test_install_node_native_repos(monkeypatch, distro) -> None:
+    commands = _node_install_commands(monkeypatch, distro)
+    assert commands == [["nodejs", "npm"]]

--- a/tests/test_package_managers.py
+++ b/tests/test_package_managers.py
@@ -13,7 +13,6 @@ from pilot.package_managers import (
     BrewPackageManager,
     DnfPackageManager,
     PacmanPackageManager,
-    XbpsPackageManager,
     get_package_manager,
 )
 from pilot.platform import Distro
@@ -31,7 +30,7 @@ def _force_linux(monkeypatch) -> None:
 
 # ── detect_distro ─────────────────────────────────────────────────────────────
 
-@pytest.mark.parametrize("distro_id", ["debian", "ubuntu", "fedora", "arch", "void", "alpine"])
+@pytest.mark.parametrize("distro_id", ["debian", "ubuntu", "fedora", "arch", "alpine"])
 def test_detect_distro_by_id(tmp_path: Path, monkeypatch, distro_id: str) -> None:
     _force_linux(monkeypatch)
     _write_os_release(tmp_path, monkeypatch, f'ID={distro_id}\n')
@@ -90,7 +89,6 @@ def test_is_alpine_from_os_release(tmp_path: Path, monkeypatch) -> None:
         (Distro.UNKNOWN, AptPackageManager),
         (Distro.FEDORA, DnfPackageManager),
         (Distro.ARCH, PacmanPackageManager),
-        (Distro.VOID, XbpsPackageManager),
         (Distro.ALPINE, ApkPackageManager),
     ],
 )
@@ -117,12 +115,8 @@ def test_resolve_expands_tuple_aliases() -> None:
 
 
 def test_resolve_deduplicates() -> None:
-    # Void maps both nodejs and npm onto the single nodejs package.
-    assert XbpsPackageManager()._resolve("nodejs", "npm") == ["nodejs"]
-
-
-def test_resolve_mariadb_single_package_on_void() -> None:
-    assert XbpsPackageManager()._resolve("mariadb-server", "mariadb-client") == ["mariadb"]
+    # Alpine aliases mariadb-server onto the same package as a bare mariadb.
+    assert ApkPackageManager()._resolve("mariadb-server", "mariadb") == ["mariadb"]
 
 
 # ── install/is_installed/update argv ──────────────────────────────────────────
@@ -136,7 +130,6 @@ def _run_as_root(monkeypatch) -> None:
     [
         (DnfPackageManager(), ["dnf", "install", "-y", "nginx"]),
         (PacmanPackageManager(), ["pacman", "-S", "--noconfirm", "--needed", "nginx"]),
-        (XbpsPackageManager(), ["xbps-install", "-Sy", "nginx"]),
         (ApkPackageManager(), ["apk", "add", "--no-cache", "nginx"]),
         (AptPackageManager(), ["apt-get", "install", "-y", "nginx"]),
     ],
@@ -153,7 +146,6 @@ def test_install_argv(monkeypatch, manager, expected) -> None:
     [
         (DnfPackageManager(), ["rpm", "-q", "valkey"]),
         (PacmanPackageManager(), ["pacman", "-Qi", "valkey"]),
-        (XbpsPackageManager(), ["xbps-query", "redis"]),
         (ApkPackageManager(), ["apk", "info", "-e", "redis"]),
         (AptPackageManager(), ["dpkg", "-l", "redis-server"]),
     ],
@@ -170,7 +162,6 @@ def test_is_installed_argv(monkeypatch, manager, expected) -> None:
     [
         (DnfPackageManager(), ["dnf", "-y", "makecache"]),
         (PacmanPackageManager(), ["pacman", "-Sy", "--noconfirm"]),
-        (XbpsPackageManager(), ["xbps-install", "-S"]),
         (ApkPackageManager(), ["apk", "update"]),
         (AptPackageManager(), ["apt-get", "-y", "update"]),
     ],
@@ -218,7 +209,7 @@ def test_install_node_fedora_uses_nodesource_rpm(monkeypatch) -> None:
     assert commands[1] == ["sudo", "dnf", "install", "-y", "nodejs"]
 
 
-@pytest.mark.parametrize("distro", [Distro.ARCH, Distro.VOID, Distro.ALPINE])
+@pytest.mark.parametrize("distro", [Distro.ARCH, Distro.ALPINE])
 def test_install_node_native_repos(monkeypatch, distro) -> None:
     commands = _node_install_commands(monkeypatch, distro)
     assert commands == [["nodejs", "npm"]]


### PR DESCRIPTION
install.sh previously knew only apt and apk, and the runtime fell back to apt-get on every non-Alpine Linux. Both now detect the distro from /etc/os-release (ID, with ID_LIKE fallback so derivatives like Mint and EndeavourOS map to their parent).

Installer:
- per-distro package primitives (apt/dnf/pacman/xbps/apk) and a generalized bootstrap that installs git/curl/bash/sudo/python on bare images of any supported distro, not just Alpine
- admin group is wheel on Fedora/Arch/Void/Alpine (usermod -aG sudo silently did nothing there)
- Node via NodeSource on deb/rpm distros, native repos on Arch/Void/Alpine
- distro quirks: dnf --allowerasing (curl-minimal conflict in containers), pacman --disable-download-timeout, Void needs util-linux/tar/gzip
- REPO_URL/BRANCH_NAME overridable via PILOT_REPO_URL/PILOT_BRANCH for tests

Runtime:
- new pilot/package_managers.py with Dnf/Pacman/Xbps managers whose alias maps translate the canonical Debian names used at call sites (e.g. build-essential -> gcc gcc-c++ make, redis-server -> valkey)
- MariaDB's apt-repo setup now runs only on apt distros; other repos ship a recent MariaDB
- redis detection falls back to valkey-server (Fedora/Arch ship valkey)

Tests: 46 unit tests for detection/aliases/dispatch, a Docker smoke script running install.sh end-to-end per distro (verified locally on all six), and a CI workflow (shellcheck + six-image matrix) on PRs touching the installer.