### PR TITLE
fix: clarify external vs pilot-managed DB in setup wizard

### DIFF
--- a/admin/backend/views/setup.py
+++ b/admin/backend/views/setup.py
@@ -101,14 +101,14 @@ def validate_mariadb():
     admin_user = data.get("mariadb_admin_user", "root")
     host = data.get("mariadb_host", "")
     port = data.get("mariadb_port")
-    external = bool(data.get("mariadb_external"))
+    existing = bool(data.get("mariadb_existing"))
 
     bench_root = Path(current_app.config["BENCH_ROOT"])
-    config = _mariadb_config(bench_root, password, admin_user, host, port, external)
+    config = _mariadb_config(bench_root, password, admin_user, host, port, existing)
     manager = MariaDBManager(config)
 
-    # external is a deliberate choice, never inferred from host: just check the login.
-    if config.external:
+    # existing is a deliberate choice, never inferred from host: just check the login.
+    if config.existing:
         return jsonify({"state": "valid" if manager.check_credentials(password) else "invalid"})
 
     if _is_fresh_install(manager):
@@ -132,14 +132,14 @@ def validate_postgres():
     admin_user = data.get("postgres_admin_user") or "postgres"
     host = data.get("postgres_host") or "localhost"
     port = int(data.get("postgres_port") or 5432)
-    external = bool(data.get("postgres_external"))
+    existing = bool(data.get("postgres_existing"))
 
     config = PostgresConfig(
-        host=host, port=port, root_password=password, admin_user=admin_user, external=external
+        host=host, port=port, root_password=password, admin_user=admin_user, existing=existing
     )
     manager = PostgresManager(config)
 
-    if config.external:
+    if config.existing:
         return jsonify({"state": "valid" if manager.check_credentials(password) else "invalid"})
 
     if _is_fresh_install(manager):
@@ -165,7 +165,7 @@ def _mariadb_config(
     admin_user: str = "root",
     host: str = "",
     port=None,
-    external: bool = False,
+    existing: bool = False,
 ):
     """Build a MariaDBConfig from the bench's toml with the entered credentials applied."""
     from pilot.config.mariadb_config import MariaDBConfig
@@ -175,7 +175,7 @@ def _mariadb_config(
         admin_user=admin_user,
         host=host or "localhost",
         port=int(port or 3306),
-        external=external,
+        existing=existing,
     )
     toml_path = bench_root / "bench.toml"
     if toml_path.exists():
@@ -198,12 +198,12 @@ def _validate(data: dict) -> str | None:
         return "mariadb_password is required"
     if db_type == "postgres" and not data.get("postgres_password"):
         return "postgres_password is required"
-    if data.get(f"{db_type}_external"):
+    if data.get(f"{db_type}_existing"):
         if not data.get(f"{db_type}_host"):
-            return f"{db_type}_host is required when connecting to an external database server"
+            return f"{db_type}_host is required when connecting to an existing database server"
         if not data.get(f"{db_type}_admin_user"):
             return (
-                f"{db_type}_admin_user is required when connecting to an external database server"
+                f"{db_type}_admin_user is required when connecting to an existing database server"
             )
     return None
 

