### PR TITLE
rename: S3 Bucket to Object Storage in Settings modal

### DIFF
--- a/admin/frontend/src/components/settings/S3Bucket.vue
+++ b/admin/frontend/src/components/settings/S3Bucket.vue
@@ -3,10 +3,10 @@
     <span class="size-5 text-ink-gray-4 animate-spin lucide-loader-circle"></span>
   </div>
   <div v-else class="space-y-6">
-    <Alert v-if="!connected" theme="blue" title="Why connect S3?" :dismissible="false">
+    <Alert v-if="!connected" theme="blue" title="Why connect object storage?" :dismissible="false">
       <template #description>
         <p class="text-ink-gray-6 text-p-sm">
-          Connect an S3-compatible bucket to send offsite backups and snapshots.
+          Connect S3-compatible object storage to send offsite backups and snapshots.
         </p>
       </template>
     </Alert>
@@ -111,13 +111,13 @@ async function save() {
     })
     if (!result.error) {
       secretKey.value = ''
-      toast.success('S3 settings saved')
+      toast.success('Object storage settings saved')
       await load()
     } else {
-      error.value = apiErrorMessage(result, 'Could not save S3 settings.')
+      error.value = apiErrorMessage(result, 'Could not save object storage settings.')
     }
   } catch (e) {
-    error.value = e.message || 'Could not save S3 settings.'
+    error.value = e.message || 'Could not save object storage settings.'
   } finally {
     saving.value = false
   }
@@ -134,12 +134,12 @@ async function disconnect() {
       provider.value = providers.value[0]?.value || ''
       region.value = ''
       secretKeySet.value = false
-      toast.success('S3 disconnected')
+      toast.success('Object storage disconnected')
     } else {
-      toast.error(apiErrorMessage(result, 'Could not disconnect S3.'))
+      toast.error(apiErrorMessage(result, 'Could not disconnect object storage.'))
     }
   } catch (e) {
-    toast.error(e.message || 'Could not disconnect S3.')
+    toast.error(e.message || 'Could not disconnect object storage.')
   } finally {
     disconnecting.value = false
   }

--- a/admin/frontend/src/components/settings/SettingsDialog.vue
+++ b/admin/frontend/src/components/settings/SettingsDialog.vue
@@ -65,7 +65,7 @@ const isMobile = useIsMobile()
 const sections = computed(() => [
   { id: 'github', label: 'Git', icon: 'lucide-git-branch' },
   { id: 'workers', label: 'Workers', icon: 'lucide-server-cog' },
-  { id: 's3-bucket', label: 'S3 Bucket', icon: 'lucide-archive' },
+  { id: 's3-bucket', label: 'Object Storage', icon: 'lucide-archive' },
   { id: 'firewall', label: 'Firewall', icon: 'lucide-shield' },
   { id: 'waf', label: 'WAF', icon: 'lucide-shield-alert' },
   { id: 'ssh-keys', label: 'SSH Keys', icon: 'lucide-key-round' },


### PR DESCRIPTION
## Summary
- Renames the "S3 Bucket" label to "Object Storage" in the Settings modal (sidebar tab, alert title, help text, toast/error messages)
- Only user-facing strings changed - the `s3` API payload key, `S3Bucket.vue` filename, and internal `s3-bucket` section id are untouched

## Test plan
- [x] `npm run build` passes
- [ ] Open Settings modal, confirm "Object Storage" tab renders and connect/disconnect flows still work