### PR TITLE
feat(dev): Enable hot reload by default on dev benches

### DIFF
--- a/pilot/config/bench.py
+++ b/pilot/config/bench.py
@@ -39,7 +39,7 @@ class BenchConfig:
     http_port: int = 8000
     socketio_port: int = 9000
     socketio_backend: str = "node"
-    watch_apps_js: bool = True
+    watch_apps_js: bool = False
     reload_python: bool = True
     watch_admin_js: bool = False
     # The single database engine for this bench's sites: "mariadb" or "postgres".
@@ -96,7 +96,7 @@ class BenchConfig:
             http_port=bench_data.get("http_port", 8000),
             socketio_port=bench_data.get("socketio_port", 9000),
             socketio_backend=bench_data.get("socketio_backend", "node"),
-            watch_apps_js=bench_data.get("watch_apps_js", True),
+            watch_apps_js=bench_data.get("watch_apps_js", False),
             reload_python=bench_data.get("reload_python", True),
             watch_admin_js=bench_data.get("watch_admin_js", False),
             db_type=bench_data.get("db_type", "mariadb"),

--- a/pilot/config/bench.py
+++ b/pilot/config/bench.py
@@ -39,8 +39,8 @@ class BenchConfig:
     http_port: int = 8000
     socketio_port: int = 9000
     socketio_backend: str = "node"
-    watch_apps_js: bool = False
-    reload_python: bool = False
+    watch_apps_js: bool = True
+    reload_python: bool = True
     watch_admin_js: bool = False
     # The single database engine for this bench's sites: "mariadb" or "postgres".
     db_type: str = "mariadb"
@@ -96,8 +96,8 @@ class BenchConfig:
             http_port=bench_data.get("http_port", 8000),
             socketio_port=bench_data.get("socketio_port", 9000),
             socketio_backend=bench_data.get("socketio_backend", "node"),
-            watch_apps_js=bench_data.get("watch_apps_js", False),
-            reload_python=bench_data.get("reload_python", False),
+            watch_apps_js=bench_data.get("watch_apps_js", True),
+            reload_python=bench_data.get("reload_python", True),
             watch_admin_js=bench_data.get("watch_admin_js", False),
             db_type=bench_data.get("db_type", "mariadb"),
             default_branch=bench_data.get("default_branch", ""),

--- a/pilot/config/bench.py
+++ b/pilot/config/bench.py
@@ -39,7 +39,7 @@ class BenchConfig:
     http_port: int = 8000
     socketio_port: int = 9000
     socketio_backend: str = "node"
-    watch_apps_js: bool = False
+    watch_apps_js: bool = True
     reload_python: bool = True
     watch_admin_js: bool = False
     # The single database engine for this bench's sites: "mariadb" or "postgres".
@@ -96,7 +96,7 @@ class BenchConfig:
             http_port=bench_data.get("http_port", 8000),
             socketio_port=bench_data.get("socketio_port", 9000),
             socketio_backend=bench_data.get("socketio_backend", "node"),
-            watch_apps_js=bench_data.get("watch_apps_js", False),
+            watch_apps_js=bench_data.get("watch_apps_js", True),
             reload_python=bench_data.get("reload_python", True),
             watch_admin_js=bench_data.get("watch_admin_js", False),
             db_type=bench_data.get("db_type", "mariadb"),

--- a/pilot/managers/processes/local.py
+++ b/pilot/managers/processes/local.py
@@ -57,6 +57,7 @@ class ProcessDefinition:
     env: dict = field(default_factory=dict)
     working_dir: Path | None = None  # was `cd {dir} &&`
     stop_timeout: int | None = None  # graceful-stop seconds (redis=300, web+companion=1600)
+    critical: bool = True  # dev runner stops the whole bench when this process exits
 
 
 class ProcessManager:
@@ -207,12 +208,18 @@ class ProcessManager:
             (self.bench.pids_path / f"{pd.name}.pid").write_text(str(proc.pid))
             threading.Thread(target=self._stream, args=(pd.name, proc, color), daemon=True).start()
 
+        is_critical = {pd.name: pd.critical for pd in defs}
         while not self._stopping:
             for name, proc in list(self._procs.items()):
