### PR TITLE
fix: SSL flag

### DIFF
--- a/pilot/core/bench/production.py
+++ b/pilot/core/bench/production.py
@@ -81,7 +81,7 @@ class BenchProduction:
         letsencrypt_manager.install()
         letsencrypt_manager.setup_sudoers()
         letsencrypt_manager.ensure_webroot()
-        nginx_manager.generate_config(ssl_ready=False)
+        nginx_manager.generate_config(ssl_ready=True)
         nginx_manager.reload()
         letsencrypt_manager.obtain_all()
         nginx_manager.generate_config(ssl_ready=True)

--- a/pilot/core/site/provisioning.py
+++ b/pilot/core/site/provisioning.py
@@ -116,8 +116,6 @@ class SiteProvisioner:
         site.set_ssl(True)
         on_progress("Obtaining SSL certificate...")
         nginx_manager = NginxManager(self.bench)
-        nginx_manager.generate_config(ssl_ready=False)
-        nginx_manager.reload()
         LetsEncryptManager(self.bench).obtain(site.config)
         nginx_manager.generate_config(ssl_ready=True)
         nginx_manager.reload()

--- a/tests/pilot/core/test_site_provisioning.py
+++ b/tests/pilot/core/test_site_provisioning.py
@@ -1,0 +1,41 @@
+"""Cert issuance during site provisioning must not disturb sibling vhosts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pilot.config import BenchConfig, SiteConfig
+from pilot.core.bench import Bench
+from pilot.core.site.provisioning import SiteProvisioner
+
+_BASE_DATA: dict = {
+    "bench": {"name": "test-bench", "python": "3.14"},
+    "apps": [{"name": "frappe", "repo": "https://github.com/frappe/frappe", "branch": "version-16"}],
+    "mariadb": {"root_password": "root"},
+    "redis": {"cache_port": 13000, "queue_port": 11000},
+    "production": {"enabled": True},
+}
+
+
+def _provisioner(tmp_path: Path) -> SiteProvisioner:
+    bench = Bench(BenchConfig._from_dict(_BASE_DATA), tmp_path)
+    return SiteProvisioner(bench, "site1.example.com", ["frappe"], "admin", "mariadb")
+
+
+def test_obtain_cert_never_regenerates_without_ssl(tmp_path: Path) -> None:
+    """An ssl_ready=False pass would strip 443 bench-wide while certbot runs."""
+    site = MagicMock()
+    site.config = SiteConfig(name="site1.example.com", apps=["frappe"])
+
+    with (
+        patch("pilot.managers.nginx.NginxManager") as mock_nginx,
+        patch("pilot.managers.letsencrypt.LetsEncryptManager") as mock_letsencrypt,
+    ):
+        _provisioner(tmp_path).obtain_cert(site, lambda _: None)
+
+    manager = mock_nginx.return_value
+    ssl_ready_flags = [call.kwargs["ssl_ready"] for call in manager.generate_config.call_args_list]
+    assert ssl_ready_flags == [True]
+    mock_letsencrypt.return_value.obtain.assert_called_once_with(site.config)
+    manager.reload.assert_called_once()


### PR DESCRIPTION
- Removing SSL ready which is a bench wide flag also takes away https (443) from admin and other sites for sometime.

https://github.com/frappe/bench-cli/blob/e1177a55430726cc235f1093728a9f65057dc912/pilot/managers/nginx/__init__.py#L229