### PR TITLE
fix: e2e (postgres) always red since the user-owned DB refactor, and failed wizard runs holding CI for 45 minutes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install PostgreSQL
         if: matrix.db_type == 'postgres'
         run: |
-          sudo apt-get install -y postgresql postgresql-client libpq-dev
+          sudo apt-get install -y postgresql postgresql-client libpq-dev libmariadb-dev
           # Same as MariaDB above: bench provisions its own rootless server.
           sudo systemctl disable --now postgresql
 

--- a/pilot/managers/postgres_manager.py
+++ b/pilot/managers/postgres_manager.py
@@ -16,6 +16,8 @@ from pilot.utils import run_command
 # per-bench units.
 _STATE_DIR = Path.home() / ".local" / "share" / "pilot" / "postgres"
 
+_DEBIAN_POSTGRES_ROOT = Path("/usr/lib/postgresql")
+
 
 class PostgresManager(UserOwnedDBManager):
     """Manage the single, per-bench-user PostgreSQL server. Every bench for a
@@ -97,7 +99,7 @@ class PostgresManager(UserOwnedDBManager):
             # No --username: the bootstrap superuser matches whoever runs
             # initdb (the bench user), authenticated via unix-socket peer
             # auth — no sudo, no OS-level 'postgres' account involved.
-            run_command(["initdb", "-D", str(self.data_dir())])
+            run_command([self._server_binary("initdb"), "-D", str(self.data_dir())])
             self._install_unit()
             run_command(
                 self._systemctl("enable", "--now", self._UNIT_NAME), env=self._systemctl_env()
@@ -121,7 +123,7 @@ class PostgresManager(UserOwnedDBManager):
         )
 
     def _install_unit(self) -> None:
-        postgres = which("postgres") or "/usr/lib/postgresql/bin/postgres"
+        postgres = self._server_binary("postgres")
         content = (
             "[Unit]\n"
             "Description=PostgreSQL (pilot, user-owned)\n\n"
@@ -233,6 +235,22 @@ class PostgresManager(UserOwnedDBManager):
             )
             return result.returncode == 0
         return self.is_running()
+
+    def _server_binary(self, name: str) -> str:
+        found = which(name)
+        if found:
+            return found
+        candidates = sorted(
+            _DEBIAN_POSTGRES_ROOT.glob(f"*/bin/{name}"), key=self._debian_version_key
+        )
+        if candidates:
+            return str(candidates[-1])
+        return name
+
+    @staticmethod
+    def _debian_version_key(binary: Path) -> tuple[int, ...]:
+        version = binary.parent.parent.name
+        return tuple(int(part) for part in version.split(".") if part.isdigit())
 
     def _psql(self) -> str | None:
         found = which("psql")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ admin = ["flask>=3.0", "psutil>=5.9", "pymysql>=1.1", "gunicorn>=21.2", "boto3==
 test = ["pytest>=8.0", "pytest-cov>=5.0", "requests>=2.31"]
 # Browser-driven admin-UI lifecycle tests (tests/e2e). pytest-playwright pulls
 # in pytest + playwright; run `playwright install chromium` after installing.
-e2e = ["pytest>=8.0", "pytest-playwright>=0.5", "playwright>=1.40"]
+e2e = ["pytest>=8.0", "pytest-playwright>=0.5", "playwright>=1.51"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/e2e/flows/wizard.py
+++ b/tests/e2e/flows/wizard.py
@@ -84,7 +84,7 @@ def complete_dev_wizard(
     # locator times out 45 minutes later.
     ready = page.get_by_text("Your bench is ready.")
     failed = page.get_by_role("button", name="Back to configuration")
-    expect(ready.or_(failed).first).to_be_visible(timeout=SETUP_TIMEOUT_MS)
+    expect(ready.or_(failed).filter(visible=True).first).to_be_visible(timeout=SETUP_TIMEOUT_MS)
 
     if failed.is_visible():
         raise WizardSetupError(_wizard_error_text(page))

--- a/tests/test_postgres_manager.py
+++ b/tests/test_postgres_manager.py
@@ -218,6 +218,7 @@ def test_provision_user_owned_initialises_and_installs_unit_when_fresh(tmp_path)
          patch.object(m, "_ensure_port_available"), \
          patch.object(m, "is_running", return_value=False), \
          patch.object(m, "_install_unit") as install_unit, \
+         patch.object(m, "_server_binary", side_effect=lambda name: name), \
          patch(f"{MODULE}.run_command") as rc:
         m._provision_user_owned()
     install_unit.assert_called_once()
@@ -285,6 +286,38 @@ def test_run_sql_as_superuser_uses_default_socket_on_macos() -> None:
         m._run_sql_as_superuser("SELECT 1;")
     cmd = run.call_args[0][0]
     assert "-h" not in cmd
+
+
+def test_server_binary_prefers_path() -> None:
+    with patch(f"{MODULE}.which", return_value="/usr/bin/initdb"):
+        assert _mgr()._server_binary("initdb") == "/usr/bin/initdb"
+
+
+def test_server_binary_falls_back_to_newest_debian_versioned_dir(tmp_path) -> None:
+    for version in ("9.6", "16", "17"):
+        bin_dir = tmp_path / version / "bin"
+        bin_dir.mkdir(parents=True)
+        (bin_dir / "initdb").touch()
+    with patch(f"{MODULE}.which", return_value=None), \
+         patch(f"{MODULE}._DEBIAN_POSTGRES_ROOT", tmp_path):
+        assert _mgr()._server_binary("initdb") == str(tmp_path / "17" / "bin" / "initdb")
+
+
+def test_server_binary_returns_bare_name_when_missing(tmp_path) -> None:
+    with patch(f"{MODULE}.which", return_value=None), \
+         patch(f"{MODULE}._DEBIAN_POSTGRES_ROOT", tmp_path / "missing"):
+        assert _mgr()._server_binary("initdb") == "initdb"
+
+
+def test_install_unit_execstart_uses_resolved_postgres_binary(tmp_path) -> None:
+    m = _mgr(port=5440)
+    with patch.object(m, "unit_path", return_value=tmp_path / "pilot-postgres.service"), \
+         patch.object(m, "_server_binary", return_value="/usr/lib/postgresql/17/bin/postgres"), \
+         patch.object(m, "_user_unit_dir", return_value=tmp_path), \
+         patch(f"{MODULE}.run_command"):
+        m._install_unit()
+    content = (tmp_path / "pilot-postgres.service").read_text()
+    assert "ExecStart=/usr/lib/postgresql/17/bin/postgres " in content
 
 
 def test_install_unit_pins_unix_socket_directories_to_owned_dir(tmp_path) -> None:


### PR DESCRIPTION
Two commits, two related CI fixes: the first makes `e2e (postgres)` pass again, the second makes any future setup failure fail the suite in seconds instead of 45 minutes.

## Commit 1 — postgres provisioning: `initdb` is never on PATH on Debian/Ubuntu

Every `e2e (postgres)` CI run has failed since the user-owned DB refactor (2a785bce) landed on July 14, while `e2e (mariadb)` passes. The setup wizard dies at **Install system packages** with:

```
FileNotFoundError: [Errno 2] No such file or directory: 'initdb'
```

Debian/Ubuntu install postgres server binaries (`initdb`, `postgres`) under `/usr/lib/postgresql/<version>/bin`, which is never on PATH — only client tools like `psql` get `/usr/bin` shims via postgresql-common. So `is_installed()` returns True (finds `/usr/bin/psql`), install is skipped, and `_provision_user_owned()` execs bare `initdb` → `FileNotFoundError`, deterministically. The pre-refactor provisioning used Debian's cluster tooling (`pg_createcluster`), which *is* on PATH — that's why postgres e2e used to pass.

The same bug sat one step further down: `_install_unit()` fell back to `/usr/lib/postgresql/bin/postgres`, a path that never exists (missing the version segment), so fixing `initdb` alone would just move the crash into the systemd unit.

**Fix**: `PostgresManager._server_binary()` resolves a server binary via `which()` first, then the newest `/usr/lib/postgresql/*/bin/<name>`. Used for both the `initdb` invocation and the unit file's `ExecStart`. macOS is unaffected (Homebrew puts everything on PATH, so `which()` still wins there).

**Tests**: `_server_binary` prefers PATH, falls back to the newest versioned Debian dir (numeric sort, so 16/17 beat 9.6), returns the bare name when nothing is found; `_install_unit` writes the resolved binary into `ExecStart`. `tests/test_postgres_manager.py`: 34 passed; related suites (init command, wizard task, postgres setup/settings, managers): 75 passed.

## Commit 2 — e2e wizard: failed setups burn the full 45-minute timeout

`complete_dev_wizard()` intends to fail fast on setup failure:

```python
expect(ready.or_(failed).first).to_be_visible(timeout=SETUP_TIMEOUT_MS)
```

It doesn't. Setup.vue renders every step with `v-show`, so **both** terminal states are always in the DOM, merely hidden. `.first` pins the combined locator to the DOM-first match — the (hidden) "Your bench is ready." paragraph — and `to_be_visible()` retries against that one element until the timeout, never considering the failure button that's visible on screen. [Run 29485149917](https://github.com/frappe/pilot/actions/runs/29485149917) (`e2e (postgres)`) shows it: the setup task crashed in the first minute, yet the job held the runner for 45 more:

```
Expect "to_be_visible" with timeout 2700000ms
5351 × locator resolved to <p ...> Your bench is ready. ...</p>
      - unexpected value "hidden"
```

**Fix**: filter the combined locator to visible elements before taking `.first`. `Locator.filter(visible=...)` landed in Playwright 1.51, so the `e2e` extra's floor moves from `>=1.40` to `>=1.51` (CI installs latest anyway; this keeps the pin honest).

**Verification**: ran a real chromium check against markup replicating both `v-show` terminal states — the old locator times out on the failure state (reproducing the CI hang), the fixed one resolves immediately in both failure and success states.

Closes #208 (folded in here as the second commit).