-                if proc.poll() is not None:
+                if proc.poll() is None:
+                    continue
+                if is_critical[name]:
                     print(f"[{name}] exited with code {proc.returncode}", file=sys.stderr)
                     self._stopping = True
                     break
+                print(f"[{name}] exited with code {proc.returncode}; continuing without it", file=sys.stderr)
+                del self._procs[name]
+                (self.bench.pids_path / f"{name}.pid").unlink(missing_ok=True)
             if not self._stopping:
                 time.sleep(0.5)
 
@@ -336,11 +343,14 @@ class ProcessManager:
         )
 
     def _watch_definition(self) -> ProcessDefinition:
+        # Non-critical: frappe watch dies when the initial esbuild build fails
+        # (e.g. unbuilt assets on a fresh bench); the bench must outlive it.
         return ProcessDefinition(
             name="watch",
             argv=[str(self.python), "-m", "frappe.utils.bench_helper", "frappe", "watch"],
             log_file=self.bench.logs_path / "watch.log",
             working_dir=self.bench.sites_path,
+            critical=False,
         )
 
     def _worker_pool_definition(self, queues: str, num_workers: int) -> ProcessDefinition:

--- a/tests/pilot/config/test_config.py
+++ b/tests/pilot/config/test_config.py
@@ -78,16 +78,16 @@ def test_config_without_apps_is_valid() -> None:
     assert config.apps == []
 
 
-def test_watch_apps_js_defaults_to_disabled() -> None:
+def test_watch_apps_js_defaults_to_enabled() -> None:
     config = load_from_dict(copy.deepcopy(MINIMAL_VALID_DATA))
-    assert config.watch_apps_js is False
-
-
-def test_watch_apps_js_can_be_enabled() -> None:
-    data = copy.deepcopy(MINIMAL_VALID_DATA)
-    data["bench"]["watch_apps_js"] = True
-    config = load_from_dict(data)
     assert config.watch_apps_js is True
+
+
+def test_watch_apps_js_can_be_disabled() -> None:
+    data = copy.deepcopy(MINIMAL_VALID_DATA)
+    data["bench"]["watch_apps_js"] = False
+    config = load_from_dict(data)
+    assert config.watch_apps_js is False
 
 
 def test_toml_writer_includes_watch_apps_js() -> None:
@@ -97,16 +97,16 @@ def test_toml_writer_includes_watch_apps_js() -> None:
     assert "watch_apps_js = true" in toml
 
 
-def test_reload_python_defaults_to_disabled() -> None:
+def test_reload_python_defaults_to_enabled() -> None:
     config = load_from_dict(copy.deepcopy(MINIMAL_VALID_DATA))
-    assert config.reload_python is False
-
-
-def test_reload_python_can_be_enabled() -> None:
-    data = copy.deepcopy(MINIMAL_VALID_DATA)
-    data["bench"]["reload_python"] = True
-    config = load_from_dict(data)
     assert config.reload_python is True
+
+
+def test_reload_python_can_be_disabled() -> None:
+    data = copy.deepcopy(MINIMAL_VALID_DATA)
+    data["bench"]["reload_python"] = False
+    config = load_from_dict(data)
+    assert config.reload_python is False
 
 
 def test_toml_writer_includes_reload_python() -> None:

--- a/tests/pilot/config/test_config.py
+++ b/tests/pilot/config/test_config.py
@@ -78,16 +78,16 @@ def test_config_without_apps_is_valid() -> None:
     assert config.apps == []
 
 
-def test_watch_apps_js_defaults_to_enabled() -> None:
+def test_watch_apps_js_defaults_to_disabled() -> None:
     config = load_from_dict(copy.deepcopy(MINIMAL_VALID_DATA))
-    assert config.watch_apps_js is True
-
-
-def test_watch_apps_js_can_be_disabled() -> None:
-    data = copy.deepcopy(MINIMAL_VALID_DATA)
-    data["bench"]["watch_apps_js"] = False
-    config = load_from_dict(data)
     assert config.watch_apps_js is False