--- a/admin/frontend/src/composables/useSetup.js
+++ b/admin/frontend/src/composables/useSetup.js
@@ -51,13 +51,16 @@ export function useSetup() {
   const _useExternalDb = ref(false)
   const dbHost = ref('')
   const dbPort = ref('')
-  // Clears the password/host/port on toggle; loadConfig bypasses this via _useExternalDb.
+  // Clears the password on toggle; loadConfig bypasses this via _useExternalDb.
   const useExternalDb = computed({
     get: () => _useExternalDb.value,
     set: (value) => {
       _useExternalDb.value = value
       dbPassword.value = ''
-      if (!value) {
+      if (value) {
+        dbHost.value = dbHost.value || '127.0.0.1'
+        dbPort.value = dbPort.value || dbPortPlaceholder.value
+      } else {
         dbHost.value = ''
         dbPort.value = ''
       }
@@ -83,10 +86,10 @@ export function useSetup() {
   )
   const rootPasswordDescription = computed(() => {
     const engine = dbType.value === 'mariadb' ? 'MariaDB' : 'PostgreSQL'
-    if (useExternalDb.value) return `Credentials for the existing ${engine} server.`
-    return dbWillInstall.value
-      ? `${engine} will be installed and its ${dbType.value === 'mariadb' ? 'root' : 'superuser'} password set to this value.`
-      : undefined
+    if (useExternalDb.value) return `Credentials for the existing ${engine} server at ${dbHost.value || 'the given host'}.`
+    if (dbWillInstall.value)
+      return `${engine} will be installed and its ${dbType.value === 'mariadb' ? 'root' : 'superuser'} password set to this value.`
+    return `Using the ${engine} server pilot already manages for this user — enter its existing password.`
   })
 
   const branchOptions = computed(() => {
@@ -145,16 +148,16 @@ export function useSetup() {
         if (config.postgres_password) dbPassword.value = config.postgres_password
         if (config.postgres_external) {
           _useExternalDb.value = true
-          dbHost.value = config.postgres_host || ''
-          dbPort.value = config.postgres_port ? String(config.postgres_port) : ''
+          dbHost.value = config.postgres_host || '127.0.0.1'
+          dbPort.value = config.postgres_port ? String(config.postgres_port) : '5432'
         }
       } else {
         if (config.mariadb_admin_user) dbUser.value = config.mariadb_admin_user
         if (config.mariadb_password) dbPassword.value = config.mariadb_password
         if (config.mariadb_external) {
           _useExternalDb.value = true
-          dbHost.value = config.mariadb_host || ''
-          dbPort.value = config.mariadb_port ? String(config.mariadb_port) : ''
+          dbHost.value = config.mariadb_host || '127.0.0.1'
+          dbPort.value = config.mariadb_port ? String(config.mariadb_port) : '3306'
         }
       }
 

--- a/admin/frontend/src/composables/useSetup.js
+++ b/admin/frontend/src/composables/useSetup.js
@@ -48,14 +48,14 @@ export function useSetup() {
   const appBranch = ref('develop')
 
   // Off by default: pilot spawns and owns its own MariaDB/PostgreSQL server.
-  const _useExternalDb = ref(false)
+  const _useExistingDb = ref(false)
   const dbHost = ref('')
   const dbPort = ref('')
-  // Clears the password on toggle; loadConfig bypasses this via _useExternalDb.
-  const useExternalDb = computed({
-    get: () => _useExternalDb.value,
+  // Clears the password on toggle; loadConfig bypasses this via _useExistingDb.
+  const useExistingDb = computed({
+    get: () => _useExistingDb.value,
     set: (value) => {
-      _useExternalDb.value = value
+      _useExistingDb.value = value
       dbPassword.value = ''
       if (value) {
         dbHost.value = dbHost.value || '127.0.0.1'
@@ -72,11 +72,11 @@ export function useSetup() {
   // no per-bench deployment mode to choose, just whether that shared server
   // still needs to be installed and secured, or already exists.
   const dbWillInstall = computed(
-    () => !useExternalDb.value && (dbType.value === 'postgres' ? postgresWillInstall.value : mariadbWillInstall.value),
+    () => !useExistingDb.value && (dbType.value === 'postgres' ? postgresWillInstall.value : mariadbWillInstall.value),
   )
   const isAdminPasswordValid = computed(() => meetsPasswordRequirements(adminPassword.value))
 
-  const showRootUsername = computed(() => useExternalDb.value || !dbWillInstall.value)
+  const showRootUsername = computed(() => useExistingDb.value || !dbWillInstall.value)
   const rootUserPlaceholder = computed(() => (dbType.value === 'mariadb' ? 'root' : 'postgres'))
   const dbPortPlaceholder = computed(() => (dbType.value === 'mariadb' ? '3306' : '5432'))
   // The username the API receives: what the user typed, or the engine default
@@ -86,7 +86,7 @@ export function useSetup() {
   )
   const rootPasswordDescription = computed(() => {
     const engine = dbType.value === 'mariadb' ? 'MariaDB' : 'PostgreSQL'
-    if (useExternalDb.value) return `Credentials for the existing ${engine} server at ${dbHost.value || 'the given host'}.`
+    if (useExistingDb.value) return `Credentials for the existing ${engine} server at ${dbHost.value || 'the given host'}.`
     if (dbWillInstall.value)
       return `${engine} will be installed and its ${dbType.value === 'mariadb' ? 'root' : 'superuser'} password set to this value.`
     return `Using the ${engine} server pilot already manages for this user — enter its existing password.`
@@ -146,16 +146,16 @@ export function useSetup() {
       if (config.db_type === 'postgres') {
         if (config.postgres_admin_user) dbUser.value = config.postgres_admin_user
         if (config.postgres_password) dbPassword.value = config.postgres_password
-        if (config.postgres_external) {
-          _useExternalDb.value = true
+        if (config.postgres_existing) {
+          _useExistingDb.value = true
           dbHost.value = config.postgres_host || '127.0.0.1'
           dbPort.value = config.postgres_port ? String(config.postgres_port) : '5432'
         }
       } else {
         if (config.mariadb_admin_user) dbUser.value = config.mariadb_admin_user
         if (config.mariadb_password) dbPassword.value = config.mariadb_password
-        if (config.mariadb_external) {
-          _useExternalDb.value = true
+        if (config.mariadb_existing) {
+          _useExistingDb.value = true
           dbHost.value = config.mariadb_host || '127.0.0.1'
           dbPort.value = config.mariadb_port ? String(config.mariadb_port) : '3306'
         }
@@ -227,15 +227,15 @@ export function useSetup() {
 
   async function validateMariadbStep() {
     if (!dbPassword.value) return 'MariaDB password is required'
-    if (useExternalDb.value && !dbHost.value) return 'Host is required for an external database'
+    if (useExistingDb.value && !dbHost.value) return 'Host is required for an existing database'
     isSubmitting.value = true
     try {
       const { state } = await setupApi.validateMariadb({
         mariadb_password: dbPassword.value,
         mariadb_admin_user: resolvedDbUser.value,
-        mariadb_external: useExternalDb.value,
-        mariadb_host: useExternalDb.value ? dbHost.value : '',
-        mariadb_port: useExternalDb.value ? Number(dbPort.value) || 3306 : undefined,
+        mariadb_existing: useExistingDb.value,
+        mariadb_host: useExistingDb.value ? dbHost.value : '',
+        mariadb_port: useExistingDb.value ? Number(dbPort.value) || 3306 : undefined,
       })
       mariadbWillInstall.value = state === 'will_install'
       if (state === 'invalid') return 'Incorrect MariaDB credentials.'
@@ -248,15 +248,15 @@ export function useSetup() {
 
   async function validatePostgresStep() {
     if (!dbPassword.value) return 'PostgreSQL password is required'
-    if (useExternalDb.value && !dbHost.value) return 'Host is required for an external database'
+    if (useExistingDb.value && !dbHost.value) return 'Host is required for an existing database'
     isSubmitting.value = true
     try {
       const { state } = await setupApi.validatePostgres({
         postgres_password: dbPassword.value,
         postgres_admin_user: resolvedDbUser.value,
-        postgres_external: useExternalDb.value,
-        postgres_host: useExternalDb.value ? dbHost.value : '',
-        postgres_port: useExternalDb.value ? Number(dbPort.value) || 5432 : undefined,
+        postgres_existing: useExistingDb.value,
+        postgres_host: useExistingDb.value ? dbHost.value : '',
+        postgres_port: useExistingDb.value ? Number(dbPort.value) || 5432 : undefined,
       })
       postgresWillInstall.value = state === 'will_install'
       if (state === 'invalid') return 'Incorrect PostgreSQL credentials.'
@@ -294,7 +294,7 @@ export function useSetup() {
     currentStep.value = stepSequence.value.at(-1)
   }
 
-  // Port is only sent in external mode, so a locally customized port isn't clobbered on save.
+  // Port is only sent in existing mode, so a locally customized port isn't clobbered on save.
   function buildPayload() {
     const base = {
       admin_password: adminPassword.value,
@@ -302,17 +302,17 @@ export function useSetup() {
       app_repo: appRepo.value,
       app_branch: appBranch.value,
     }
-    const external = useExternalDb.value
+    const existing = useExistingDb.value
     // 'localhost', not '', when off — an empty host breaks check_credentials'
     // TCP fallback on systems where the local socket isn't detected.
-    const host = external ? dbHost.value : 'localhost'
-    const port = external ? Number(dbPort.value) || undefined : undefined
+    const host = existing ? dbHost.value : 'localhost'
+    const port = existing ? Number(dbPort.value) || undefined : undefined
     if (dbType.value === 'postgres') {
       return {
         ...base,
         postgres_password: dbPassword.value,
         postgres_admin_user: resolvedDbUser.value,
-        postgres_external: external,
+        postgres_existing: existing,
         postgres_host: host,
         ...(port ? { postgres_port: port } : {}),
         mariadb_password: '',
@@ -323,7 +323,7 @@ export function useSetup() {
       ...base,
       mariadb_password: dbPassword.value,
       mariadb_admin_user: resolvedDbUser.value,
-      mariadb_external: external,
+      mariadb_existing: existing,
       mariadb_host: host,
       ...(port ? { mariadb_port: port } : {}),
       postgres_password: '',
@@ -383,7 +383,7 @@ export function useSetup() {
     dbType,
     dbUser,
     dbPassword,
-    useExternalDb,
+    useExistingDb,
     dbHost,
     dbPort,
     dbPortPlaceholder,

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -117,7 +117,7 @@
         </Button>
         <Button v-show="isConfiguring && currentStep === 'database'" variant="solid" :loading="isSubmitting"
           class="flex-1" @click="goToNextStep">
-          Next
+          Verify credentials
         </Button>
         <Button v-show="isConfiguring && currentStep !== 'passwords' && currentStep !== 'database' && !isLastConfigStep"
           variant="solid" class="flex-1" @click="goToNextStep">

--- a/admin/frontend/src/pages/Setup.vue
+++ b/admin/frontend/src/pages/Setup.vue
@@ -32,18 +32,17 @@
         <!-- Database -->
         <div v-show="currentStep === 'database'" class="flex flex-col gap-4">
           <Select label="Database engine" v-model="dbType" :options="dbTypeOptions" />
-          <Switch v-model="useExternalDb" label="Connect to an existing database server"
+          <Switch v-model="useExistingDb" label="Connect to an existing database server"
             description="Leave off to let pilot set up and manage its own user owned database server if not already present." />
-          <div v-show="useExternalDb" class="flex gap-4">
+          <div v-show="useExistingDb" class="flex gap-4">
             <TextInput class="flex-1" label="Host" v-model="dbHost" placeholder="db.example.com" />
             <TextInput class="w-28" label="Port" v-model="dbPort" :placeholder="dbPortPlaceholder" />
           </div>
-          <TextInput v-show="showRootUsername" :label="useExternalDb ? 'Username' : 'Root username'" v-model="dbUser"
+          <TextInput v-show="showRootUsername" label="Root username" v-model="dbUser"
             :placeholder="rootUserPlaceholder" />
           <div>
-            <Password :label="useExternalDb ? 'Password' : 'Root user password'" v-model="dbPassword"
-              placeholder="password" autocomplete="off" data-lpignore="true" data-1p-ignore data-bwignore
-              @keydown.enter="goToNextStep" />
+            <Password label="Root user password" v-model="dbPassword" placeholder="password" autocomplete="off"
+              data-lpignore="true" data-1p-ignore data-bwignore @keydown.enter="goToNextStep" />
             <p v-show="rootPasswordDescription" class="mt-1.5 text-ink-gray-6 text-p-sm">{{ rootPasswordDescription }}
             </p>
           </div>
@@ -164,7 +163,7 @@ const {
   dbType,
   dbUser,
   dbPassword,
-  useExternalDb,
+  useExistingDb,
   dbHost,
   dbPort,
   dbPortPlaceholder,

--- a/pilot/commands/init.py
+++ b/pilot/commands/init.py
@@ -154,7 +154,7 @@ class InitCommand(Command):
 
         pkg = get_package_manager()
 
-        # A bench runs exactly one engine; install/provision (or verify, if external) only that one.
+        # A bench runs exactly one engine; install/provision (or verify, if existing) only that one.
         if self.bench.config.db_type == "postgres":
             self._provision_or_verify(self._postgres_manager(), "PostgreSQL")
         elif self.bench.config.db_type == "sqlite":
@@ -167,14 +167,14 @@ class InitCommand(Command):
         PythonEnvManager(self.bench).ensure_python()
 
     def _provision_or_verify(self, manager, label: str) -> None:
-        if not manager.config.external:
+        if not manager.config.existing:
             manager.provision()
             return
         if not manager.check_credentials():
             from pilot.exceptions import BenchError
 
             raise BenchError(
-                f"Could not connect to external {label} server at "
+                f"Could not connect to existing {label} server at "
                 f"{manager.config.host}:{manager.config.port} as '{manager.config.admin_user}'. "
                 "Check the host, port, username, and password."
             )

--- a/pilot/config/bench_toml_builder.py
+++ b/pilot/config/bench_toml_builder.py
@@ -24,7 +24,7 @@ FLAT_KEYS = {
     "mariadb_admin_user": "mariadb.admin_user",
     "mariadb_socket_path": "mariadb.socket_path",
     "mariadb_host": "mariadb.host",
-    "mariadb_external": "mariadb.external",
+    "mariadb_existing": "mariadb.existing",
     # mariadb.port and postgres.port are deliberately NOT offset-managed
     # (not in _PORT_FIELDS): every bench for a given OS user shares the same
     # single MariaDB/PostgreSQL server, so their ports must stay identical
@@ -37,7 +37,7 @@ FLAT_KEYS = {
     "postgres_admin_user": "postgres.admin_user",
     "postgres_port": "postgres.port",
     "postgres_host": "postgres.host",
-    "postgres_external": "postgres.external",
+    "postgres_existing": "postgres.existing",
     "admin_enabled": "admin.enabled",
     "admin_password": "admin.password",
     "admin_domain": "admin.domain",

--- a/pilot/config/mariadb_config.py
+++ b/pilot/config/mariadb_config.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass
 
 @dataclass
 class MariaDBConfig:
-    # external is a deliberate user choice, never inferred from host (see MariaDBManager).
+    # existing is a deliberate user choice, never inferred from host (see MariaDBManager).
     host: str = "localhost"
     port: int = 3306
     root_password: str = ""
     admin_user: str = "root"
     socket_path: str = ""
-    external: bool = False
+    existing: bool = False

--- a/pilot/config/postgres_config.py
+++ b/pilot/config/postgres_config.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 
 @dataclass
 class PostgresConfig:
-    # external is a deliberate user choice, never inferred from host (see PostgresManager).
+    # existing is a deliberate user choice, never inferred from host (see PostgresManager).
     host: str = "localhost"
     port: int = 5432
     root_password: str = ""
     admin_user: str = "postgres"
-    external: bool = False
+    existing: bool = False

--- a/pilot/config/toml_writer.py
+++ b/pilot/config/toml_writer.py
@@ -37,7 +37,7 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append(f'root_password = "{m.root_password}"')
     parts.append(f'admin_user = "{m.admin_user}"')
     parts.append(f'socket_path = "{m.socket_path}"')
-    parts.append(f"external = {'true' if m.external else 'false'}")
+    parts.append(f"existing = {'true' if m.existing else 'false'}")
     parts.append("")
 
     pg = config.postgres
@@ -46,7 +46,7 @@ def bench_config_to_toml(config: BenchConfig) -> str:
     parts.append(f"port = {pg.port}")
     parts.append(f'root_password = "{pg.root_password}"')
     parts.append(f'admin_user = "{pg.admin_user}"')
-    parts.append(f"external = {'true' if pg.external else 'false'}")
+    parts.append(f"existing = {'true' if pg.existing else 'false'}")
     parts.append("")
 
     r = config.redis

--- a/tests/e2e/flows/wizard.py
+++ b/tests/e2e/flows/wizard.py
@@ -58,7 +58,7 @@ def complete_dev_wizard(
     if page.get_by_label("Root username").is_visible():
         page.get_by_label("Root username").fill(postgres_admin_user if db_type == "postgres" else "root")
     page.get_by_label("Root user password").fill(postgres_password if db_type == "postgres" else mariadb_password)
-    page.get_by_role("button", name="Next").click()
+    page.get_by_role("button", name="Verify credentials").click()
     # A wrong password surfaces inline and keeps us on this step.
     expect(page.get_by_text("Incorrect MariaDB credentials.")).to_be_hidden()
     expect(page.get_by_text("Incorrect PostgreSQL credentials.")).to_be_hidden()

--- a/tests/test_bench_toml_builder.py
+++ b/tests/test_bench_toml_builder.py
@@ -88,20 +88,20 @@ def test_current_port_offset_zero_when_file_invalid(tmp_path: Path) -> None:
     assert current_port_offset(toml_path) == 0
 
 
-# ── external database settings ───────────────────────────────────────────────
+# ── existing database settings ───────────────────────────────────────────────
 
 
-def test_mariadb_host_and_external_round_trip(tmp_path: Path) -> None:
-    settings = {"mariadb_external": True, "mariadb_host": "db.example.com", "mariadb_admin_user": "admin"}
+def test_mariadb_host_and_existing_round_trip(tmp_path: Path) -> None:
+    settings = {"mariadb_existing": True, "mariadb_host": "db.example.com", "mariadb_admin_user": "admin"}
     toml_path = tmp_path / "bench.toml"
     toml_path.write_text(BenchTomlBuilder("my-bench", settings).render())
 
     read_back = BenchTomlBuilder.read_settings(toml_path)
-    assert read_back["mariadb_external"] is True
+    assert read_back["mariadb_existing"] is True
     assert read_back["mariadb_host"] == "db.example.com"
 
 
-def test_external_defaults_to_false_when_unset(tmp_path: Path) -> None:
+def test_existing_defaults_to_false_when_unset(tmp_path: Path) -> None:
     data = _render(tmp_path)
-    assert data["mariadb"]["external"] is False
-    assert data["postgres"]["external"] is False
+    assert data["mariadb"]["existing"] is False
+    assert data["postgres"]["existing"] is False

--- a/tests/test_init_command.py
+++ b/tests/test_init_command.py
@@ -1,4 +1,4 @@
-"""InitCommand._provision_or_verify: external database handling."""
+"""InitCommand._provision_or_verify: existing database handling."""
 from __future__ import annotations
 
 from unittest.mock import MagicMock
@@ -15,7 +15,7 @@ def _command() -> InitCommand:
 
 def test_provisions_a_pilot_owned_server() -> None:
     manager = MagicMock()
-    manager.config.external = False
+    manager.config.existing = False
 
     _command()._provision_or_verify(manager, "MariaDB")
 
@@ -23,9 +23,9 @@ def test_provisions_a_pilot_owned_server() -> None:
     manager.check_credentials.assert_not_called()
 
 
-def test_verifies_credentials_for_an_external_server_without_provisioning() -> None:
+def test_verifies_credentials_for_an_existing_server_without_provisioning() -> None:
     manager = MagicMock()
-    manager.config.external = True
+    manager.config.existing = True
     manager.check_credentials.return_value = True
 
     _command()._provision_or_verify(manager, "MariaDB")
@@ -34,9 +34,9 @@ def test_verifies_credentials_for_an_external_server_without_provisioning() -> N
     manager.check_credentials.assert_called_once()
 
 
-def test_raises_when_external_credentials_are_wrong() -> None:
+def test_raises_when_existing_credentials_are_wrong() -> None:
     manager = MagicMock()
-    manager.config.external = True
+    manager.config.existing = True
     manager.config.host = "db.example.com"
     manager.config.port = 3306
     manager.config.admin_user = "admin"

--- a/tests/test_mariadb_manager.py
+++ b/tests/test_mariadb_manager.py
@@ -27,15 +27,15 @@ def test_socket_path_honors_explicit_value() -> None:
     assert MariaDBManager(MariaDBConfig(socket_path="/tmp/custom.sock")).socket_path() == "/tmp/custom.sock"
 
 
-# ── external ─────────────────────────────────────────────────────────────────
+# ── existing ─────────────────────────────────────────────────────────────────
 
 
-def test_external_defaults_to_false() -> None:
-    assert MariaDBConfig().external is False
+def test_existing_defaults_to_false() -> None:
+    assert MariaDBConfig().existing is False
 
 
-def test_external_is_not_inferred_from_host() -> None:
-    assert MariaDBConfig(host="db.example.com").external is False
+def test_existing_is_not_inferred_from_host() -> None:
+    assert MariaDBConfig(host="db.example.com").existing is False
 
 
 # ── install ──────────────────────────────────────────────────────────────────

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -15,15 +15,15 @@ def _mgr(**kwargs) -> PostgresManager:
     return PostgresManager(PostgresConfig(**kwargs))
 
 
-# ── external ─────────────────────────────────────────────────────────────────
+# ── existing ─────────────────────────────────────────────────────────────────
 
 
-def test_external_defaults_to_false() -> None:
-    assert PostgresConfig().external is False
+def test_existing_defaults_to_false() -> None:
+    assert PostgresConfig().existing is False
 
 
-def test_external_is_not_inferred_from_host() -> None:
-    assert PostgresConfig(host="db.example.com").external is False
+def test_existing_is_not_inferred_from_host() -> None:
+    assert PostgresConfig(host="db.example.com").existing is False
 
 
 # ── install ───────────────────────────────────────────────────────────────────

--- a/tests/test_setup_postgres.py
+++ b/tests/test_setup_postgres.py
@@ -25,37 +25,37 @@ def test_validate_requires_mariadb_password() -> None:
     assert error and "mariadb_password" in error
 
 
-def test_validate_requires_host_for_external_mariadb() -> None:
-    data = {"admin_password": "x", "db_type": "mariadb", "mariadb_password": "pw", "mariadb_external": True}
+def test_validate_requires_host_for_existing_mariadb() -> None:
+    data = {"admin_password": "x", "db_type": "mariadb", "mariadb_password": "pw", "mariadb_existing": True}
     error = _validate(data)
     assert error and "mariadb_host" in error
 
 
-def test_validate_requires_admin_user_for_external_mariadb() -> None:
+def test_validate_requires_admin_user_for_existing_mariadb() -> None:
     data = {
         "admin_password": "x",
         "db_type": "mariadb",
         "mariadb_password": "pw",
-        "mariadb_external": True,
+        "mariadb_existing": True,
         "mariadb_host": "db.example.com",
     }
     error = _validate(data)
     assert error and "mariadb_admin_user" in error
 
 
-def test_validate_accepts_complete_external_mariadb() -> None:
+def test_validate_accepts_complete_existing_mariadb() -> None:
     data = {
         "admin_password": "x",
         "db_type": "mariadb",
         "mariadb_password": "pw",
-        "mariadb_external": True,
+        "mariadb_existing": True,
         "mariadb_host": "db.example.com",
         "mariadb_admin_user": "admin",
     }
     assert _validate(data) is None
 
 
-def test_validate_ignores_host_when_not_marked_external() -> None:
+def test_validate_ignores_host_when_not_marked_existing() -> None:
     data = {"admin_password": "x", "db_type": "mariadb", "mariadb_password": "pw", "mariadb_host": "db.example.com"}
     assert _validate(data) is None
 


### PR DESCRIPTION
## Summary
Follow-up to #199 (already merged).

- Root password field now describes three distinct cases: fresh install, reusing pilot's own already-provisioned server, or an external server — the "reuse pilot's own server" case previously showed no description, easy to confuse with the external case.
- Turning on "Connect to an existing database server" now prefills host/port with 127.0.0.1 and the engine's default port instead of leaving them blank.
- Database step's button now reads "Verify credentials" instead of "Next", since it always validates against the server before advancing.

## Test plan
- [x] `pytest tests/` (851 passed)
- [ ] Manual: open setup wizard, toggle the external DB switch, confirm host/port prefill and button label