### PR TITLE
fix: Password less certbot & openssl

### DIFF
--- a/pilot/core/bench/production.py
+++ b/pilot/core/bench/production.py
@@ -79,6 +79,7 @@ class BenchProduction:
         letsencrypt_manager = LetsEncryptManager(self.bench)
         nginx_manager = NginxManager(self.bench)
         letsencrypt_manager.install()
+        letsencrypt_manager.setup_sudoers()
         letsencrypt_manager.ensure_webroot()
         nginx_manager.generate_config(ssl_ready=False)
         nginx_manager.reload()

--- a/pilot/managers/letsencrypt.py
+++ b/pilot/managers/letsencrypt.py
@@ -90,16 +90,26 @@ class LetsEncryptManager:
         openssl = which("openssl") or "/usr/bin/openssl"
         mkdir = which("mkdir") or "/bin/mkdir"
         webroot_path = self.bench.config.letsencrypt.webroot_path
+        hook = _nginx_reload_hook()
+        # Domain/cert-name/email tokens must stay wildcarded (new sites arrive after
+        # this grant is installed), but every wildcard here is anchored between fixed
+        # literal text on both sides - nothing can smuggle in extra flags (e.g. a
+        # different --deploy-hook, or openssl -out) before or after the match.
         install_sudoers_grant(
             self.bench.config_path / "letsencrypt",
             bench_user,
             "certbot",
             [
-                f"{certbot} certonly *",
-                f"{certbot} renew *",
+                # obtain(): multiple -d flags + --cert-name + --expand
+                f'{certbot} certonly --webroot -w {webroot_path} * --cert-name * '
+                f'--expand --email * --agree-tos --non-interactive --deploy-hook "{hook}"',
+                # obtain_admin(): single -d, no --cert-name/--expand
+                f'{certbot} certonly --webroot -w {webroot_path} -d * --email * '
+                f'--agree-tos --non-interactive --deploy-hook "{hook}"',
+                f"{certbot} renew --quiet",
                 f"{mkdir} -p {webroot_path}",
-                f"{openssl} x509 -noout -ext subjectAltName -in {LETSENCRYPT_LIVE}/*",
-                f"{openssl} x509 -enddate -noout -in {LETSENCRYPT_LIVE}/*",
+                f"{openssl} x509 -noout -ext subjectAltName -in {LETSENCRYPT_LIVE}/*/fullchain.pem",
+                f"{openssl} x509 -enddate -noout -in {LETSENCRYPT_LIVE}/*/fullchain.pem",
             ],
         )
 
@@ -108,7 +118,7 @@ class LetsEncryptManager:
         """True when the sudoers grant from `setup_sudoers` lets this user run
         certbot without a password prompt."""
         certbot = which("certbot") or "/usr/bin/certbot"
-        return has_passwordless_sudo_for([certbot, "renew", "--dry-run"])
+        return has_passwordless_sudo_for([certbot, "renew", "--quiet"])
 
     def ensure_webroot(self) -> None:
         # /var/www is root-owned, so create the webroot with sudo. Default 0755

--- a/pilot/managers/letsencrypt.py
+++ b/pilot/managers/letsencrypt.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import pwd
 import shutil
 from datetime import UTC
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from pilot.managers.nginx import LETSENCRYPT_LIVE
 from pilot.managers.packages import get_package_manager
-from pilot.managers.platform import _privileged
+from pilot.managers.platform import _privileged, which
+from pilot.managers.sudoers import has_passwordless_sudo_for, install_sudoers_grant
 from pilot.utils import run_command
 
 if TYPE_CHECKING:
@@ -78,6 +81,34 @@ class LetsEncryptManager:
     def install(self) -> None:
         if not self.is_installed():
             get_package_manager().install("certbot")
