### PR TITLE
fix: macOS is_provisioned() always False, silently resetting a secured DB password

### DIFF
--- a/pilot/commands/new.py
+++ b/pilot/commands/new.py
@@ -86,41 +86,21 @@ class NewCommand(Command):
             "db_type": self.db_type,
         }
         if self.db_type == "mariadb":
-            # Every bench for this OS user shares one MariaDB server (see
-            # MariaDBManager), so a new bench must inherit whichever port a
-            # sibling already established for it. If none exists yet, pick a
-            # free port up front — 3306 is often already taken by a
-            # system-wide MariaDB, and MariaDBManager refuses to bind an
-            # occupied port.
             settings["mariadb_port"] = self._sibling_mariadb_port() or self._pick_mariadb_port()
-            # Every bench for this OS user shares one MariaDB server, so a new
-            # bench must inherit the password that already secured it — a fresh
-            # random one here would lock it out of a server a sibling provisioned.
-            # No sibling means this is the first bench: generate a random
-            # password rather than falling back to a guessable default.
             settings["mariadb_password"] = self._sibling_mariadb_password() or secrets.token_hex(
                 nbytes=8
             )
         if self.db_type == "postgres":
-            # Every bench for this OS user shares one PostgreSQL server, so a new
-            # bench must inherit the password that already secured it — a fresh
-            # random one here would lock it out of a server a sibling provisioned.
             settings["postgres_password"] = self._sibling_postgres_password() or secrets.token_hex(
                 nbytes=8
             )
         if self.process_manager:
             settings["production_process_manager"] = self.process_manager
-        # The Let's Encrypt account email is a server-wide setting; inherit it
-        # from a sibling bench so a new production bench can issue certs without
-        # re-entering it.
+
         sibling_email = self._sibling_letsencrypt_email()
         if sibling_email:
             settings["letsencrypt_email"] = sibling_email
-        # Every bench for this OS user shares the same MariaDB/PostgreSQL server
-        # (see MariaDBManager/PostgresManager) — no per-bench instance to set up.
-        # The remote JWKS issuer is server-wide too: carry its URL and audience
-        # forward so the control plane can authenticate to a freshly created
-        # bench right away.
+
         sibling_admin = self._sibling_jwks_admin()
         if sibling_admin:
             settings["admin_jwks_url"] = sibling_admin.jwks_url

--- a/pilot/managers/mariadb_manager.py
+++ b/pilot/managers/mariadb_manager.py
@@ -39,11 +39,29 @@ class MariaDBManager(UserOwnedDBManager):
         # which() searches sbin too; mysqld/mariadbd live in /usr/sbin.
         return bool(which("mysqld") or which("mariadbd"))
 
+    def _macos_provisioned_marker(self) -> Path:
+        # macOS has no systemd --user unit file (is_provisioned()'s normal
+        # signal) to prove this server has already been through provision()
+        # once — Homebrew owns install/start, not us. Without our own marker,
+        # is_provisioned() would always read False here, making
+        # _is_fresh_install() think every bench is the first one and skip
+        # password validation, letting a second bench silently reset an
+        # already-secured server's password.
+        return _STATE_DIR / ".provisioned"
+
+    def is_provisioned(self) -> bool:
+        if is_macos():
+            return self._macos_provisioned_marker().exists()
+        return super().is_provisioned()
+
     def _provision_macos(self):
         if not self.is_running():
             self.start()
         self._wait_until_reachable()
         self.secure_installation()
+        marker = self._macos_provisioned_marker()
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
 
     def provision(self) -> None:
         """Ensure the shared MariaDB server is installed, running and secured.
@@ -114,16 +132,10 @@ class MariaDBManager(UserOwnedDBManager):
         unix-socket auth (i.e. a fresh, not-yet-secured install). The bench
         user owns this server outright, so no privilege escalation is needed
         to connect as its admin account."""