+
+
+def test_watch_apps_js_can_be_enabled() -> None:
+    data = copy.deepcopy(MINIMAL_VALID_DATA)
+    data["bench"]["watch_apps_js"] = True
+    config = load_from_dict(data)
+    assert config.watch_apps_js is True
 
 
 def test_toml_writer_includes_watch_apps_js() -> None:

--- a/tests/pilot/config/test_config.py
+++ b/tests/pilot/config/test_config.py
@@ -78,16 +78,16 @@ def test_config_without_apps_is_valid() -> None:
     assert config.apps == []
 
 
-def test_watch_apps_js_defaults_to_disabled() -> None:
+def test_watch_apps_js_defaults_to_enabled() -> None:
     config = load_from_dict(copy.deepcopy(MINIMAL_VALID_DATA))
-    assert config.watch_apps_js is False
-
-
-def test_watch_apps_js_can_be_enabled() -> None:
-    data = copy.deepcopy(MINIMAL_VALID_DATA)
-    data["bench"]["watch_apps_js"] = True
-    config = load_from_dict(data)
     assert config.watch_apps_js is True
+
+
+def test_watch_apps_js_can_be_disabled() -> None:
+    data = copy.deepcopy(MINIMAL_VALID_DATA)
+    data["bench"]["watch_apps_js"] = False
+    config = load_from_dict(data)
+    assert config.watch_apps_js is False
 
 
 def test_toml_writer_includes_watch_apps_js() -> None:

