### PR TITLE
fix: Unwrap errors and propagate & fix monitoring sudo calls.

### DIFF
--- a/admin/frontend/src/api/apps.js
+++ b/admin/frontend/src/api/apps.js
@@ -1,18 +1,8 @@
-import { apiErrorMessage, request } from './client'
-
-// ky is configured with throwHttpErrors: false, so an error response (e.g.
-// {"error": {...}}) resolves instead of rejecting - callers expecting an
-// array would otherwise silently get an error object. Throw here instead,
-// once, so every caller gets the real backend message.
-async function getOrThrow(path) {
-  const data = await request.get(path).json()
-  if (data?.error) throw new Error(apiErrorMessage(data))
-  return data
-}
+import { request, unwrap } from './client'
 
 export const appsApi = {
-  marketplace: () => getOrThrow('marketplace/apps'),
-  installed: () => getOrThrow('apps'),
+  marketplace: () => unwrap(request.get('marketplace/apps').json()),
+  installed: () => unwrap(request.get('apps').json()),
   fetchUpdates: () => request.post('apps/fetch').json(),
   add: (payload) => request.post('apps', { json: payload }).json(),
 }

--- a/admin/frontend/src/api/client.js
+++ b/admin/frontend/src/api/client.js
@@ -14,6 +14,12 @@ export function apiErrorMessage(payload, fallback = 'Request failed.') {
   return fallback
 }
 