-        cmd = [
-            "mariadb",
-            f"--socket={self.socket_path()}",
-            "-u",
-            self.config.admin_user,
-            "--batch",
-            "--skip-column-names",
-            "-e",
-            "SELECT 1",
-        ]
+        cmd = ["mariadb"]
+        if not is_macos():
+            cmd.append(f"--socket={self.socket_path()}")
+        cmd += ["-u", self.config.admin_user, "--batch", "--skip-column-names", "-e", "SELECT 1"]
         result = subprocess.run(cmd, capture_output=True, text=True)
         return result.returncode == 0
 

--- a/pilot/managers/mariadb_manager.py
+++ b/pilot/managers/mariadb_manager.py
@@ -39,19 +39,14 @@ class MariaDBManager(UserOwnedDBManager):
         # which() searches sbin too; mysqld/mariadbd live in /usr/sbin.
         return bool(which("mysqld") or which("mariadbd"))
 
-    def _macos_provisioned_marker(self) -> Path:
-        # macOS has no systemd --user unit file (is_provisioned()'s normal
-        # signal) to prove this server has already been through provision()
-        # once — Homebrew owns install/start, not us. Without our own marker,
-        # is_provisioned() would always read False here, making
-        # _is_fresh_install() think every bench is the first one and skip
-        # password validation, letting a second bench silently reset an
-        # already-secured server's password.
-        return _STATE_DIR / ".provisioned"
-
     def is_provisioned(self) -> bool:
         if is_macos():
-            return self._macos_provisioned_marker().exists()
+            # No systemd --user unit exists here (Homebrew owns install/start,
+            # not us), so there's nothing of ours to check — a marker file we
+            # invented could drift from reality (e.g. get deleted) without the
+            # server itself changing. Ask the server directly instead: it's
+            # only "fresh" if it's both up and still passwordless.
+            return self.is_running() and not self.is_unsecured()
         return super().is_provisioned()
 
     def _provision_macos(self):
@@ -59,9 +54,6 @@ class MariaDBManager(UserOwnedDBManager):
             self.start()
         self._wait_until_reachable()
         self.secure_installation()