--- a/tests/pilot/core/test_core.py
+++ b/tests/pilot/core/test_core.py
@@ -330,12 +330,12 @@ def test_process_definitions_returns_correct_count(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
     # workers: default=2, short=1, long=1 => 4 worker processes
     # plus web, socketio, redis_cache, redis_queue = 4
-    # plus admin, watch (on by default in dev) = 2
-    # total = 10
+    # plus admin = 1
+    # total = 9
     process_manager = ProcessManager(bench)
     definitions = process_manager._process_definitions()
-    assert len(definitions) == 10
-    assert "watch" in [pd.name for pd in definitions]
+    assert len(definitions) == 9
+    assert "watch" not in [pd.name for pd in definitions]
     assert "admin-ui" not in [pd.name for pd in definitions]
 
 
@@ -343,23 +343,18 @@ def test_process_definitions_watch_admin_js_adds_vite_ui(tmp_path: Path) -> None
     bench = make_bench(tmp_path)
     definitions = ProcessManager(bench, watch_admin_js=True)._process_definitions()
     assert "admin-ui" in [pd.name for pd in definitions]
-    assert len(definitions) == 11
+    assert len(definitions) == 10
 
 
-def test_process_definitions_can_disable_app_watch(tmp_path: Path) -> None:
+def test_process_definitions_can_enable_app_watch(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
-    bench.config.watch_apps_js = False
+    bench.config.watch_apps_js = True
     definitions = ProcessManager(bench)._process_definitions()
-    assert "watch" not in [pd.name for pd in definitions]
-    assert len(definitions) == 9
-
-
-def test_watch_definition_runs_frappe_watch_in_sites(tmp_path: Path) -> None:
-    bench = make_bench(tmp_path)
-    definitions = ProcessManager(bench)._process_definitions()
+    assert "watch" in [pd.name for pd in definitions]
     watch = next(pd for pd in definitions if pd.name == "watch")
     assert "frappe watch" in shlex.join(watch.argv)
     assert watch.working_dir == bench.sites_path
+    assert len(definitions) == 10
 
 
 def test_process_definitions_worker_names_are_numbered(tmp_path: Path) -> None:
@@ -420,7 +415,7 @@ def test_honcho_generate_config_writes_procfile(tmp_path: Path) -> None:
     assert "web:" in content
     assert "socketio:" in content
     assert "worker_default_1:" in content
-    assert "watch:" in content
+    assert "watch:" not in content
     assert "redis_cache:" in content
 
 

--- a/tests/pilot/core/test_core.py
+++ b/tests/pilot/core/test_core.py
@@ -13,7 +13,7 @@ from pilot.core.app import App, RevisionPin
 from pilot.core.bench import Bench
 from pilot.core.site import Site
 from pilot.exceptions import BenchError
-from pilot.managers.processes.local import ProcessManager
+from pilot.managers.processes.local import ProcessDefinition, ProcessManager
 
 
 FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures"
@@ -330,12 +330,12 @@ def test_process_definitions_returns_correct_count(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
     # workers: default=2, short=1, long=1 => 4 worker processes
     # plus web, socketio, redis_cache, redis_queue = 4
-    # plus admin = 1
-    # total = 9
+    # plus admin, watch (on by default in dev) = 2
+    # total = 10
     process_manager = ProcessManager(bench)
     definitions = process_manager._process_definitions()
-    assert len(definitions) == 9
-    assert "watch" not in [pd.name for pd in definitions]
+    assert len(definitions) == 10
+    assert "watch" in [pd.name for pd in definitions]
     assert "admin-ui" not in [pd.name for pd in definitions]
 
 
@@ -343,18 +343,41 @@ def test_process_definitions_watch_admin_js_adds_vite_ui(tmp_path: Path) -> None
     bench = make_bench(tmp_path)
     definitions = ProcessManager(bench, watch_admin_js=True)._process_definitions()
     assert "admin-ui" in [pd.name for pd in definitions]
-    assert len(definitions) == 10
+    assert len(definitions) == 11
 
 
-def test_process_definitions_can_enable_app_watch(tmp_path: Path) -> None:
+def test_process_definitions_can_disable_app_watch(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
-    bench.config.watch_apps_js = True
+    bench.config.watch_apps_js = False
     definitions = ProcessManager(bench)._process_definitions()
-    assert "watch" in [pd.name for pd in definitions]
+    assert "watch" not in [pd.name for pd in definitions]
+    assert len(definitions) == 9
+
+
+def test_run_processes_survives_noncritical_exit(tmp_path: Path) -> None:
+    import time
+
+    bench = make_bench(tmp_path)
+    bench.create_directories()
+    log = tmp_path / "logs"
+    defs = [
+        ProcessDefinition(name="flaky", argv=["true"], log_file=log / "flaky.log", critical=False),
+        ProcessDefinition(name="main", argv=["sleep", "1.2"], log_file=log / "main.log"),
+    ]
+    started = time.monotonic()
+    ProcessManager(bench)._run_processes(defs)
+    assert time.monotonic() - started >= 1.0
+    assert not (bench.pids_path / "flaky.pid").exists()
+
+
+def test_watch_definition_is_noncritical_frappe_watch(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    definitions = ProcessManager(bench)._process_definitions()
     watch = next(pd for pd in definitions if pd.name == "watch")
     assert "frappe watch" in shlex.join(watch.argv)
     assert watch.working_dir == bench.sites_path
-    assert len(definitions) == 10
+    assert watch.critical is False
+    assert all(pd.critical for pd in definitions if pd.name != "watch")
 
 
 def test_process_definitions_worker_names_are_numbered(tmp_path: Path) -> None:
@@ -415,7 +438,7 @@ def test_honcho_generate_config_writes_procfile(tmp_path: Path) -> None:
     assert "web:" in content
     assert "socketio:" in content
     assert "worker_default_1:" in content
-    assert "watch:" not in content
+    assert "watch:" in content
     assert "redis_cache:" in content
 
 

--- a/tests/pilot/core/test_core.py
+++ b/tests/pilot/core/test_core.py
@@ -330,12 +330,12 @@ def test_process_definitions_returns_correct_count(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
     # workers: default=2, short=1, long=1 => 4 worker processes
     # plus web, socketio, redis_cache, redis_queue = 4
-    # plus admin = 1
-    # total = 9
+    # plus admin, watch (on by default in dev) = 2
+    # total = 10
     process_manager = ProcessManager(bench)
     definitions = process_manager._process_definitions()
-    assert len(definitions) == 9
-    assert "watch" not in [pd.name for pd in definitions]
+    assert len(definitions) == 10
+    assert "watch" in [pd.name for pd in definitions]
     assert "admin-ui" not in [pd.name for pd in definitions]
 
 
@@ -343,18 +343,23 @@ def test_process_definitions_watch_admin_js_adds_vite_ui(tmp_path: Path) -> None
     bench = make_bench(tmp_path)
     definitions = ProcessManager(bench, watch_admin_js=True)._process_definitions()
     assert "admin-ui" in [pd.name for pd in definitions]
-    assert len(definitions) == 10
+    assert len(definitions) == 11
 
 
-def test_process_definitions_can_enable_app_watch(tmp_path: Path) -> None:
+def test_process_definitions_can_disable_app_watch(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
-    bench.config.watch_apps_js = True
+    bench.config.watch_apps_js = False
     definitions = ProcessManager(bench)._process_definitions()
-    assert "watch" in [pd.name for pd in definitions]
+    assert "watch" not in [pd.name for pd in definitions]
+    assert len(definitions) == 9
+
+
+def test_watch_definition_runs_frappe_watch_in_sites(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    definitions = ProcessManager(bench)._process_definitions()
     watch = next(pd for pd in definitions if pd.name == "watch")
     assert "frappe watch" in shlex.join(watch.argv)
     assert watch.working_dir == bench.sites_path
-    assert len(definitions) == 10
 
 
 def test_process_definitions_worker_names_are_numbered(tmp_path: Path) -> None:
@@ -385,19 +390,19 @@ def test_process_definitions_order_starts_with_web(tmp_path: Path) -> None:
     assert definitions[0].name == "web"
 
 
-def test_dev_web_disables_python_reloader_by_default(tmp_path: Path) -> None:
+def test_dev_web_enables_python_reloader_by_default(tmp_path: Path) -> None:
     bench = make_bench(tmp_path)
-    web = ProcessManager(bench)._process_definitions()[0]
-    assert web.name == "web"
-    assert "--noreload" in web.argv
-
-
-def test_dev_web_can_enable_python_reloader(tmp_path: Path) -> None:
-    bench = make_bench(tmp_path)
-    bench.config.reload_python = True
     web = ProcessManager(bench)._process_definitions()[0]
     assert web.name == "web"
     assert "--noreload" not in web.argv
+
+
+def test_dev_web_can_disable_python_reloader(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    bench.config.reload_python = False
+    web = ProcessManager(bench)._process_definitions()[0]
+    assert web.name == "web"
+    assert "--noreload" in web.argv
 
 
 # ── ProcessManager tests ───────────────────────────────────────────────
@@ -415,7 +420,7 @@ def test_honcho_generate_config_writes_procfile(tmp_path: Path) -> None:
     assert "web:" in content
     assert "socketio:" in content
     assert "worker_default_1:" in content
-    assert "watch:" not in content
+    assert "watch:" in content
     assert "redis_cache:" in content
 
 


### PR DESCRIPTION
Fixes https://github.com/frappe/pilot/issues/211

Dev benches currently start the web server with `--noreload` and skip the `frappe watch` process unless `reload_python` / `watch_apps_js` are explicitly enabled in bench.toml, so every code edit needs a manual bench restart. Classic bench hot-reloads both by default in dev, and these flags are only consulted when building dev process definitions — the gunicorn/systemd/supervisor paths never read them — so defaulting them off only makes new benches surprising.

This flips both `reload_python` and `watch_apps_js` to default `true` (dataclass defaults and the `_from_dict` fallbacks). An explicit `false` in bench.toml still disables either flag, so existing benches that wrote `false` keep their behaviour. `watch_admin_js` stays off since it is only for developing the admin UI itself.

Defaulting `watch` on exposed a runner problem (it failed e2e in an earlier revision of this PR): `frappe watch` dies when its initial esbuild build fails (e.g. unbuilt assets on a fresh bench), and the dev runner stopped the whole bench — admin included — when any process exited. `ProcessDefinition` now carries a `critical` flag (default `true`); `watch` is the only non-critical process, so its death is logged (`[watch] exited with code N; continuing without it`) and the bench keeps running.

Tests: defaults pinned (no `--noreload`, `watch` in the default process list), override tests flipped to cover disabling, plus a runner test that a non-critical process exiting doesn't stop the bench and a definition test that only `watch` is non-critical.