+
+    def setup_sudoers(self) -> None:
+        """Give certbot passwordless sudo for exactly the commands issuing and
+        renewing certs needs. Idempotent: same deterministic content every call."""
+        bench_user = pwd.getpwuid(self.bench.path.stat().st_uid).pw_name
+        certbot = which("certbot") or "/usr/bin/certbot"
+        openssl = which("openssl") or "/usr/bin/openssl"
+        mkdir = which("mkdir") or "/bin/mkdir"
+        webroot_path = self.bench.config.letsencrypt.webroot_path
+        install_sudoers_grant(
+            self.bench.config_path / "letsencrypt",
+            bench_user,
+            "certbot",
+            [
+                f"{certbot} certonly *",
+                f"{certbot} renew *",
+                f"{mkdir} -p {webroot_path}",
+                f"{openssl} x509 -noout -ext subjectAltName -in {LETSENCRYPT_LIVE}/*",
+                f"{openssl} x509 -enddate -noout -in {LETSENCRYPT_LIVE}/*",
+            ],
+        )
+
+    @property
+    def has_passwordless_sudo(self) -> bool:
+        """True when the sudoers grant from `setup_sudoers` lets this user run
+        certbot without a password prompt."""
+        certbot = which("certbot") or "/usr/bin/certbot"
+        return has_passwordless_sudo_for([certbot, "renew", "--dry-run"])
 
     def ensure_webroot(self) -> None:
         # /var/www is root-owned, so create the webroot with sudo. Default 0755

--- a/pilot/managers/nginx/__init__.py
+++ b/pilot/managers/nginx/__init__.py
@@ -17,11 +17,11 @@ from pilot.managers.platform import (
     _privileged,
     default_nginx_config_dir,
     is_linux,
-    is_root,
     service_command,
     service_running,
     which,
 )
+from pilot.managers.sudoers import has_passwordless_sudo_for, install_sudoers_grant, stage_and_copy
 from pilot.managers.waf import WafManager
 from pilot.utils import run_command
 
@@ -198,33 +198,30 @@ class NginxManager:
             get_package_manager().install("nginx")
 
     def setup_sudoers(self):
-        """Give nginx password less sudo access to allow reloads and other actions.
+        """Give nginx passwordless sudo for exactly the commands reload needs.
         Idempotent: same deterministic content every call."""
         bench_user = pwd.getpwuid(self.bench.path.stat().st_uid).pw_name
-        sudoers_file = Path(f"/etc/sudoers.d/{bench_user}-pilot-nginx")
         systemctl = which("systemctl") or "/bin/systemctl"
         nginx = which("nginx") or "/usr/sbin/nginx"
-        sudoers_content = (
-            f"{bench_user} ALL=(ALL) NOPASSWD: {nginx} -t,"
-            f"{nginx} -T,"
-            f"{systemctl} start nginx,"
-            f"{systemctl} stop nginx,"
-            f"{systemctl} reload nginx\n"
+        install_sudoers_grant(
+            self.bench.config_path / "nginx",
+            bench_user,
+            "nginx",
+            [
+                f"{nginx} -t",
+                f"{nginx} -T",
+                f"{systemctl} start nginx",
+                f"{systemctl} stop nginx",
+                f"{systemctl} reload nginx",
+            ],
         )
-        self._stage_and_copy(sudoers_content, sudoers_file, validate=["visudo", "-cf"])
-        run_command(_privileged(["chmod", "440", str(sudoers_file)]))
 
     @property
     def has_passwordless_sudo(self) -> bool:
         """True when the sudoers grant from `setup_sudoers` lets this user run
         nginx commands without a password prompt."""
-        if is_root():
-            return True
-        if which("sudo") is None:
-            return False
         nginx = which("nginx") or "/usr/sbin/nginx"
-        result = subprocess.run(["sudo", "-n", "-l", nginx, "-t"], capture_output=True, timeout=5)
-        return result.returncode == 0
+        return has_passwordless_sudo_for([nginx, "-t"])
 
     def generate_config(self, ssl_ready: bool = False) -> None:
         nginx_dir = self.bench.config_path / "nginx"
@@ -342,16 +339,8 @@ class NginxManager:
         self._stage_and_copy(config, target)
 
     def _stage_and_copy(self, content: str, target: Path, validate: list[str] | None = None) -> None:
-        """Sudo-copy content into a root-owned target via a bench-owned staging file.
-        `validate`, if given, is a command run against the staged file before it's
-        copied into place - e.g. ["visudo", "-cf"] to catch bad sudoers syntax."""
-        staged = self.bench.config_path / "nginx" / target.name
-        staged.parent.mkdir(parents=True, exist_ok=True)
-        staged.write_text(content)
-        if validate:
-            run_command(_privileged([*validate, str(staged)]))
-        run_command(_privileged(["cp", str(staged), str(target)]))
-        staged.unlink()
+        """Sudo-copy content into a root-owned target via a bench-owned staging file."""
+        stage_and_copy(self.bench.config_path / "nginx", content, target, validate)
 
     def _ensure_modsecurity_module(self) -> None:
         """Debian auto-enables the module; elsewhere inject a load_module line.

