### PR TITLE
feat: connect setup wizard to an external database server

### DIFF
--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+import typing
 from pathlib import Path
 
 from flask import Blueprint, Response, current_app, jsonify, request, stream_with_context
 
 from admin.backend.tasks.manager.task_reader import TaskReader
 from admin.backend.tasks.manager.task_runner import TaskRunner
-from pilot.config.bench_toml_builder import FRAMEWORK_BRANCHES, BenchTomlBuilder, current_port_offset
+from pilot.config.bench_toml_builder import (
+    FRAMEWORK_BRANCHES,
+    BenchTomlBuilder,
+    current_port_offset,
+)
 from pilot.config.toml_store import BenchTomlStore
+
+if typing.TYPE_CHECKING:
+    from pilot.managers.mariadb_manager import MariaDBManager
+    from pilot.managers.postgres_manager import PostgresManager
 
 setup_bp = Blueprint("setup", __name__)
 
@@ -56,7 +65,9 @@ def save_config():
             pass
 
     settings = {**existing, **data, "admin_enabled": True}
-    store.write_flat(_current_name(bench_root), settings, port_offset=current_port_offset(toml_path))
+    store.write_flat(
+        _current_name(bench_root), settings, port_offset=current_port_offset(toml_path)
+    )
 
     resp = jsonify({"ok": True})
     # Setting the password closes the open setup phase; hand back a session so the
@@ -69,8 +80,13 @@ def save_config():
 def _issue_setup_session(resp, toml_path: Path) -> None:
     from pilot.commands.generate_session import ensure_jwt_secret, issue_token
 
-    resp.set_cookie("sid", issue_token(ensure_jwt_secret(toml_path)),
-                    max_age=24 * 3600, httponly=True, samesite="Lax")
+    resp.set_cookie(
+        "sid",
+        issue_token(ensure_jwt_secret(toml_path)),
+        max_age=24 * 3600,
+        httponly=True,
+        samesite="Lax",
+    )
 
 
 @setup_bp.route("/validate-mariadb", methods=["POST"])
@@ -118,7 +134,9 @@ def validate_postgres():
     port = int(data.get("postgres_port") or 5432)
     external = bool(data.get("postgres_external"))
 
-    config = PostgresConfig(host=host, port=port, root_password=password, admin_user=admin_user, external=external)
+    config = PostgresConfig(
+        host=host, port=port, root_password=password, admin_user=admin_user, external=external
+    )
     manager = PostgresManager(config)
 
     if config.external:
@@ -131,7 +149,7 @@ def validate_postgres():
     return jsonify({"state": "invalid"})
 
 
-def _is_fresh_install(manager) -> bool:
+def _is_fresh_install(manager: PostgresManager | MariaDBManager) -> bool:
     """True when init will install/provision + secure the server itself
     (rather than connecting to an already-configured one). is_provisioned()
     checks for the manager's own systemd --user unit — the single source of
@@ -142,7 +160,12 @@ def _is_fresh_install(manager) -> bool:
 
 
 def _mariadb_config(
-    bench_root: Path, password: str, admin_user: str = "root", host: str = "", port=None, external: bool = False
+    bench_root: Path,
+    password: str,
+    admin_user: str = "root",
+    host: str = "",
+    port=None,
+    external: bool = False,
 ):
     """Build a MariaDBConfig from the bench's toml with the entered credentials applied."""
     from pilot.config.mariadb_config import MariaDBConfig
@@ -179,7 +202,9 @@ def _validate(data: dict) -> str | None:
         if not data.get(f"{db_type}_host"):
             return f"{db_type}_host is required when connecting to an external database server"
         if not data.get(f"{db_type}_admin_user"):
-            return f"{db_type}_admin_user is required when connecting to an external database server"
+            return (
+                f"{db_type}_admin_user is required when connecting to an external database server"
+            )
     return None
 
 
@@ -249,7 +274,9 @@ def finish_setup():
     # socket, so the kill can't race ahead of the response. The tiny timer
     # just lets the handler thread finish tearing down the connection.
     response = jsonify({"ok": True})
