### PR TITLE
fix(admin): reconcile admin venv dependencies on every start

### DIFF
--- a/pilot/managers/environment.py
+++ b/pilot/managers/environment.py
@@ -42,14 +42,9 @@ class AdminEnvManager:
         return uv
 
     def ensure(self) -> None:
-        """Create the admin venv and reconcile admin dependencies.
-
-        Deps are reconciled on every call, not just at creation, so an existing venv
-        picks up dependencies added since. Announce only the one-time setup; the
-        reconcile is a no-op once satisfied and should stay silent.
-        """
-        created = self._ensure_venv()
-        self.install_python_deps(announce=created)
+        """Create the admin venv and install admin dependencies when they change."""
+        self._ensure_venv()
+        self.install_python_deps()
         self._ensure_frontend_deps()
 
     def _ensure_venv(self) -> bool:
@@ -61,22 +56,24 @@ class AdminEnvManager:
         print("done")
         return True
 
-    def install_python_deps(self, announce: bool = True) -> None:
-        """Install any missing admin Python dependencies into the admin venv."""
+    def install_python_deps(self) -> None:
+        """Install admin Python dependencies when the declared set changed."""
         self._ensure_venv()
         deps = self._read_admin_deps()
         if not deps:
-            if announce:
-                print("  No admin dependencies specified, skipping installation.")
+            print("  No admin dependencies specified, skipping installation.")
             return
 
-        if announce:
-            print(f"  Installing {', '.join(deps)}...", end=" ", flush=True)
+        installed = self.venv_path / ".admin-deps"
+        if installed.exists() and installed.read_text().splitlines() == deps:
+            return
+
+        print(f"  Installing {', '.join(deps)}...", end=" ", flush=True)
         subprocess.run(
             [self.uv, "pip", "install", "--python", str(self.python), "--quiet", *deps], check=True
         )
-        if announce:
-            print("done")
+        installed.write_text("\n".join(deps))
+        print("done")
 
     def _ensure_frontend_deps(self) -> None:
         frontend = self.venv_path.parent / "admin" / "frontend"

--- a/pilot/managers/environment.py
+++ b/pilot/managers/environment.py
@@ -42,9 +42,14 @@ class AdminEnvManager:
         return uv
 
     def ensure(self) -> None:
-        """Create the admin venv and install admin dependencies if not already done."""
-        if self._ensure_venv():
-            self.install_python_deps()
+        """Create the admin venv and reconcile admin dependencies.
+
+        Deps are reconciled on every call, not just at creation, so an existing venv
+        picks up dependencies added since. Announce only the one-time setup; the
+        reconcile is a no-op once satisfied and should stay silent.
+        """
+        created = self._ensure_venv()
+        self.install_python_deps(announce=created)
         self._ensure_frontend_deps()
 
     def _ensure_venv(self) -> bool:
@@ -56,19 +61,22 @@ class AdminEnvManager:
         print("done")
         return True
 
-    def install_python_deps(self) -> None:
+    def install_python_deps(self, announce: bool = True) -> None:
         """Install any missing admin Python dependencies into the admin venv."""
         self._ensure_venv()
         deps = self._read_admin_deps()
         if not deps:
-            print("  No admin dependencies specified, skipping installation.")
+            if announce:
+                print("  No admin dependencies specified, skipping installation.")
             return
 
-        print(f"  Installing {', '.join(deps)}...", end=" ", flush=True)
+        if announce:
+            print(f"  Installing {', '.join(deps)}...", end=" ", flush=True)
         subprocess.run(
             [self.uv, "pip", "install", "--python", str(self.python), "--quiet", *deps], check=True
         )
-        print("done")
+        if announce:
+            print("done")
 
     def _ensure_frontend_deps(self) -> None:
         frontend = self.venv_path.parent / "admin" / "frontend"

--- a/tests/pilot/managers/test_admin_env.py
+++ b/tests/pilot/managers/test_admin_env.py
@@ -24,10 +24,14 @@ def _existing_venv(root: Path) -> None:
 
 
 @pytest.fixture
-def uv_runs():
+def uv_runs(tmp_path: Path):
+    def fake_run(command, **kwargs):
+        if "venv" in command:
+            _existing_venv(tmp_path)
+
     with (
         patch("pilot.managers.environment.shutil.which", return_value="uv"),
-        patch("pilot.managers.environment.subprocess.run") as run,
+        patch("pilot.managers.environment.subprocess.run", side_effect=fake_run) as run,
     ):
         yield run
 