--- a/pilot/managers/sudoers.py
+++ b/pilot/managers/sudoers.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pilot.managers.platform import _privileged
+from pilot.utils import run_command
+
+
+def stage_and_copy(stage_dir: Path, content: str, target: Path, validate: list[str] | None = None) -> None:
+    """Sudo-copy content into a root-owned target via a caller-owned staging file.
+    `validate`, if given, is a command run against the staged file before it's
+    copied into place - e.g. ["visudo", "-cf"] to catch bad sudoers syntax."""
+    staged = stage_dir / target.name
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    staged.write_text(content)
+    if validate:
+        run_command(_privileged([*validate, str(staged)]))
+    run_command(_privileged(["cp", str(staged), str(target)]))
+    staged.unlink()
+
+
+def install_sudoers_grant(stage_dir: Path, bench_user: str, name: str, commands: list[str]) -> None:
+    """Give bench_user passwordless sudo for exactly `commands`, no more.
+    Idempotent: same deterministic content every call."""
+    sudoers_file = Path(f"/etc/sudoers.d/{bench_user}-pilot-{name}")
+    content = f"{bench_user} ALL=(ALL) NOPASSWD: " + ",".join(commands) + "\n"
+    stage_and_copy(stage_dir, content, sudoers_file, validate=["visudo", "-cf"])
+    run_command(_privileged(["chmod", "440", str(sudoers_file)]))
+
+
+def has_passwordless_sudo_for(command: list[str]) -> bool:
+    """True when `sudo -n -l <command>` shows it's grantable without a password prompt."""
+    import subprocess
+
+    from pilot.managers.platform import is_root, which
+
+    if is_root():
+        return True
+    if which("sudo") is None:
+        return False
+    result = subprocess.run(["sudo", "-n", "-l", *command], capture_output=True, timeout=5)
+    return result.returncode == 0

--- a/tests/pilot/managers/test_letsencrypt.py
+++ b/tests/pilot/managers/test_letsencrypt.py
@@ -36,10 +36,17 @@ def test_setup_sudoers_grants_only_certbot_and_cert_reads(tmp_path: Path) -> Non
     assert mock_stage.call_args.kwargs == {"validate": ["visudo", "-cf"]}
     assert target == sudoers_file
     assert "runner ALL=(ALL) NOPASSWD:" in content
-    assert "certbot certonly *," in content
-    assert "certbot renew *," in content
+    # no bare trailing wildcard anywhere - every "*" is anchored by fixed text
+    # on both sides, so nothing can be appended or substituted after a match.
+    for clause in content.removeprefix("runner ALL=(ALL) NOPASSWD: ").rstrip("\n").split(","):
+        assert not clause.rstrip().endswith("*"), f"unanchored trailing wildcard: {clause!r}"
+    assert 'certonly --webroot -w /var/www/letsencrypt * --cert-name * --expand --email *' in content
+    assert '--deploy-hook "systemctl reload nginx"' in content
+    assert "certonly --webroot -w /var/www/letsencrypt -d * --email *" in content
+    assert "certbot renew --quiet," in content
+    assert "certbot renew *" not in content
     assert "mkdir -p /var/www/letsencrypt," in content
-    assert "-in /etc/letsencrypt/live/*" in content
+    assert "-in /etc/letsencrypt/live/*/fullchain.pem" in content
     assert content.count("openssl") == 2
     assert "ALL=(ALL) NOPASSWD: ALL" not in content
 
@@ -56,4 +63,4 @@ def test_has_passwordless_sudo_checks_certbot_grant(tmp_path: Path) -> None:
         assert manager.has_passwordless_sudo is True
 
     checked_command = mock_check.call_args.args[0]
-    assert checked_command[-2:] == ["renew", "--dry-run"]
+    assert checked_command[-2:] == ["renew", "--quiet"]

