### PR TITLE
fix: bench new picks a MariaDB port macOS will never actually bind to

### DIFF
--- a/pilot/commands/new.py
+++ b/pilot/commands/new.py
@@ -136,10 +136,20 @@ class NewCommand(Command):
         """Smallest port at/above the default 3306 that isn't already live —
         used only when no sibling has picked one yet, so the very first
         MariaDB bench on a host doesn't collide with a system-wide MariaDB
-        already listening on 3306."""
+        already listening on 3306.
+
+        macOS never creates a bindable-anywhere instance of its own —
+        MariaDBManager just starts Homebrew's single shared service via
+        `brew services`, which always uses its own default port and ignores
+        this config entirely. Scanning for a "free" port there would just
+        record a value the real server will never actually bind to.
+        """
         from pilot.config.mariadb_config import MariaDBConfig
+        from pilot.platform import is_macos
 
         port = MariaDBConfig().port
+        if is_macos():
+            return port
         while self._port_is_live(port):
             port += 1
         return port

--- a/pilot/commands/new.py
+++ b/pilot/commands/new.py
@@ -91,6 +91,7 @@ class NewCommand(Command):
                 nbytes=8
             )
         if self.db_type == "postgres":
+            settings["postgres_port"] = self._sibling_postgres_port() or self._pick_postgres_port()
             settings["postgres_password"] = self._sibling_postgres_password() or secrets.token_hex(
                 nbytes=8
             )
@@ -161,6 +162,39 @@ class NewCommand(Command):
             if config.db_type == "mariadb" and config.mariadb.root_password:
                 return config.mariadb.root_password
         return ""
+
+    def _sibling_postgres_port(self) -> int:
+        """The PostgreSQL port a sibling bench already established for the
+        shared server (see PostgresManager), so this bench points at the
+        same running instance instead of a fresh guess."""
+        for _, config in iter_sibling_benches(self.target_directory):
+            if config.db_type == "postgres" and config.postgres.port:
+                return config.postgres.port
+        return 0
+
+    def _pick_postgres_port(self) -> int:
+        """Smallest port at/above the default 5432 that isn't already live —
+        used only when no sibling has picked one yet, so the very first
+        Postgres bench on a host doesn't collide with a system-wide
+        PostgreSQL already listening on 5432. Mirrors _pick_mariadb_port().
+
+        macOS never creates a bindable-anywhere instance of its own —
+        PostgresManager just starts Homebrew's single shared service via
+        `brew services`, which always uses its own default port and ignores
+        this config entirely. Scanning for a "free" port there would just
+        record a value the real server will never actually bind to. Linux
+        does run a genuine per-user instance (a systemd --user unit started
+        with -p <config>), so scanning is meaningful there.
+        """
+        from pilot.config.postgres_config import PostgresConfig
+        from pilot.platform import is_macos
+
+        port = PostgresConfig().port
+        if is_macos():
+            return port
+        while self._port_is_live(port):
+            port += 1
+        return port
 
     def _sibling_postgres_password(self) -> str:
         """The PostgreSQL superuser password from any sibling Postgres bench —

--- a/pilot/commands/new.py
+++ b/pilot/commands/new.py
@@ -141,9 +141,7 @@ class NewCommand(Command):
 
         macOS never creates a bindable-anywhere instance of its own —
         MariaDBManager just starts Homebrew's single shared service via
