### PR TITLE
fix: e2e wizard test burns the full 45-minute timeout instead of failing fast

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ admin = ["flask>=3.0", "psutil>=5.9", "pymysql>=1.1", "gunicorn>=21.2", "boto3==
 test = ["pytest>=8.0", "pytest-cov>=5.0", "requests>=2.31"]
 # Browser-driven admin-UI lifecycle tests (tests/e2e). pytest-playwright pulls
 # in pytest + playwright; run `playwright install chromium` after installing.
-e2e = ["pytest>=8.0", "pytest-playwright>=0.5", "playwright>=1.40"]
+e2e = ["pytest>=8.0", "pytest-playwright>=0.5", "playwright>=1.51"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/e2e/flows/wizard.py
+++ b/tests/e2e/flows/wizard.py
@@ -84,7 +84,7 @@ def complete_dev_wizard(
     # locator times out 45 minutes later.
     ready = page.get_by_text("Your bench is ready.")
     failed = page.get_by_role("button", name="Back to configuration")
-    expect(ready.or_(failed).first).to_be_visible(timeout=SETUP_TIMEOUT_MS)
+    expect(ready.or_(failed).filter(visible=True).first).to_be_visible(timeout=SETUP_TIMEOUT_MS)
 
     if failed.is_visible():
         raise WizardSetupError(_wizard_error_text(page))


### PR DESCRIPTION
## Problem

`complete_dev_wizard()` intends to fail fast when setup fails:

```python
ready = page.get_by_text("Your bench is ready.")
failed = page.get_by_role("button", name="Back to configuration")
expect(ready.or_(failed).first).to_be_visible(timeout=SETUP_TIMEOUT_MS)
```

It doesn't. Setup.vue renders every step with `v-show`, so **both** terminal states are always in the DOM, merely hidden. `.first` pins the combined locator to the DOM-first match — the (hidden) "Your bench is ready." paragraph — and `to_be_visible()` retries against that one element until the timeout expires, never considering the failure button that's visible on screen the whole time.

CI shows exactly this: in [run 29485149917](https://github.com/frappe/pilot/actions/runs/29485149917) (`e2e (postgres)`), the setup task crashed in the first minute, the "Back to configuration" button was visible, and the test still held the runner for the full 45 minutes:

```
Expect "to_be_visible" with timeout 2700000ms
5351 × locator resolved to <p ...> Your bench is ready. ...</p>
      - unexpected value "hidden"
```

Every failed wizard run costs ~50 minutes of CI per matrix job instead of seconds.

## Fix

Filter the combined locator to visible elements before taking `.first`:

```python
expect(ready.or_(failed).filter(visible=True).first).to_be_visible(timeout=SETUP_TIMEOUT_MS)
```

`Locator.filter(visible=...)` landed in Playwright 1.51, so the `e2e` extra's floor moves from `>=1.40` to `>=1.51` (CI always installs latest anyway; this just keeps the pin honest).

## Verification

Ran a real chromium check against markup mimicking Setup.vue's two `v-show` terminal states:

- old locator, failure state: **timed out** (reproduces the CI hang)
- new locator, failure state: resolves **immediately**
- new locator, success state: resolves **immediately**

This pairs with #207 (which fixes the underlying postgres provisioning crash) — with both, a genuinely broken setup fails the suite in seconds instead of 45 minutes.