### PR TITLE
fix: anchor release tarball excludes to repo root

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,14 +31,14 @@ jobs:
       - name: Package release tarball
         run: |
           tar -czf /tmp/pilot.tar.gz \
-            --exclude=.git \
-            --exclude=.github \
+            --exclude=./.git \
+            --exclude=./.github \
             --exclude=node_modules \
-            --exclude=benches \
-            --exclude=.venv \
-            --exclude=.admin-venv \
+            --exclude=./benches \
+            --exclude=./.venv \
+            --exclude=./.admin-venv \
             --exclude='*.egg-info' \
-            --exclude=build \
+            --exclude=./build \
             --exclude=__pycache__ \
             -C "$GITHUB_WORKSPACE" .
 


### PR DESCRIPTION
`tar --exclude` takes patterns, not paths, so `--exclude=benches` also matched `admin/backend/api/v1/benches/`. The `v0.0.1-pre-alpha` tarball shipped without that package and a fresh install crashed on startup:

```
ModuleNotFoundError: No module named 'admin.backend.api.v1.benches'
```

Anchors the root-only excludes (`.git`, `.github`, `benches`, `.venv`, `.admin-venv`, `build`) with `./`; leaves `node_modules`, `__pycache__` and `*.egg-info` matching at any depth.

Verified locally with the same tar invocation: 5 `admin/backend/api/v1/benches/` entries present, root `benches/` still excluded, no `node_modules` or `.git`.

`v0.0.1-pre-alpha` can't be repaired by re-running its workflow (it checks out the tag, which still has the bug) — needs a fresh tag after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)