-        marker = self._macos_provisioned_marker()
-        marker.parent.mkdir(parents=True, exist_ok=True)
-        marker.touch()
 
     def provision(self) -> None:
         """Ensure the shared MariaDB server is installed, running and secured.

--- a/pilot/managers/mariadb_manager.py
+++ b/pilot/managers/mariadb_manager.py
@@ -41,11 +41,6 @@ class MariaDBManager(UserOwnedDBManager):
 
     def is_provisioned(self) -> bool:
         if is_macos():
-            # No systemd --user unit exists here (Homebrew owns install/start,
-            # not us), so there's nothing of ours to check — a marker file we
-            # invented could drift from reality (e.g. get deleted) without the
-            # server itself changing. Ask the server directly instead: it's
-            # only "fresh" if it's both up and still passwordless.
             return self.is_running() and not self.is_unsecured()
         return super().is_provisioned()
 

--- a/pilot/managers/postgres_manager.py
+++ b/pilot/managers/postgres_manager.py
@@ -43,6 +43,21 @@ class PostgresManager(UserOwnedDBManager):
     def is_installed(self) -> bool:
         return bool(which("psql") or which("postgres") or which("initdb"))
 
+    def _macos_provisioned_marker(self) -> Path:
+        # macOS has no systemd --user unit file (is_provisioned()'s normal
+        # signal) to prove this server has already been through provision()
+        # once — Homebrew owns install/start, not us. Without our own marker,
+        # is_provisioned() would always read False here, making
+        # _is_fresh_install() think every bench is the first one and skip
+        # password validation, letting a second bench silently reset an
+        # already-secured server's password.
+        return _STATE_DIR / ".provisioned"
+
+    def is_provisioned(self) -> bool:
+        if is_macos():
+            return self._macos_provisioned_marker().exists()
+        return super().is_provisioned()
+
     # ── provisioning ─────────────────────────────────────────────────────────
 
     def provision(self) -> None:
@@ -57,6 +72,10 @@ class PostgresManager(UserOwnedDBManager):
             self._provision_user_owned()
         self._wait_until_reachable()
         self.secure()
+        if is_macos():
+            marker = self._macos_provisioned_marker()
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.touch()
 
     def _provision_user_owned(self) -> None:
         if not self.is_provisioned():

--- a/pilot/managers/postgres_manager.py
+++ b/pilot/managers/postgres_manager.py
@@ -43,20 +43,34 @@ class PostgresManager(UserOwnedDBManager):
     def is_installed(self) -> bool:
         return bool(which("psql") or which("postgres") or which("initdb"))
 
-    def _macos_provisioned_marker(self) -> Path:
-        # macOS has no systemd --user unit file (is_provisioned()'s normal
-        # signal) to prove this server has already been through provision()
-        # once — Homebrew owns install/start, not us. Without our own marker,
-        # is_provisioned() would always read False here, making
-        # _is_fresh_install() think every bench is the first one and skip
-        # password validation, letting a second bench silently reset an
-        # already-secured server's password.
-        return _STATE_DIR / ".provisioned"
-
     def is_provisioned(self) -> bool:
         if is_macos():
-            return self._macos_provisioned_marker().exists()
+            # No systemd --user unit exists here (Homebrew owns install/start,
+            # not us), so there's nothing of ours to check — a marker file we
+            # invented could drift from reality (e.g. get deleted) without the
+            # server itself changing. Ask the server directly instead: it's
+            # only "fresh" if it's both up and still passwordless.
+            return self.is_running() and not self.is_unsecured()
         return super().is_provisioned()
+
+    def is_unsecured(self) -> bool:
+        """True if the admin role has no password yet and is reachable via
+        local peer auth (i.e. a fresh, not-yet-secured install)."""
+        cmd = [
+            self._psql() or "psql",
+            "-p",
+            str(self.config.port),
+            "-U",
+            self.config.admin_user,
+            "-d",
+            "postgres",
+            "-tAc",
+            "SELECT 1",
+        ]
+        if not is_macos():
+            cmd[1:1] = ["-h", str(self.socket_dir())]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        return result.returncode == 0
 
     # ── provisioning ─────────────────────────────────────────────────────────
 
@@ -72,10 +86,6 @@ class PostgresManager(UserOwnedDBManager):
             self._provision_user_owned()
         self._wait_until_reachable()
         self.secure()
-        if is_macos():
-            marker = self._macos_provisioned_marker()
-            marker.parent.mkdir(parents=True, exist_ok=True)
-            marker.touch()
 
     def _provision_user_owned(self) -> None:
         if not self.is_provisioned():

--- a/pilot/managers/postgres_manager.py
+++ b/pilot/managers/postgres_manager.py
@@ -49,23 +49,30 @@ class PostgresManager(UserOwnedDBManager):
         return super().is_provisioned()
 
     def is_unsecured(self) -> bool:
-        """True if the admin role has no password yet and is reachable via
-        local peer auth (i.e. a fresh, not-yet-secured install)."""
+        """True if the admin role has no password set yet (i.e. a fresh,
+        not-yet-secured install). Queries the catalog directly via a local
+        bootstrap connection (peer auth on Linux, trust on macOS by default)
+        rather than testing whether a passwordless connection succeeds —
+        local trust/peer auth grants access regardless of whether the role
+        has a password, so a successful connection alone proves nothing."""
+        role = self._sql_quote(self.config.admin_user)
         cmd = [
             self._psql() or "psql",
             "-p",
             str(self.config.port),
-            "-U",
-            self.config.admin_user,
             "-d",
             "postgres",
             "-tAc",
-            "SELECT 1",
+            f"SELECT rolpassword IS NULL FROM pg_authid WHERE rolname = {role}",
         ]
         if not is_macos():
             cmd[1:1] = ["-h", str(self.socket_dir())]
         result = subprocess.run(cmd, capture_output=True, text=True)
-        return result.returncode == 0
+        if result.returncode != 0:
+            return False
+        output = result.stdout.strip()
+        # Empty output means the role doesn't exist yet at all — also fresh.
+        return output in ("", "t")
 
     # ── provisioning ─────────────────────────────────────────────────────────
 

--- a/pilot/managers/postgres_manager.py
+++ b/pilot/managers/postgres_manager.py
@@ -45,11 +45,6 @@ class PostgresManager(UserOwnedDBManager):
 
     def is_provisioned(self) -> bool:
         if is_macos():
-            # No systemd --user unit exists here (Homebrew owns install/start,
-            # not us), so there's nothing of ours to check — a marker file we
-            # invented could drift from reality (e.g. get deleted) without the
-            # server itself changing. Ask the server directly instead: it's
-            # only "fresh" if it's both up and still passwordless.
             return self.is_running() and not self.is_unsecured()
         return super().is_provisioned()
 

--- a/tests/test_mariadb_manager.py
+++ b/tests/test_mariadb_manager.py
@@ -68,6 +68,30 @@ def test_provision_initialises_and_installs_unit_when_fresh(tmp_path) -> None:
     assert any("mariadb-install-db" in argv for argv in argv_calls)
 
 
+def test_is_provisioned_on_macos_uses_marker_not_unit_file(tmp_path) -> None:
+    """No systemd --user unit ever exists on macOS — is_provisioned() must not
+    always read False there, or a second bench's wizard validation would
+    think the server is fresh and silently reset an already-secured password."""
+    m = _manager()
+    with patch(f"{MODULE}.is_macos", return_value=True), \
+         patch.object(m, "_macos_provisioned_marker", return_value=tmp_path / ".provisioned"):
+        assert m.is_provisioned() is False
+        (tmp_path / ".provisioned").touch()
+        assert m.is_provisioned() is True
+
+
+def test_provision_macos_writes_marker_after_securing(tmp_path) -> None:
+    m = _manager()
+    marker = tmp_path / "state" / ".provisioned"
+    with patch(f"{MODULE}.is_macos", return_value=True), \
+         patch.object(m, "install"), patch.object(m, "is_running", return_value=True), \
+         patch.object(m, "_wait_until_reachable"), patch.object(m, "secure_installation") as secure, \
+         patch.object(m, "_macos_provisioned_marker", return_value=marker):
+        m.provision()
+    secure.assert_called_once()
+    assert marker.exists()
+
+
 def test_provision_reuses_already_provisioned_server() -> None:
     m = _manager()
     with patch(f"{MODULE}.is_macos", return_value=False), \
@@ -228,6 +252,21 @@ def test_validate_endpoint_valid(tmp_path) -> None:
 def test_validate_endpoint_invalid(tmp_path) -> None:
     with patch(f"{MODULE}.MariaDBManager.is_installed", return_value=True), \
          patch(f"{MODULE}.MariaDBManager.is_provisioned", return_value=True), \
+         patch(f"{MODULE}.MariaDBManager.check_credentials", return_value=False):
+        resp = _post_validate(_client(tmp_path), "wrong")
+    assert resp.get_json() == {"state": "invalid"}
+
+
+def test_validate_endpoint_on_macos_checks_password_for_already_secured_server(tmp_path) -> None:
+    """Regression: on macOS there's no unit file, so is_provisioned() must use
+    its own marker (not always read False) — otherwise a second bench's wizard
+    would think the server is fresh and let a wrong password through, which
+    bench init then uses to silently reset the first bench's real password."""
+    marker = tmp_path / ".provisioned"
+    marker.touch()
+    with patch(f"{MODULE}.is_macos", return_value=True), \
+         patch(f"{MODULE}.MariaDBManager.is_installed", return_value=True), \
+         patch(f"{MODULE}.MariaDBManager._macos_provisioned_marker", return_value=marker), \
          patch(f"{MODULE}.MariaDBManager.check_credentials", return_value=False):
         resp = _post_validate(_client(tmp_path), "wrong")
     assert resp.get_json() == {"state": "invalid"}

