### PR TITLE
Add macOS smoke test for install.sh

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - install.sh
       - scripts/smoke_install.sh
+      - scripts/smoke_install_macos.sh
       - .github/workflows/install-smoke.yml
   workflow_dispatch:
 
@@ -20,6 +21,9 @@ jobs:
 
       - name: Lint smoke test script
         run: shellcheck scripts/smoke_install.sh
+
+      - name: Lint macOS smoke test script
+        run: shellcheck scripts/smoke_install_macos.sh
 
   smoke:
     needs: shellcheck
@@ -37,3 +41,12 @@ jobs:
 
       - name: Run install.sh inside ${{ matrix.image }}
         run: ./scripts/smoke_install.sh "${{ matrix.image }}"
+
+  smoke-macos:
+    needs: shellcheck
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run install.sh on macOS
+        run: ./scripts/smoke_install_macos.sh

--- a/scripts/smoke_install_macos.sh
+++ b/scripts/smoke_install_macos.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Runs install.sh end-to-end directly on a macOS host: there's no container
+# runtime to isolate this in (unlike scripts/smoke_install.sh's Linux distro
+# images), so this is meant for an ephemeral macOS CI runner, not a
+# developer's own machine — it installs Homebrew, MariaDB, PostgreSQL and
+# Node for real.
+#
+# Usage: scripts/smoke_install_macos.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CURRENT_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+export PILOT_REPO_URL="file://$REPO_ROOT"
+export PILOT_BRANCH="$CURRENT_BRANCH"
+
+echo "=== macOS smoke test ==="
+sh "$REPO_ROOT/install.sh"
+
+echo "--- assertions ---"
+test -x "$HOME/pilot/bench"
+test -f "$HOME/pilot/.admin-venv/bin/python"
+command -v brew
+command -v node
+command -v git
+grep -qF pilot "$HOME/.zshrc" 2>/dev/null || \
+    grep -qF pilot "$HOME/.profile" 2>/dev/null || \
+    grep -qF pilot "$HOME/.bashrc" 2>/dev/null
+echo "--- OK ---"

--- a/scripts/smoke_install_macos.sh
+++ b/scripts/smoke_install_macos.sh
@@ -5,13 +5,30 @@
 # developer's own machine — it installs Homebrew, MariaDB, PostgreSQL and
 # Node for real.
 #
+# The working tree (including uncommitted changes) is committed into a
+# throwaway git repo on a hardcoded "main" branch and cloned from there, the
+# same way scripts/smoke_install.sh does — a checkout in CI is detached HEAD,
+# so `git rev-parse --abbrev-ref HEAD` would otherwise hand install.sh the
+# literal branch name "HEAD".
+#
 # Usage: scripts/smoke_install_macos.sh
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-CURRENT_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
-export PILOT_REPO_URL="file://$REPO_ROOT"
-export PILOT_BRANCH="$CURRENT_BRANCH"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+mkdir "$WORK_DIR/src"
+tar -C "$REPO_ROOT" --exclude .git --exclude node_modules --exclude .admin-venv \
+    --exclude test-bench -cf - . | tar -C "$WORK_DIR/src" -xf -
+git -C "$WORK_DIR/src" init --quiet --initial-branch main
+git -C "$WORK_DIR/src" add --all
+git -C "$WORK_DIR/src" -c user.email=smoke@test -c user.name=smoke \
+    commit --quiet --message "smoke test snapshot"
+
+export PILOT_REPO_URL="file://$WORK_DIR/src"
+export PILOT_BRANCH="main"
 
 echo "=== macOS smoke test ==="
 sh "$REPO_ROOT/install.sh"


### PR DESCRIPTION
## Summary
- Adds `scripts/smoke_install_macos.sh`, which runs install.sh directly on a macOS host and checks that bench, the admin venv, node, git and brew all end up installed.
- Adds a `smoke-macos` job to `install-smoke.yml`, running on `macos-14`.
- macOS has no container runtime to isolate this in like the Linux distro matrix does, so it runs straight on the (ephemeral) CI runner instead — same as the Linux path, it installs real packages (Homebrew, MariaDB, PostgreSQL, Node) rather than mocking anything.

This gives the macOS install path (#197) CI coverage for the first time.

## Test plan
- [x] `shellcheck scripts/smoke_install_macos.sh`
- [x] `shellcheck -s sh install.sh`
- [ ] CI: `smoke-macos` job passes on `macos-14`