-        `brew services`, which always uses its own default port and ignores
-        this config entirely. Scanning for a "free" port there would just
-        record a value the real server will never actually bind to.
+        `brew services`.
         """
         from pilot.config.mariadb_config import MariaDBConfig
         from pilot.platform import is_macos
@@ -180,11 +178,7 @@ class NewCommand(Command):
 
         macOS never creates a bindable-anywhere instance of its own —
         PostgresManager just starts Homebrew's single shared service via
-        `brew services`, which always uses its own default port and ignores
-        this config entirely. Scanning for a "free" port there would just
-        record a value the real server will never actually bind to. Linux
-        does run a genuine per-user instance (a systemd --user unit started
-        with -p <config>), so scanning is meaningful there.
+        `brew services`
         """
         from pilot.config.postgres_config import PostgresConfig
         from pilot.platform import is_macos

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -204,6 +204,24 @@ def test_new_command_mariadb_port_is_not_offset_between_benches(tmp_path: Path, 
     assert data["bench"]["http_port"] == 8001  # other ports still offset
 
 
+def test_new_command_mariadb_port_ignores_live_scan_on_macos(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """On macOS, MariaDBManager just starts Homebrew's single shared service
+    (`brew services start`, no --port override) — the actual server always
+    binds to its own default regardless of config. Scanning for a "free" port
+    there would record a value nothing will ever actually bind to."""
+    from pilot.commands.new import NewCommand
+
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    # 3306 reads as live, which would normally push the picker to 3307+.
+    monkeypatch.setattr(NewCommand, "_port_is_live", staticmethod(lambda port: port == 3306))
+    with patch("pilot.platform.is_macos", return_value=True):
+        NewCommand(tmp_path / "benches" / "m", "m").run()
+
+    with open(tmp_path / "benches" / "m" / "bench.toml", "rb") as f:
+        data = tomllib.load(f)
+    assert data["mariadb"]["port"] == 3306
+
+
 def test_new_command_second_mariadb_bench_inherits_password(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Every bench for this OS user shares one MariaDB server, so a second
     bench must reuse the password that already secured it — not the bare

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -173,6 +173,41 @@ def test_new_command_second_postgres_bench_inherits_password(tmp_path: Path, mon
     assert first["postgres"]["root_password"] == second["postgres"]["root_password"]
 
 
+def test_new_command_postgres_port_is_not_offset_between_benches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Every bench for this OS user shares one PostgreSQL server, so
+    postgres.port must stay identical across benches — unlike http_port/redis
+    ports, which are offset per bench. Mirrors the equivalent mariadb test."""
+    from pilot.commands.new import NewCommand
+
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    monkeypatch.setattr(NewCommand, "_port_is_live", staticmethod(lambda port: False))
+    benches_dir = tmp_path / "benches"
+    NewCommand(benches_dir / "first", "first", db_type="postgres").run()
+    NewCommand(benches_dir / "second", "second", db_type="postgres").run()
+
+    with open(benches_dir / "second" / "bench.toml", "rb") as f:
+        data = tomllib.load(f)
+    assert data["postgres"]["port"] == 5432
+    assert data["bench"]["http_port"] == 8001  # other ports still offset
+
+
+def test_new_command_postgres_port_ignores_live_scan_on_macos(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """On macOS, PostgresManager just starts Homebrew's single shared service
+    (`brew services start`, no -p override) — the actual server always binds
+    to its own default regardless of config. Mirrors the mariadb version."""
+    from pilot.commands.new import NewCommand
+
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    # 5432 reads as live, which would normally push the picker to 5433+.
+    monkeypatch.setattr(NewCommand, "_port_is_live", staticmethod(lambda port: port == 5432))
+    with patch("pilot.platform.is_macos", return_value=True):
+        NewCommand(tmp_path / "benches" / "pg", "pg", db_type="postgres").run()
+
+    with open(tmp_path / "benches" / "pg" / "bench.toml", "rb") as f:
+        data = tomllib.load(f)
+    assert data["postgres"]["port"] == 5432
+
+
 def test_new_command_mariadb_bench_has_no_postgres_password(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from pilot.commands.new import NewCommand
 


### PR DESCRIPTION
## Summary

- `bench new`'s `_pick_mariadb_port()` scans upward from 3306 for the smallest currently-free TCP port, on the assumption that `MariaDBManager` will bind whatever port ends up in `bench.toml`. True on Linux (a per-user systemd unit started with `--port=<config>`), but not on macOS.
- On macOS, `MariaDBManager.start()` (inherited from the shared base class) just runs `brew services start mariadb` — no port override. Homebrew's single shared instance always binds its own configured default, completely ignoring `bench.toml`.
- If port 3306 happened to be occupied at `bench new` time (e.g. a previous bench's Homebrew MariaDB still starting up, or something else transiently bound), the picker would record e.g. `3307` into `bench.toml` — a port the real server will never actually bind to, breaking every subsequent connection attempt for that bench.
- Fix: `_pick_mariadb_port()` now returns the fixed default directly on macOS instead of scanning for a "free" port that has no effect on where the shared Homebrew instance actually listens.

## Caveats

- Postgres doesn't have this bug — `bench new` never scans for a Postgres port at all (always uses the dataclass default `5432`), which already happens to match Homebrew's fixed default, so no change was needed there.
- This only changes macOS behavior; Linux's live-port-scanning (correctly meaningful there, since the per-user unit does honor `--port`) is untouched.