--- a/tests/test_mariadb_manager.py
+++ b/tests/test_mariadb_manager.py
@@ -68,28 +68,21 @@ def test_provision_initialises_and_installs_unit_when_fresh(tmp_path) -> None:
     assert any("mariadb-install-db" in argv for argv in argv_calls)
 
 
-def test_is_provisioned_on_macos_uses_marker_not_unit_file(tmp_path) -> None:
-    """No systemd --user unit ever exists on macOS — is_provisioned() must not
-    always read False there, or a second bench's wizard validation would
-    think the server is fresh and silently reset an already-secured password."""
+def test_is_provisioned_on_macos_checks_live_server_not_a_marker_file() -> None:
+    """No systemd --user unit ever exists on macOS — is_provisioned() must
+    reflect the server's actual live state (running + already secured), not
+    a marker file that could drift from reality (e.g. get deleted)."""
     m = _manager()
+    with patch(f"{MODULE}.is_macos", return_value=True), patch.object(m, "is_running", return_value=False):
+        assert m.is_provisioned() is False  # not running yet
     with patch(f"{MODULE}.is_macos", return_value=True), \
-         patch.object(m, "_macos_provisioned_marker", return_value=tmp_path / ".provisioned"):
-        assert m.is_provisioned() is False
-        (tmp_path / ".provisioned").touch()
-        assert m.is_provisioned() is True
-
-
-def test_provision_macos_writes_marker_after_securing(tmp_path) -> None:
-    m = _manager()
-    marker = tmp_path / "state" / ".provisioned"
+         patch.object(m, "is_running", return_value=True), \
+         patch.object(m, "is_unsecured", return_value=True):
+        assert m.is_provisioned() is False  # up but still passwordless
     with patch(f"{MODULE}.is_macos", return_value=True), \