+export async function unwrap(parsed) {
+  const data = await parsed
+  if (data?.error) throw new Error(apiErrorMessage(data))
+  return data
+}
+
 export const request = ky.create({
   prefix: API_V1_PREFIX,
   throwHttpErrors: false,

--- a/admin/frontend/src/api/sites.js
+++ b/admin/frontend/src/api/sites.js
@@ -1,4 +1,4 @@
-import { apiUrl, request } from './client'
+import { apiUrl, request, unwrap } from './client'
 
 export const sitesApi = {
   list: () => request.get('sites').json(),
@@ -6,8 +6,9 @@ export const sitesApi = {
   create: (payload) => request.post('sites', { json: payload }).json(),
   loginLink: (name) => request.post(`sites/${encodeURIComponent(name)}/login`).json(),
   configuration: {
-    get: (name) => request.get(`sites/${encodeURIComponent(name)}/configuration`).json(),
-    update: (name, patch) => request.patch(`sites/${encodeURIComponent(name)}/configuration`, { json: patch }).json(),
+    get: (name) => unwrap(request.get(`sites/${encodeURIComponent(name)}/configuration`).json()),
+    update: (name, patch) =>
+      unwrap(request.patch(`sites/${encodeURIComponent(name)}/configuration`, { json: patch }).json()),
   },
   enableTls: (name, email) => request.post(`sites/${encodeURIComponent(name)}/actions/enable-tls`, { json: email ? { email } : {} }).json(),
   clearCache: (name) => request.post(`sites/${encodeURIComponent(name)}/actions/clear-cache`).json(),

--- a/admin/frontend/src/utils/apiUrl.test.js
+++ b/admin/frontend/src/utils/apiUrl.test.js
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { API_V1_PREFIX, apiErrorMessage, apiUrl } from '../api/client.js'
+import { API_V1_PREFIX, apiErrorMessage, apiUrl, unwrap } from '../api/client.js'
 
 test('builds relative and cross-origin v1 API URLs', () => {
   assert.equal(API_V1_PREFIX, '/api/v1')
@@ -13,4 +13,15 @@ test('reads canonical and transitional API error messages', () => {
   assert.equal(apiErrorMessage({ error: { message: 'Invalid value.' } }), 'Invalid value.')
   assert.equal(apiErrorMessage({ error: 'Legacy error.' }), 'Legacy error.')
   assert.equal(apiErrorMessage({}, 'Try again.'), 'Try again.')
+})
+
+test('unwrap rethrows a resolved error body as a rejection', async () => {
+  await assert.rejects(
+    unwrap(Promise.resolve({ error: { message: 'System-managed and secret-like configuration keys cannot be changed.' } })),
+    { message: 'System-managed and secret-like configuration keys cannot be changed.' },
+  )
+})
+
+test('unwrap passes a successful payload through', async () => {
+  assert.deepEqual(await unwrap(Promise.resolve({ ssl: true })), { ssl: true })
 })

--- a/pilot/core/bench/setup.py
+++ b/pilot/core/bench/setup.py
@@ -144,11 +144,15 @@ class ProductionSetup:
         from pilot.core.server.monitoring import MonitorConfigurator, resolve_monitor_log_path
         from pilot.core.site.uptime_monitoring_config import UptimeMonitorConfigurator
 
-        MonitorConfigurator().install()
+        monitor = MonitorConfigurator(self.bench)
+        monitor.install()
         self.bench.config.monitor.log_path = resolve_monitor_log_path(self.bench.config)
         self.bench.config.write(self.bench.path)
+        monitor.setup()
 
-        UptimeMonitorConfigurator().install()
+        uptime = UptimeMonitorConfigurator(self.bench)
+        uptime.install()
+        uptime.setup()
 
     def _persist_production_state(self) -> None:
         """Write the production state to bench.toml LAST, so the switcher never

--- a/pilot/core/server/monitoring.py
+++ b/pilot/core/server/monitoring.py
@@ -33,7 +33,6 @@ class Monitor:
         self._targets: dict[str, int] | None = None
         self._cpu_before: tuple[dict[str, int], dict[int, int]] | None = None
         self._io_before: tuple[dict[str, int], dict[str, int]] | None = None
-        self._configurator.setup()
 
     def monitored_targets(self) -> dict[str, int]:
         if self._targets is None:

--- a/pilot/core/site/uptime_monitoring.py
+++ b/pilot/core/site/uptime_monitoring.py
@@ -25,7 +25,6 @@ class UptimeMonitor:
     def __init__(self, bench: "Bench"):
         self.bench = bench
         self._configurator = UptimeMonitorConfigurator(bench)
-        self._configurator.setup()
 
     def get_sites(self) -> list[str]:
         return [site.config.name for site in self.bench.sites()]

--- a/tests/pilot/commands/test_setup_production.py
+++ b/tests/pilot/commands/test_setup_production.py
@@ -189,6 +189,8 @@ def test_setup_monitoring_persists_log_path_to_toml(tmp_path: Path, monkeypatch)
 
     monkeypatch.setattr(MonitorConfigurator, "install", lambda self: None)
     monkeypatch.setattr(UptimeMonitorConfigurator, "install", lambda self: None)
+    monkeypatch.setattr(MonitorConfigurator, "setup", lambda self: None)
+    monkeypatch.setattr(UptimeMonitorConfigurator, "setup", lambda self: None)
 
     cmd._setup_monitoring()
 
@@ -207,11 +209,33 @@ def test_setup_monitoring_log_path_is_path_on_config(tmp_path: Path, monkeypatch
 
     monkeypatch.setattr(MonitorConfigurator, "install", lambda self: None)
     monkeypatch.setattr(UptimeMonitorConfigurator, "install", lambda self: None)
+    monkeypatch.setattr(MonitorConfigurator, "setup", lambda self: None)
+    monkeypatch.setattr(UptimeMonitorConfigurator, "setup", lambda self: None)
 
     cmd._setup_monitoring()
 
     assert isinstance(bench.config.monitor.log_path, Path)
     assert bench.config.monitor.log_path.name == f"{bench.config.name}-stats.log"
+
+
+def test_setup_monitoring_runs_privileged_setup_at_provision_time(tmp_path: Path, monkeypatch) -> None:
+    """Privileged log-dir/logrotate setup must run here, not in the user-service daemons."""
+    from pilot.core.server.monitoring import MonitorConfigurator
+    from pilot.core.site.uptime_monitoring_config import UptimeMonitorConfigurator
+
+    bench = _make_bench(tmp_path, process_manager="systemd")
+    bench.config.production.enabled = True
+    cmd = ProductionSetup(bench)
+
+    called = []
+    monkeypatch.setattr(MonitorConfigurator, "install", lambda self: None)
+    monkeypatch.setattr(UptimeMonitorConfigurator, "install", lambda self: None)
+    monkeypatch.setattr(MonitorConfigurator, "setup", lambda self: called.append("monitor"))
+    monkeypatch.setattr(UptimeMonitorConfigurator, "setup", lambda self: called.append("uptime"))
+
+    cmd._setup_monitoring()
+
+    assert called == ["monitor", "uptime"]
 
 
 def test_setup_letsencrypt_reraises_by_default(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
- Surface API errors on the site config page — unwrap() helper so throwHttpErrors: false responses reject instead of silently resolving; applied to sites.js config get/update; apps.js deduped.
- Move monitoring's privileged setup out of the daemons — dropped setup() from the Monitor/UptimeMonitor constructors (was running sudo every cycle in non-interactive user services) and run it at setup production time instead.
- Plus short Tests and Note (recover via re-running setup production) sections.