--- a/tests/pilot/managers/test_letsencrypt.py
+++ b/tests/pilot/managers/test_letsencrypt.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from pilot.config import BenchConfig
+from pilot.core.bench import Bench
+from pilot.managers.letsencrypt import LetsEncryptManager
+
+_BASE_DATA: dict = {
+    "bench": {"name": "test-bench", "python": "3.14"},
+    "apps": [{"name": "frappe", "repo": "https://github.com/frappe/frappe", "branch": "version-16"}],
+    "mariadb": {"root_password": "root"},
+    "redis": {"cache_port": 13000, "queue_port": 11000},
+}
+
+
+def _make_bench(tmp_path: Path, data: dict) -> Bench:
+    return Bench(BenchConfig._from_dict(data), tmp_path)
+
+
+def test_setup_sudoers_grants_only_certbot_and_cert_reads(tmp_path: Path) -> None:
+    bench = _make_bench(tmp_path, _BASE_DATA)
+    manager = LetsEncryptManager(bench)
+    sudoers_file = Path("/etc/sudoers.d/runner-pilot-certbot")
+
+    with (
+        patch("pwd.getpwuid") as mock_getpwuid,
+        patch("pilot.managers.sudoers.stage_and_copy") as mock_stage,
+        patch("pilot.managers.sudoers.run_command") as mock_run,
+    ):
+        mock_getpwuid.return_value.pw_name = "runner"
+        manager.setup_sudoers()
+
+    content, target = mock_stage.call_args.args[1:3]
+    assert mock_stage.call_args.kwargs == {"validate": ["visudo", "-cf"]}
+    assert target == sudoers_file
+    assert "runner ALL=(ALL) NOPASSWD:" in content
+    assert "certbot certonly *," in content
+    assert "certbot renew *," in content
+    assert "mkdir -p /var/www/letsencrypt," in content
+    assert "-in /etc/letsencrypt/live/*" in content
+    assert content.count("openssl") == 2
+    assert "ALL=(ALL) NOPASSWD: ALL" not in content
+
+    mock_run.assert_called_once()
+    assert mock_run.call_args.args[0][-3:] == ["chmod", "440", str(sudoers_file)]
+
+
+def test_has_passwordless_sudo_checks_certbot_grant(tmp_path: Path) -> None:
+    bench = _make_bench(tmp_path, _BASE_DATA)
+    manager = LetsEncryptManager(bench)
+
+    with patch("pilot.managers.letsencrypt.has_passwordless_sudo_for") as mock_check:
+        mock_check.return_value = True
+        assert manager.has_passwordless_sudo is True
+
+    checked_command = mock_check.call_args.args[0]
+    assert checked_command[-2:] == ["renew", "--dry-run"]

--- a/tests/pilot/managers/test_nginx_config.py
+++ b/tests/pilot/managers/test_nginx_config.py
@@ -476,7 +476,7 @@ def test_stage_and_copy_creates_missing_nginx_config_dir(tmp_path: Path) -> None
     nginx_dir = bench.config_path / "nginx"
     assert not nginx_dir.exists()
 
-    with patch("pilot.managers.nginx.run_command") as mock_run:
+    with patch("pilot.managers.sudoers.run_command") as mock_run:
         manager._stage_and_copy("content", Path("/etc/logrotate.d/test-bench-nginx"))
 
     mock_run.assert_called_once()
@@ -488,7 +488,7 @@ def test_stage_and_copy_validates_staged_file_before_copying(tmp_path: Path) -> 
     manager = NginxManager(bench)
     target = Path("/etc/sudoers.d/test-bench-pilot-nginx")
 
-    with patch("pilot.managers.nginx.run_command") as mock_run:
+    with patch("pilot.managers.sudoers.run_command") as mock_run:
         manager._stage_and_copy("content", target, validate=["visudo", "-cf"])
 
     assert mock_run.call_count == 2
@@ -505,13 +505,13 @@ def test_setup_sudoers_grants_only_start_stop_reload(tmp_path: Path) -> None:
 
     with (
         patch("pwd.getpwuid") as mock_getpwuid,
-        patch.object(manager, "_stage_and_copy") as mock_stage,
-        patch("pilot.managers.nginx.run_command") as mock_run,
+        patch("pilot.managers.sudoers.stage_and_copy") as mock_stage,
+        patch("pilot.managers.sudoers.run_command") as mock_run,
     ):
         mock_getpwuid.return_value.pw_name = "runner"
         manager.setup_sudoers()
 
-    content, target = mock_stage.call_args.args
+    content, target = mock_stage.call_args.args[1:3]
     assert mock_stage.call_args.kwargs == {"validate": ["visudo", "-cf"]}
     assert target == sudoers_file
     assert "runner ALL=(ALL) NOPASSWD:" in content


### PR DESCRIPTION

- Ensure cerbot and openssl have limited passwordless sudo access
- Remove code duplication for passwordless sudo setup