-         patch.object(m, "install"), patch.object(m, "is_running", return_value=True), \
-         patch.object(m, "_wait_until_reachable"), patch.object(m, "secure_installation") as secure, \
-         patch.object(m, "_macos_provisioned_marker", return_value=marker):
-        m.provision()
-    secure.assert_called_once()
-    assert marker.exists()
+         patch.object(m, "is_running", return_value=True), \
+         patch.object(m, "is_unsecured", return_value=False):
+        assert m.is_provisioned() is True  # up and already secured
 
 
 def test_provision_reuses_already_provisioned_server() -> None:
@@ -258,15 +251,15 @@ def test_validate_endpoint_invalid(tmp_path) -> None:
 
 
 def test_validate_endpoint_on_macos_checks_password_for_already_secured_server(tmp_path) -> None:
-    """Regression: on macOS there's no unit file, so is_provisioned() must use
-    its own marker (not always read False) — otherwise a second bench's wizard
-    would think the server is fresh and let a wrong password through, which
-    bench init then uses to silently reset the first bench's real password."""
-    marker = tmp_path / ".provisioned"
-    marker.touch()
+    """Regression: on macOS there's no unit file, so is_provisioned() must
+    reflect the live server (running + already secured), not always read
+    False — otherwise a second bench's wizard would think the server is fresh
+    and let a wrong password through, which bench init then uses to silently
+    reset the first bench's real password."""
     with patch(f"{MODULE}.is_macos", return_value=True), \
          patch(f"{MODULE}.MariaDBManager.is_installed", return_value=True), \
-         patch(f"{MODULE}.MariaDBManager._macos_provisioned_marker", return_value=marker), \
+         patch(f"{MODULE}.MariaDBManager.is_running", return_value=True), \
+         patch(f"{MODULE}.MariaDBManager.is_unsecured", return_value=False), \
          patch(f"{MODULE}.MariaDBManager.check_credentials", return_value=False):
         resp = _post_validate(_client(tmp_path), "wrong")
     assert resp.get_json() == {"state": "invalid"}

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -144,28 +144,31 @@ def test_provision_orchestrates_steps_on_linux() -> None:
     sec.assert_called_once()
 
 