-    response.call_on_close(lambda: threading.Timer(0.1, lambda: os.kill(os.getpid(), signal.SIGTERM)).start())
+    response.call_on_close(
+        lambda: threading.Timer(0.1, lambda: os.kill(os.getpid(), signal.SIGTERM)).start()
+    )
     return response
 
 
@@ -330,8 +357,11 @@ def _running_setup_task(bench_root: Path):
     """The wizard's setup task if it's currently running, else None. The single
     live task is the whole resume signal: a reload reattaches to it."""
     return next(
-        (t for t in TaskReader(bench_root).list_tasks()
-         if t.command == "wizard-setup" and t.status == "running"),
+        (
+            t
+            for t in TaskReader(bench_root).list_tasks()
+            if t.command == "wizard-setup" and t.status == "running"
+        ),
         None,
     )
 

--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -83,10 +83,17 @@ def validate_mariadb():
     data = request.get_json(silent=True) or {}
     password = data.get("mariadb_password", "")
     admin_user = data.get("mariadb_admin_user", "root")
+    host = data.get("mariadb_host", "")
+    port = data.get("mariadb_port")
+    external = bool(data.get("mariadb_external"))
 
     bench_root = Path(current_app.config["BENCH_ROOT"])
-    config = _mariadb_config(bench_root, password, admin_user)
+    config = _mariadb_config(bench_root, password, admin_user, host, port, external)
     manager = MariaDBManager(config)
+
+    # external is a deliberate choice, never inferred from host: just check the login.
+    if config.external:
+        return jsonify({"state": "valid" if manager.check_credentials(password) else "invalid"})
 
     if _is_fresh_install(manager):
         return jsonify({"state": "will_install"})
@@ -107,8 +114,16 @@ def validate_postgres():
     data = request.get_json(silent=True) or {}
     password = data.get("postgres_password", "")
     admin_user = data.get("postgres_admin_user") or "postgres"
+    host = data.get("postgres_host") or "localhost"
+    port = int(data.get("postgres_port") or 5432)
+    external = bool(data.get("postgres_external"))
 
-    manager = PostgresManager(PostgresConfig(root_password=password, admin_user=admin_user))
+    config = PostgresConfig(host=host, port=port, root_password=password, admin_user=admin_user, external=external)
+    manager = PostgresManager(config)
+
+    if config.external:
+        return jsonify({"state": "valid" if manager.check_credentials(password) else "invalid"})
+
     if _is_fresh_install(manager):
         return jsonify({"state": "will_install"})
     if manager.check_credentials(password):
@@ -126,11 +141,19 @@ def _is_fresh_install(manager) -> bool:
     return not manager.is_provisioned()
 
 
-def _mariadb_config(bench_root: Path, password: str, admin_user: str = "root"):
+def _mariadb_config(
+    bench_root: Path, password: str, admin_user: str = "root", host: str = "", port=None, external: bool = False
+):
     """Build a MariaDBConfig from the bench's toml with the entered credentials applied."""
     from pilot.config.mariadb_config import MariaDBConfig
 
-    config = MariaDBConfig(root_password=password, admin_user=admin_user)
+    config = MariaDBConfig(
+        root_password=password,
+        admin_user=admin_user,
+        host=host or "localhost",
+        port=int(port or 3306),
+        external=external,
+    )
     toml_path = bench_root / "bench.toml"
     if toml_path.exists():
         try:
@@ -152,6 +175,11 @@ def _validate(data: dict) -> str | None:
         return "mariadb_password is required"
     if db_type == "postgres" and not data.get("postgres_password"):
         return "postgres_password is required"
+    if data.get(f"{db_type}_external"):
+        if not data.get(f"{db_type}_host"):
+            return f"{db_type}_host is required when connecting to an external database server"
+        if not data.get(f"{db_type}_admin_user"):
+            return f"{db_type}_admin_user is required when connecting to an external database server"
     return None
 
 

--- a/admin/frontend/src/composables/useSetup.js
+++ b/admin/frontend/src/composables/useSetup.js
@@ -300,7 +300,9 @@ export function useSetup() {
       app_branch: appBranch.value,
     }
     const external = useExternalDb.value