@@ -49,19 +53,27 @@ def test_ensure_creates_venv_and_installs_deps(tmp_path: Path, uv_runs) -> None:
     assert any("cowsay" in command for command in commands)
 
 
-def test_ensure_is_quiet_when_venv_already_exists(
+def test_ensure_skips_install_when_deps_unchanged(
     tmp_path: Path, uv_runs, capsys: pytest.CaptureFixture[str]
 ) -> None:
     _existing_venv(tmp_path)
-    _make_manager(tmp_path).ensure()
+    manager = _make_manager(tmp_path)
+    manager.ensure()
+    uv_runs.reset_mock()
+    capsys.readouterr()
 
+    manager.ensure()
+
+    assert not [call for call in uv_runs.call_args_list if "pip" in call.args[0]]
     assert capsys.readouterr().out == ""
 
 
-def test_install_python_deps_announces_by_default(
-    tmp_path: Path, uv_runs, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_ensure_reinstalls_when_deps_change(tmp_path: Path, uv_runs) -> None:
     _existing_venv(tmp_path)
-    _make_manager(tmp_path).install_python_deps()
+    _make_manager(tmp_path).ensure()
+    uv_runs.reset_mock()
 
-    assert "Installing" in capsys.readouterr().out
+    _make_manager(tmp_path, deps='["cowsay", "flask"]').ensure()
+
+    installed = [call.args[0] for call in uv_runs.call_args_list if "pip" in call.args[0]]
+    assert installed and "flask" in installed[0]

--- a/tests/pilot/managers/test_admin_env.py
+++ b/tests/pilot/managers/test_admin_env.py
@@ -1,0 +1,67 @@
+"""Tests for admin venv dependency reconciliation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pilot.managers.environment import AdminEnvManager
+
+
+def _make_manager(root: Path, deps: str = '["cowsay"]') -> AdminEnvManager:
+    (root / "pyproject.toml").write_text(
+        f"[project.optional-dependencies]\nadmin = {deps}\n"
+    )
+    return AdminEnvManager(root)
+
+
+def _existing_venv(root: Path) -> None:
+    bin_dir = root / ".admin-venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    (bin_dir / "python").touch()
+
+
+@pytest.fixture
+def uv_runs():
+    with (
+        patch("pilot.managers.environment.shutil.which", return_value="uv"),
+        patch("pilot.managers.environment.subprocess.run") as run,
+    ):
+        yield run
+
+
+def test_ensure_installs_deps_added_after_venv_was_created(tmp_path: Path, uv_runs) -> None:
+    _existing_venv(tmp_path)
+    _make_manager(tmp_path).ensure()
+
+    installed = [call.args[0] for call in uv_runs.call_args_list if "pip" in call.args[0]]
+    assert installed, "existing venv should still reconcile admin dependencies"
+    assert "cowsay" in installed[0]
+
+
+def test_ensure_creates_venv_and_installs_deps(tmp_path: Path, uv_runs) -> None:
+    _make_manager(tmp_path).ensure()
+
+    commands = [call.args[0] for call in uv_runs.call_args_list]
+    assert any("venv" in command for command in commands)
+    assert any("cowsay" in command for command in commands)
+
+
+def test_ensure_is_quiet_when_venv_already_exists(
+    tmp_path: Path, uv_runs, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _existing_venv(tmp_path)
+    _make_manager(tmp_path).ensure()
+
+    assert capsys.readouterr().out == ""
+
+
+def test_install_python_deps_announces_by_default(
+    tmp_path: Path, uv_runs, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _existing_venv(tmp_path)
+    _make_manager(tmp_path).install_python_deps()
+
+    assert "Installing" in capsys.readouterr().out


### PR DESCRIPTION
Fixes #242

`AdminEnvManager.ensure()` installed admin dependencies only when it had just created the venv, so an existing `.admin-venv` never picked up dependencies added later. `ensure()` runs on every `bench start` (via `ProcessManager.write_config()`), so it reads as the self-healing path but wasn't — the failure surfaced as a bare `ModuleNotFoundError`.

Dependencies are now reconciled on every call. `install_python_deps()` already calls `_ensure_venv()` itself, so the branch was redundant. The announcement is gated so the already-satisfied path stays silent; `bench upgrade` keeps its current output.

### Repro (before this change)

1. Add `"cowsay"` to `[project.optional-dependencies] admin` in `pyproject.toml`
2. `bench start`
3. `.admin-venv/bin/python -c "import cowsay"` → `ModuleNotFoundError`

### Tests

`tests/pilot/managers/test_admin_env.py` — the regression test fails on the previous behaviour and passes with the fix.