-def test_is_provisioned_on_macos_uses_marker_not_unit_file(tmp_path) -> None:
-    """No systemd --user unit ever exists on macOS — is_provisioned() must not
-    always read False there, or a second bench's wizard validation would
-    think the server is fresh and silently reset an already-secured password."""
+def test_is_provisioned_on_macos_checks_live_server_not_a_marker_file() -> None:
+    """No systemd --user unit ever exists on macOS — is_provisioned() must
+    reflect the server's actual live state (running + already secured), not
+    a marker file that could drift from reality (e.g. get deleted)."""
     m = _mgr()
+    with patch(f"{MODULE}.is_macos", return_value=True), patch.object(m, "is_running", return_value=False):
+        assert m.is_provisioned() is False  # not running yet
     with patch(f"{MODULE}.is_macos", return_value=True), \
-         patch.object(m, "_macos_provisioned_marker", return_value=tmp_path / ".provisioned"):
-        assert m.is_provisioned() is False
-        (tmp_path / ".provisioned").touch()
-        assert m.is_provisioned() is True
+         patch.object(m, "is_running", return_value=True), \
+         patch.object(m, "is_unsecured", return_value=True):
+        assert m.is_provisioned() is False  # up but still passwordless
+    with patch(f"{MODULE}.is_macos", return_value=True), \
+         patch.object(m, "is_running", return_value=True), \
+         patch.object(m, "is_unsecured", return_value=False):
+        assert m.is_provisioned() is True  # up and already secured
 
 
-def test_provision_macos_writes_marker_after_securing(tmp_path) -> None:
-    m = _mgr(root_password="pw")
-    marker = tmp_path / "state" / ".provisioned"
-    with patch(f"{MODULE}.is_macos", return_value=True), \
-         patch.object(m, "install"), patch.object(m, "is_running", return_value=True), \
-         patch.object(m, "_wait_until_reachable"), patch.object(m, "secure") as sec, \
-         patch.object(m, "_macos_provisioned_marker", return_value=marker):
-        m.provision()
-    sec.assert_called_once()
-    assert marker.exists()
+def test_is_unsecured_targets_own_socket_dir_on_linux() -> None:
+    m = _mgr(port=5440)
+    with patch.object(m, "_psql", return_value="/usr/bin/psql"), \
+         patch(f"{MODULE}.is_macos", return_value=False), \
+         patch(f"{MODULE}.subprocess.run") as run:
+        m.is_unsecured()
+    cmd = run.call_args[0][0]
+    assert cmd[cmd.index("-h") + 1] == str(m.socket_dir())
 
 
 def test_provision_user_owned_initialises_and_installs_unit_when_fresh(tmp_path) -> None:

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -144,6 +144,30 @@ def test_provision_orchestrates_steps_on_linux() -> None:
     sec.assert_called_once()
 
 