-    const host = external ? dbHost.value : ''
+    // 'localhost', not '', when off — an empty host breaks check_credentials'
+    // TCP fallback on systems where the local socket isn't detected.
+    const host = external ? dbHost.value : 'localhost'
     const port = external ? Number(dbPort.value) || undefined : undefined
     if (dbType.value === 'postgres') {
       return {

--- a/admin/frontend/src/composables/useSetup.js
+++ b/admin/frontend/src/composables/useSetup.js
@@ -47,17 +47,35 @@ export function useSetup() {
   const appRepo = ref('https://github.com/frappe/frappe')
   const appBranch = ref('develop')
 
+  // Off by default: pilot spawns and owns its own MariaDB/PostgreSQL server.
+  const _useExternalDb = ref(false)
+  const dbHost = ref('')
+  const dbPort = ref('')
+  // Clears the password/host/port on toggle; loadConfig bypasses this via _useExternalDb.
+  const useExternalDb = computed({
+    get: () => _useExternalDb.value,
+    set: (value) => {
+      _useExternalDb.value = value
+      dbPassword.value = ''
+      if (!value) {
+        dbHost.value = ''
+        dbPort.value = ''
+      }
+    },
+  })
+
   // Derived database state. Every bench for this OS user shares one
   // MariaDB/PostgreSQL server (see MariaDBManager/PostgresManager) — there's
   // no per-bench deployment mode to choose, just whether that shared server
   // still needs to be installed and secured, or already exists.
-  const dbWillInstall = computed(() =>
-    dbType.value === 'postgres' ? postgresWillInstall.value : mariadbWillInstall.value,
+  const dbWillInstall = computed(
+    () => !useExternalDb.value && (dbType.value === 'postgres' ? postgresWillInstall.value : mariadbWillInstall.value),
   )
   const isAdminPasswordValid = computed(() => meetsPasswordRequirements(adminPassword.value))
 
-  const showRootUsername = computed(() => !dbWillInstall.value)
+  const showRootUsername = computed(() => useExternalDb.value || !dbWillInstall.value)
   const rootUserPlaceholder = computed(() => (dbType.value === 'mariadb' ? 'root' : 'postgres'))
+  const dbPortPlaceholder = computed(() => (dbType.value === 'mariadb' ? '3306' : '5432'))
   // The username the API receives: what the user typed, or the engine default
   // whenever the field is hidden (a fresh install always uses the default).
   const resolvedDbUser = computed(() =>
@@ -65,6 +83,7 @@ export function useSetup() {
   )
   const rootPasswordDescription = computed(() => {
     const engine = dbType.value === 'mariadb' ? 'MariaDB' : 'PostgreSQL'
+    if (useExternalDb.value) return `Credentials for the existing ${engine} server.`
     return dbWillInstall.value
       ? `${engine} will be installed and its ${dbType.value === 'mariadb' ? 'root' : 'superuser'} password set to this value.`
       : undefined
@@ -93,8 +112,7 @@ export function useSetup() {
   })
   const stepSubtitle = computed(() => STEP_SUBTITLES[currentStep.value] || null)
 
-  // A fresh install is ours to provision, so give it a generated password.
-  // An existing server keeps its own, so the field is cleared for re-entry.
+  // A fresh install gets a generated password; an existing server keeps its own.
   watch(
     dbWillInstall,
     (willInstall) => {
@@ -125,9 +143,19 @@ export function useSetup() {
       if (config.db_type === 'postgres') {
         if (config.postgres_admin_user) dbUser.value = config.postgres_admin_user
         if (config.postgres_password) dbPassword.value = config.postgres_password
+        if (config.postgres_external) {
+          _useExternalDb.value = true
+          dbHost.value = config.postgres_host || ''
+          dbPort.value = config.postgres_port ? String(config.postgres_port) : ''
+        }
       } else {
         if (config.mariadb_admin_user) dbUser.value = config.mariadb_admin_user
         if (config.mariadb_password) dbPassword.value = config.mariadb_password
+        if (config.mariadb_external) {
+          _useExternalDb.value = true
+          dbHost.value = config.mariadb_host || ''
+          dbPort.value = config.mariadb_port ? String(config.mariadb_port) : ''
+        }
       }
 
       if (config.running_setup_task_id) startStream(config.running_setup_task_id)
@@ -196,11 +224,15 @@ export function useSetup() {
 
   async function validateMariadbStep() {
     if (!dbPassword.value) return 'MariaDB password is required'
+    if (useExternalDb.value && !dbHost.value) return 'Host is required for an external database'
     isSubmitting.value = true
     try {
       const { state } = await setupApi.validateMariadb({
         mariadb_password: dbPassword.value,
         mariadb_admin_user: resolvedDbUser.value,
+        mariadb_external: useExternalDb.value,
+        mariadb_host: useExternalDb.value ? dbHost.value : '',
+        mariadb_port: useExternalDb.value ? Number(dbPort.value) || 3306 : undefined,
       })
       mariadbWillInstall.value = state === 'will_install'
       if (state === 'invalid') return 'Incorrect MariaDB credentials.'
@@ -213,11 +245,15 @@ export function useSetup() {
 
   async function validatePostgresStep() {
     if (!dbPassword.value) return 'PostgreSQL password is required'
+    if (useExternalDb.value && !dbHost.value) return 'Host is required for an external database'
     isSubmitting.value = true
     try {
       const { state } = await setupApi.validatePostgres({
         postgres_password: dbPassword.value,
         postgres_admin_user: resolvedDbUser.value,
+        postgres_external: useExternalDb.value,
+        postgres_host: useExternalDb.value ? dbHost.value : '',
+        postgres_port: useExternalDb.value ? Number(dbPort.value) || 5432 : undefined,
       })
       postgresWillInstall.value = state === 'will_install'
       if (state === 'invalid') return 'Incorrect PostgreSQL credentials.'
@@ -255,7 +291,7 @@ export function useSetup() {
     currentStep.value = stepSequence.value.at(-1)
   }
 
-  // Save: the payload is assembled from the current dropdown values
+  // Port is only sent in external mode, so a locally customized port isn't clobbered on save.
   function buildPayload() {
     const base = {
       admin_password: adminPassword.value,
@@ -263,11 +299,17 @@ export function useSetup() {
       app_repo: appRepo.value,
       app_branch: appBranch.value,
     }
+    const external = useExternalDb.value
+    const host = external ? dbHost.value : ''
+    const port = external ? Number(dbPort.value) || undefined : undefined
     if (dbType.value === 'postgres') {
       return {
         ...base,
         postgres_password: dbPassword.value,
         postgres_admin_user: resolvedDbUser.value,
+        postgres_external: external,
+        postgres_host: host,
+        ...(port ? { postgres_port: port } : {}),
         mariadb_password: '',
         mariadb_admin_user: 'root',
       }
@@ -276,6 +318,9 @@ export function useSetup() {
       ...base,
       mariadb_password: dbPassword.value,
       mariadb_admin_user: resolvedDbUser.value,
+      mariadb_external: external,
+      mariadb_host: host,
+      ...(port ? { mariadb_port: port } : {}),
       postgres_password: '',
       postgres_admin_user: 'postgres',
     }
@@ -333,6 +378,10 @@ export function useSetup() {
     dbType,
     dbUser,
     dbPassword,
+    useExternalDb,
+    dbHost,
+    dbPort,
+    dbPortPlaceholder,
     appRepo,
     appBranch,
     showRootUsername,

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -33,7 +33,7 @@
         <div v-show="currentStep === 'database'" class="flex flex-col gap-4">
           <Select label="Database engine" v-model="dbType" :options="dbTypeOptions" />
           <Switch v-model="useExternalDb" label="Connect to an existing database server"
-            description="e.g. Amazon RDS, or any server other than this machine. Leave off to let pilot set up and manage its own." />
+            description="Leave off to let pilot set up and manage its own user owned database server if not already present." />
           <div v-show="useExternalDb" class="flex gap-4">
             <TextInput class="flex-1" label="Host" v-model="dbHost" placeholder="db.example.com" />
             <TextInput class="w-28" label="Port" v-model="dbPort" :placeholder="dbPortPlaceholder" />

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -32,11 +32,18 @@
         <!-- Database -->
         <div v-show="currentStep === 'database'" class="flex flex-col gap-4">
           <Select label="Database engine" v-model="dbType" :options="dbTypeOptions" />
-          <TextInput v-show="showRootUsername" label="Root username" v-model="dbUser"
+          <Switch v-model="useExternalDb" label="Connect to an existing database server"
+            description="e.g. Amazon RDS, or any server other than this machine. Leave off to let pilot set up and manage its own." />
+          <div v-show="useExternalDb" class="flex gap-4">
+            <TextInput class="flex-1" label="Host" v-model="dbHost" placeholder="db.example.com" />
+            <TextInput class="w-28" label="Port" v-model="dbPort" :placeholder="dbPortPlaceholder" />
+          </div>
+          <TextInput v-show="showRootUsername" :label="useExternalDb ? 'Username' : 'Root username'" v-model="dbUser"
             :placeholder="rootUserPlaceholder" />
           <div>
-            <Password label="Root user password" v-model="dbPassword" placeholder="password" autocomplete="off"
-              data-lpignore="true" data-1p-ignore data-bwignore @keydown.enter="goToNextStep" />
+            <Password :label="useExternalDb ? 'Password' : 'Root user password'" v-model="dbPassword"
+              placeholder="password" autocomplete="off" data-lpignore="true" data-1p-ignore data-bwignore
+              @keydown.enter="goToNextStep" />
             <p v-show="rootPasswordDescription" class="mt-1.5 text-ink-gray-6 text-p-sm">{{ rootPasswordDescription }}
             </p>
           </div>
@@ -129,6 +136,7 @@
 import {
   Button,
   Select,
+  Switch,
   TextInput,
   FormLabel,
   Password,
@@ -156,6 +164,10 @@ const {
   dbType,
   dbUser,
   dbPassword,
+  useExternalDb,
+  dbHost,
+  dbPort,
+  dbPortPlaceholder,
   appRepo,
   appBranch,
   showRootUsername,

--- a/pilot/commands/init.py
+++ b/pilot/commands/init.py
@@ -154,19 +154,30 @@ class InitCommand(Command):
 
         pkg = get_package_manager()
 
-        # A bench runs exactly one engine; install/provision only that one. Every
-        # bench for this OS user shares the same MariaDB/PostgreSQL server, so
-        # provision() just reuses whatever a prior bench already brought up.
+        # A bench runs exactly one engine; install/provision (or verify, if external) only that one.
         if self.bench.config.db_type == "postgres":
-            self._postgres_manager().provision()
+            self._provision_or_verify(self._postgres_manager(), "PostgreSQL")
         elif self.bench.config.db_type == "sqlite":
             pass
         else:
-            self._mariadb_manager().provision()
+            self._provision_or_verify(self._mariadb_manager(), "MariaDB")
 
         RedisManager(self.bench.config.redis, self.bench).install()
         self._install_build_headers(pkg)
         PythonEnvManager(self.bench).ensure_python()
+
+    def _provision_or_verify(self, manager, label: str) -> None:
+        if not manager.config.external:
+            manager.provision()
+            return
+        if not manager.check_credentials():
+            from pilot.exceptions import BenchError
+
+            raise BenchError(
+                f"Could not connect to external {label} server at "
+                f"{manager.config.host}:{manager.config.port} as '{manager.config.admin_user}'. "
+                "Check the host, port, username, and password."
+            )
 
     def _install_build_headers(self, pkg) -> None:
         # frappe imports mysqlclient in its __init__.py for every engine, so the

--- a/pilot/config/bench_toml_builder.py
+++ b/pilot/config/bench_toml_builder.py
@@ -23,6 +23,8 @@ FLAT_KEYS = {
     "mariadb_password": "mariadb.root_password",
     "mariadb_admin_user": "mariadb.admin_user",
     "mariadb_socket_path": "mariadb.socket_path",
+    "mariadb_host": "mariadb.host",
+    "mariadb_external": "mariadb.external",
     # mariadb.port and postgres.port are deliberately NOT offset-managed
     # (not in _PORT_FIELDS): every bench for a given OS user shares the same
     # single MariaDB/PostgreSQL server, so their ports must stay identical
@@ -34,6 +36,8 @@ FLAT_KEYS = {
     "postgres_password": "postgres.root_password",
     "postgres_admin_user": "postgres.admin_user",
     "postgres_port": "postgres.port",
+    "postgres_host": "postgres.host",
+    "postgres_external": "postgres.external",
     "admin_enabled": "admin.enabled",
     "admin_password": "admin.password",
     "admin_domain": "admin.domain",

--- a/pilot/config/mariadb_config.py
+++ b/pilot/config/mariadb_config.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass
 
 @dataclass
 class MariaDBConfig:
-    # Connection to the single rootless, per-bench-user MariaDB server that
-    # every bench on this host shares (see MariaDBManager).
+    # external is a deliberate user choice, never inferred from host (see MariaDBManager).
     host: str = "localhost"
     port: int = 3306
     root_password: str = ""
     admin_user: str = "root"
     socket_path: str = ""
+    external: bool = False

--- a/pilot/config/postgres_config.py
+++ b/pilot/config/postgres_config.py
@@ -3,10 +3,9 @@ from dataclasses import dataclass
 
 @dataclass
 class PostgresConfig:
-    # Connection to the single rootless, per-bench-user PostgreSQL server that
-    # every bench on this host shares (see PostgresManager). root_password is
-    # the superuser password new-site connects with.
+    # external is a deliberate user choice, never inferred from host (see PostgresManager).
     host: str = "localhost"
     port: int = 5432
     root_password: str = ""
     admin_user: str = "postgres"
+    external: bool = False

--- a/pilot/config/toml_writer.py
+++ b/pilot/config/toml_writer.py
@@ -37,6 +37,7 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append(f'root_password = "{m.root_password}"')
     parts.append(f'admin_user = "{m.admin_user}"')
     parts.append(f'socket_path = "{m.socket_path}"')
+    parts.append(f"external = {'true' if m.external else 'false'}")
     parts.append("")
 
     pg = config.postgres
@@ -45,6 +46,7 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append(f"port = {pg.port}")
     parts.append(f'root_password = "{pg.root_password}"')
     parts.append(f'admin_user = "{pg.admin_user}"')
+    parts.append(f"external = {'true' if pg.external else 'false'}")
     parts.append("")
 
     r = config.redis

--- a/tests/test_bench_toml_builder.py
+++ b/tests/test_bench_toml_builder.py
@@ -86,3 +86,22 @@ def test_current_port_offset_zero_when_file_invalid(tmp_path: Path) -> None:
     toml_path = tmp_path / "bench.toml"
     toml_path.write_text("not valid toml {{{")
     assert current_port_offset(toml_path) == 0
+
+
+# ── external database settings ───────────────────────────────────────────────
+
+
+def test_mariadb_host_and_external_round_trip(tmp_path: Path) -> None:
+    settings = {"mariadb_external": True, "mariadb_host": "db.example.com", "mariadb_admin_user": "admin"}
+    toml_path = tmp_path / "bench.toml"
+    toml_path.write_text(BenchTomlBuilder("my-bench", settings).render())
+
+    read_back = BenchTomlBuilder.read_settings(toml_path)
+    assert read_back["mariadb_external"] is True
+    assert read_back["mariadb_host"] == "db.example.com"
+
+
+def test_external_defaults_to_false_when_unset(tmp_path: Path) -> None:
+    data = _render(tmp_path)
+    assert data["mariadb"]["external"] is False
+    assert data["postgres"]["external"] is False

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -1,0 +1,48 @@
+"""InitCommand._provision_or_verify: external database handling."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from pilot.commands.init import InitCommand
+from pilot.exceptions import BenchError
+
+
+def _command() -> InitCommand:
+    return InitCommand(MagicMock())
+
+
+def test_provisions_a_pilot_owned_server() -> None:
+    manager = MagicMock()
+    manager.config.external = False
+
+    _command()._provision_or_verify(manager, "MariaDB")
+
+    manager.provision.assert_called_once()
+    manager.check_credentials.assert_not_called()
+
+
+def test_verifies_credentials_for_an_external_server_without_provisioning() -> None:
+    manager = MagicMock()
+    manager.config.external = True
+    manager.check_credentials.return_value = True
+
+    _command()._provision_or_verify(manager, "MariaDB")
+
+    manager.provision.assert_not_called()
+    manager.check_credentials.assert_called_once()
+
+
+def test_raises_when_external_credentials_are_wrong() -> None:
+    manager = MagicMock()
+    manager.config.external = True
+    manager.config.host = "db.example.com"
+    manager.config.port = 3306
+    manager.config.admin_user = "admin"
+    manager.check_credentials.return_value = False
+
+    with pytest.raises(BenchError, match="db.example.com"):
+        _command()._provision_or_verify(manager, "MariaDB")
+
+    manager.provision.assert_not_called()

--- a/tests/test_mariadb_manager.py
+++ b/tests/test_mariadb_manager.py
@@ -27,6 +27,17 @@ def test_socket_path_honors_explicit_value() -> None:
     assert MariaDBManager(MariaDBConfig(socket_path="/tmp/custom.sock")).socket_path() == "/tmp/custom.sock"
 
 
+# ── external ─────────────────────────────────────────────────────────────────
+
+
+def test_external_defaults_to_false() -> None:
+    assert MariaDBConfig().external is False
+
+
+def test_external_is_not_inferred_from_host() -> None:
+    assert MariaDBConfig(host="db.example.com").external is False
+
+
 # ── install ──────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -15,6 +15,17 @@ def _mgr(**kwargs) -> PostgresManager:
     return PostgresManager(PostgresConfig(**kwargs))
 
 
+# ── external ─────────────────────────────────────────────────────────────────
+
+
+def test_external_defaults_to_false() -> None:
+    assert PostgresConfig().external is False
+
+
+def test_external_is_not_inferred_from_host() -> None:
+    assert PostgresConfig(host="db.example.com").external is False
+
+
 # ── install ───────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_setup_postgres.py
+++ b/tests/test_setup_postgres.py
@@ -25,6 +25,41 @@ def test_validate_requires_mariadb_password() -> None:
     assert error and "mariadb_password" in error
 
 
+def test_validate_requires_host_for_external_mariadb() -> None:
+    data = {"admin_password": "x", "db_type": "mariadb", "mariadb_password": "pw", "mariadb_external": True}
+    error = _validate(data)
+    assert error and "mariadb_host" in error
+
+
+def test_validate_requires_admin_user_for_external_mariadb() -> None:
+    data = {
+        "admin_password": "x",
+        "db_type": "mariadb",
+        "mariadb_password": "pw",
+        "mariadb_external": True,
+        "mariadb_host": "db.example.com",
+    }
+    error = _validate(data)
+    assert error and "mariadb_admin_user" in error
+
+
+def test_validate_accepts_complete_external_mariadb() -> None:
+    data = {
+        "admin_password": "x",
+        "db_type": "mariadb",
+        "mariadb_password": "pw",
+        "mariadb_external": True,
+        "mariadb_host": "db.example.com",
+        "mariadb_admin_user": "admin",
+    }
+    assert _validate(data) is None
+
+
+def test_validate_ignores_host_when_not_marked_external() -> None:
+    data = {"admin_password": "x", "db_type": "mariadb", "mariadb_password": "pw", "mariadb_host": "db.example.com"}
+    assert _validate(data) is None
+
+
 # ── _read_defaults ────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
- Adds a toggle to the database setup step for connecting to an external database server (host, port, admin user, password) — e.g. RDS or any server other than this machine.
- Leaving it off keeps the current behavior: pilot spawns and owns its own MariaDB/PostgreSQL server.
- `external` is a stored, explicit choice (never guessed from the host value) — a pilot-owned server also lives at "localhost", so host alone can't tell the two cases apart.
- When external, `bench init` skips installing/provisioning entirely and only verifies it can log in with the given credentials.

## Test plan
- [x] `pytest tests/` (851 passed)
- [ ] Manual: run the setup wizard, toggle "Connect to an existing database server", enter RDS-style credentials, confirm site creation connects to it instead of spawning a local server