+def test_is_provisioned_on_macos_uses_marker_not_unit_file(tmp_path) -> None:
+    """No systemd --user unit ever exists on macOS — is_provisioned() must not
+    always read False there, or a second bench's wizard validation would
+    think the server is fresh and silently reset an already-secured password."""
+    m = _mgr()
+    with patch(f"{MODULE}.is_macos", return_value=True), \
+         patch.object(m, "_macos_provisioned_marker", return_value=tmp_path / ".provisioned"):
+        assert m.is_provisioned() is False
+        (tmp_path / ".provisioned").touch()
+        assert m.is_provisioned() is True
+
+
+def test_provision_macos_writes_marker_after_securing(tmp_path) -> None:
+    m = _mgr(root_password="pw")
+    marker = tmp_path / "state" / ".provisioned"
+    with patch(f"{MODULE}.is_macos", return_value=True), \
+         patch.object(m, "install"), patch.object(m, "is_running", return_value=True), \
+         patch.object(m, "_wait_until_reachable"), patch.object(m, "secure") as sec, \
+         patch.object(m, "_macos_provisioned_marker", return_value=marker):
+        m.provision()
+    sec.assert_called_once()
+    assert marker.exists()
+
+
 def test_provision_user_owned_initialises_and_installs_unit_when_fresh(tmp_path) -> None:
     m = _mgr(port=5440)
     with patch.object(m, "data_dir", return_value=tmp_path / "data"), \

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -171,6 +171,35 @@ def test_is_unsecured_targets_own_socket_dir_on_linux() -> None:
     assert cmd[cmd.index("-h") + 1] == str(m.socket_dir())
 
 
+def test_is_unsecured_ignores_trust_auth_and_checks_catalog() -> None:
+    """Regression: Homebrew/vanilla initdb default local connections to
+    'trust', which grants access regardless of whether a password is set —
+    a successful connection alone must never be read as 'still passwordless'."""
+    m = _mgr()
+
+    def fake_run(cmd, **kwargs):
+        assert "rolpassword" in cmd[-1]
+        return MagicMock(returncode=0, stdout="f\n")  # role HAS a password
+
+    with patch.object(m, "_psql", return_value="/usr/bin/psql"), \
+         patch(f"{MODULE}.subprocess.run", side_effect=fake_run):
+        assert m.is_unsecured() is False
+
+
+def test_is_unsecured_true_when_role_has_no_password() -> None:
+    m = _mgr()
+    with patch.object(m, "_psql", return_value="/usr/bin/psql"), \
+         patch(f"{MODULE}.subprocess.run", return_value=MagicMock(returncode=0, stdout="t\n")):
+        assert m.is_unsecured() is True
+
+
+def test_is_unsecured_true_when_role_does_not_exist_yet() -> None:
+    m = _mgr()
+    with patch.object(m, "_psql", return_value="/usr/bin/psql"), \
+         patch(f"{MODULE}.subprocess.run", return_value=MagicMock(returncode=0, stdout="")):
+        assert m.is_unsecured() is True
+
+
 def test_provision_user_owned_initialises_and_installs_unit_when_fresh(tmp_path) -> None:
     m = _mgr(port=5440)
     with patch.object(m, "data_dir", return_value=tmp_path / "data"), \


### PR DESCRIPTION
## Summary

- Fixes `is_provisioned()` always returning `False` on macOS for `MariaDBManager`/`PostgresManager`: neither ever writes a `systemd --user` unit file there (Homebrew owns install/start), which was the only signal the shared base implementation checked.
- This broke the setup wizard's `_is_fresh_install()` check on macOS — it always reported `will_install`, so a second bench's wizard skipped password validation entirely, and `bench init` would then silently reset the first bench's real MariaDB/Postgres password to whatever was typed.
- `is_provisioned()` on macOS now asks the live server directly (`is_running() and not is_unsecured()`) instead of relying on a persisted marker file, since a marker is bookkeeping that can drift from the server's actual state (e.g. get deleted) with nothing forcing it back in sync.
- Added `PostgresManager.is_unsecured()` (Postgres didn't have one yet; mirrors the existing `MariaDBManager.is_unsecured()`), and fixed `is_unsecured()`'s own dead-but-broken macOS socket handling (same hardcoded local-socket-path bug already fixed elsewhere in this file for `_run_sql_as_superuser`/`_wait_until_reachable`).

## Caveats

- The live check only reflects reality while the server is actually running; if a previously-secured macOS server happens to be stopped when `/validate-mariadb`/`/validate-postgres` is called, it's reported as fresh (same limitation as before this PR, just now tied to live state instead of a static marker rather than introducing a new gap).
- This only affects macOS — Linux continues to use the systemd `--user` unit file's existence, which was already correct.