### PR TITLE
feat: make a bench fully operable without root after install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Benches (created by `bench new`)
 /benches/
 
+# Monitor logs (written beside the install)
+/logs/
+
 # Local agent scratch files
 /plan_refactor.md
 

--- a/install.sh
+++ b/install.sh
@@ -252,24 +252,43 @@ install_database_engines() {
         debian|ubuntu)
             pkg_install mariadb-server mariadb-client libmariadb-dev postgresql postgresql-client libpq-dev pkg-config redis-server ;;
         fedora)
-            pkg_install mariadb-server mariadb mariadb-connector-c-devel postgresql-server postgresql libpq-devel pkgconf-pkg-config redis ;;
+            # Fedora 41+ ships valkey in place of redis (same alias the runtime uses).
+            pkg_install mariadb-server mariadb mariadb-connector-c-devel postgresql-server postgresql libpq-devel pkgconf-pkg-config valkey ;;
         arch)
             pkg_install mariadb mariadb-clients mariadb-libs postgresql postgresql-libs pkgconf redis ;;
+    esac
+}
+
+# ── production stack ──────────────────────────────────────────────────────────
+# nginx, certbot and supervisor are what `bench setup production` needs. Same
+# reasoning as the database engines: installed here, as root, so deploying a
+# bench never has to install a package as the bench user — which cannot,
+# by design.
+install_production_packages() {
+    case "$DISTRO" in
+        macos)  pkg_install nginx certbot ;;
+        debian|ubuntu)
+            # libnginx-mod-http-modsecurity is the WAF module; installing it
+            # up front keeps enabling the WAF later a non-root operation.
+            pkg_install nginx certbot supervisor libnginx-mod-http-modsecurity ;;
+        fedora) pkg_install nginx certbot supervisor ;;
+        arch)   pkg_install nginx certbot supervisor ;;
     esac
 }
 
 # Distro packages auto-start/enable a system-wide service on the default
 # port (3306/5432). bench never uses that — it runs a per-user instance
 # instead — so free the ports right away rather than have every `bench
-# init` fight over them.
-disable_system_db_services() {
+# init` fight over them. nginx and supervisor are stopped for the same
+# reason: `bench setup production` starts nginx itself (a grant covers it),
+# and benches are supervised by their own config, not the distro's.
+disable_system_services() {
     case "$DISTRO" in
         macos|unknown) ;;
         *)
-            run_sudo systemctl disable --now mariadb 2>/dev/null || true
-            run_sudo systemctl disable --now postgresql 2>/dev/null || true
-            run_sudo systemctl disable --now redis-server 2>/dev/null || true
-            run_sudo systemctl disable --now redis 2>/dev/null || true
+            for service in mariadb postgresql redis-server redis valkey nginx supervisor; do
+                run_sudo systemctl disable --now "$service" 2>/dev/null || true
+            done
             ;;
     esac
 }
@@ -330,7 +349,8 @@ bootstrap() {
     pkg_update
     bootstrap_packages
     install_database_engines
-    disable_system_db_services
+    install_production_packages
+    disable_system_services
     install_node
 }
 

--- a/install.sh
+++ b/install.sh
@@ -2,29 +2,29 @@
 set -e
 
 # POSIX sh (not bash) so a bare box can bootstrap via `wget -qO- ... | sh`
-# before bash exists. The provisioned-host one-liner still pipes to bash.
+# before bash exists. Supported distros: Debian, Ubuntu, Fedora, Arch, and
+# their derivatives via ID_LIKE. Unknown distros fall back to apt.
 #
-# Supported distros: Debian, Ubuntu, Fedora, Arch (and their derivatives via
-# ID_LIKE). Unknown distros fall back to apt when available.
+# Two passes. As root it prepares the host and the bench user, then stops.
+# As that user it installs bench itself, needing no privileges at all.
 
-# ── configuration ────────────────────────────────────────────────────────────
+# ── configuration ─────────────────────────────────────────────────────────────
 INSTALL_URL="https://raw.githubusercontent.com/frappe/pilot/main/install.sh"
 # Overridable so smoke tests can install from a local checkout.
 REPO_URL="${PILOT_REPO_URL:-https://github.com/frappe/pilot}"
 BRANCH_NAME="${PILOT_BRANCH:-main}"
 PILOT_DIR="$HOME/pilot"
-DEFAULT_USER="frappe"
-
-# ── arguments / environment ──────────────────────────────────────────────────
-BENCH_USER="${BENCH_USER:-$DEFAULT_USER}"
-# Only relevant to the rare case of running this script directly as a
-# pre-existing non-root sudo user with a base tool missing (bootstrap_needed):
-# that fallback still shells out to sudo, and unattended runs (e.g. CI) can't
-# answer its password prompt.
+BENCH_USER="${BENCH_USER:-frappe}"
+# Lets an unattended run answer sudo, which `curl | sh` cannot prompt for.
 SUDO_PASS="${SUDO_PASS:-}"
-# Default install pulls a prebuilt release tarball; --dev git-clones main and
-# compiles the admin frontend from source (for contributors).
+# The default install pulls a prebuilt release tarball; --dev clones main and
+# compiles the admin frontend from source.
 DEV_MODE="${PILOT_DEV:-}"
+
+MARIADB_REPO_SETUP_URL="https://r.mariadb.com/downloads/mariadb_repo_setup"
+# Match the runtime's own defaults (MariaDBManager/PostgresManager).
+MARIADB_VERSION="11.8"
+POSTGRES_VERSION="16"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -37,7 +37,7 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-# ── distro detection ──────────────────────────────────────────────────────────
+# ── platform ──────────────────────────────────────────────────────────────────
 detect_distro() {
     if [ "$(uname)" = "Darwin" ]; then
         echo macos
@@ -67,25 +67,23 @@ detect_distro() {
 
 DISTRO="$(detect_distro)"
 
-# ── sudo wrapper ──────────────────────────────────────────────────────────────
-# Injects SUDO_PASS when provided so the script works unattended. Otherwise,
-# if sudo would actually need a password (no cached/passwordless sudo), we
-# prompt for it ourselves via /dev/tty and cache the answer in SUDO_PASS —
-# piping this script through `curl | sh` leaves stdin occupied by the script
-# itself, so sudo's own prompt can't read an answer from it.
+is_root() {
+    [ "$(id -u)" -eq 0 ]
+}
+
+# Piping this script through `curl | sh` leaves stdin occupied, so sudo's own
+# prompt cannot read an answer. Ask via /dev/tty and cache it instead.
 run_sudo() {
-    if [ "$(id -u)" -eq 0 ]; then
+    if is_root; then
         "$@"
         return
     fi
-    if [ -z "$SUDO_PASS" ] && ! sudo -n true 2>/dev/null; then
-        if [ -r /dev/tty ]; then
-            printf "[sudo] password for %s: " "$(id -un)" > /dev/tty
-            stty -echo < /dev/tty 2>/dev/null
-            read -r SUDO_PASS < /dev/tty
-            stty echo < /dev/tty 2>/dev/null
-            printf "\n" > /dev/tty
-        fi
+    if [ -z "$SUDO_PASS" ] && ! sudo -n true 2>/dev/null && [ -r /dev/tty ]; then
+        printf "[sudo] password for %s: " "$(id -un)" > /dev/tty
+        stty -echo < /dev/tty 2>/dev/null
+        read -r SUDO_PASS < /dev/tty
+        stty echo < /dev/tty 2>/dev/null
+        printf "\n" > /dev/tty
     fi
     if [ -n "$SUDO_PASS" ]; then
         echo "$SUDO_PASS" | sudo -S "$@"
@@ -94,34 +92,9 @@ run_sudo() {
     fi
 }
 
-# Downloads a vendor bootstrap script (MariaDB repo setup, NodeSource,
-# Homebrew) over a pinned HTTPS/TLS floor. These vendors only publish
-# "curl | bash" installers with no checksum/signature to pin against, so the
-# content itself is trusted the same way their own docs instruct — but a
-# truncated transfer, non-HTTPS redirect, or empty/garbage response is caught
-# before anything runs.
-download_installer() {
-    url="$1"
-    tmp="$(mktemp)"
-    curl -fsSL --proto '=https' --tlsv1.2 "$url" -o "$tmp"
-    if [ ! -s "$tmp" ] || ! head -c 2 "$tmp" | grep -q '^#'; then
-        echo "Downloaded installer from $url looks invalid, aborting." >&2
-        rm -f "$tmp"
-        exit 1
-    fi
-    echo "$tmp"
-}
-
-fetch_and_run_as_root() {
-    url="$1"; shift
-    tmp="$(download_installer "$url")" || exit 1
-    run_sudo bash "$tmp" "$@"
-    rm -f "$tmp"
-}
-
-# ── package manager primitives ────────────────────────────────────────────────
-# Unknown distros fall back to apt, mirroring the runtime in pilot/platform.py.
-# macOS uses Homebrew, ownership-per-user, so it never goes through run_sudo.
+# ── package manager ───────────────────────────────────────────────────────────
+# Unknown distros fall back to apt, mirroring pilot/managers/packages.py.
+# macOS uses Homebrew, which is per-user and never goes through run_sudo.
 pkg_update() {
     case "$DISTRO" in
         macos)  ensure_homebrew; brew update ;;
@@ -136,8 +109,8 @@ pkg_install() {
         macos)  ensure_homebrew; brew install "$@" ;;
         # --allowerasing: containers ship curl-minimal, which conflicts with curl.
         fedora) run_sudo dnf install -y --allowerasing "$@" ;;
-        # -Sy: sync the package database first; stale Arch mirrors 404 otherwise.
-        # The download timeout aborts large transfers on slow links; disable it.
+        # -Sy: stale Arch mirrors 404 otherwise. The download timeout aborts
+        # large transfers on slow links, so turn it off.
         arch)   run_sudo pacman -Sy --noconfirm --needed --disable-download-timeout "$@" ;;
         *)      run_sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "$@" ;;
     esac
@@ -152,10 +125,28 @@ pkg_installed() {
     esac
 }
 
-# download_installer (mariadb/nodesource/homebrew) needs curl before anything
-# else runs, and bootstrap_packages()'s own curl install happens too late for
-# that — so get it on its own, ahead of everything else in bootstrap().
-# macOS always ships curl, so this is a no-op there.
+# Vendors (MariaDB, NodeSource, Homebrew) only publish `curl | bash` installers
+# with nothing to pin against, so the content is trusted the way their docs
+# instruct. A truncated transfer or non-HTTPS redirect is still caught here.
+download_installer() {
+    tmp="$(mktemp)"
+    curl -fsSL --proto '=https' --tlsv1.2 "$1" -o "$tmp"
+    if [ ! -s "$tmp" ] || ! head -c 2 "$tmp" | grep -q '^#'; then
+        echo "Downloaded installer from $1 looks invalid, aborting." >&2
+        rm -f "$tmp"
+        exit 1
+    fi
+    echo "$tmp"
+}
+
+fetch_and_run_as_root() {
+    url="$1"; shift
+    tmp="$(download_installer "$url")" || exit 1
+    run_sudo bash "$tmp" "$@"
+    rm -f "$tmp"
+}
+
+# download_installer needs curl before bootstrap_packages would install it.
 ensure_curl() {
     command -v curl >/dev/null 2>&1 && return 0
     [ "$DISTRO" = "macos" ] && return 0
@@ -164,12 +155,9 @@ ensure_curl() {
     pkg_install curl
 }
 
-# Homebrew is the one base dependency on macOS the runtime can't lazily
-# install itself (pilot/package_managers.py's BrewPackageManager assumes
-# `brew` already exists). On Intel Macs, Homebrew's own installer needs sudo
-# for the initial /usr/local setup; priming the sudo timestamp cache first
-# means it reuses that instead of prompting separately (or failing outright
-# if --sudo-password was given but the installer's own prompt can't read it).
+# The one macOS dependency the runtime cannot install for itself. Priming the
+# sudo timestamp first means Homebrew's installer reuses it on Intel Macs
+# rather than prompting again, where it could not read an answer.
 ensure_homebrew() {
     command -v brew >/dev/null 2>&1 && return 0
     echo "Installing Homebrew..."
@@ -184,25 +172,13 @@ ensure_homebrew() {
     fi
 }
 
-# ── base dependency bootstrap ─────────────────────────────────────────────────
-# Bare images of most distros ship almost nothing. Install the tools the rest
-# of this script and bench need before they're first used: git/curl/bash, sudo
-# + user tooling (so the user-setup path's useradd/usermod/visudo work), a
-# Python, and the base build deps for compiling the admin venv (psutil) and
-# frappe wheels. macOS ships curl/bash/sudo itself, so brew (the one thing it
-# can't lazily install for itself) takes their place here.
-bootstrap_needed() {
-    if [ "$DISTRO" = "macos" ]; then
-        tools="git brew python3"
-    else
-        tools="git curl bash sudo python3"
-    fi
-    for tool in $tools; do
-        command -v "$tool" >/dev/null 2>&1 || return 0
-    done
-    return 1
-}
+# ── system packages ───────────────────────────────────────────────────────────
+# Everything bench needs at runtime is installed here, as root, once. The bench
+# user has no passwordless sudo, so anything missing from this list becomes a
+# password prompt in the middle of `bench init` or a deploy.
 
+# Bare images ship almost nothing: the tools this script and bench both need
+# before first use, plus the build deps for the admin venv and frappe wheels.
 bootstrap_packages() {
     case "$DISTRO" in
         macos)
@@ -216,128 +192,86 @@ bootstrap_packages() {
     esac
 }
 
-# ── database engines ──────────────────────────────────────────────────────────
-# bench runs one MariaDB server and one PostgreSQL server per bench user
-# (rootless, systemctl --user) shared across that user's benches, so the
-# engines must already be installed system-wide before `bench init` ever
-# runs — the runtime never installs packages itself, and the bench user has
-# no privileges to. Root, one-time.
-_MARIADB_REPO_SETUP_URL="https://r.mariadb.com/downloads/mariadb_repo_setup"
-_MARIADB_VERSION="11.8"
-_POSTGRES_VERSION="16"
-
-# Debian/Ubuntu ship an older MariaDB than 11.8 by default, so the official
-# repo must be added before bootstrap()'s single pkg_update() runs — that one
-# call then refreshes both the base indices and this new repo together,
-# instead of a second apt-get update just for it.
+# Debian/Ubuntu ship an older MariaDB than we want, so add the official repo
+# before the single pkg_update below refreshes both it and the base indices.
 add_distro_repos() {
     case "$DISTRO" in
         debian|ubuntu)
-            # Same version the runtime expects (MariaDBManager DEFAULT_VERSION).
-            fetch_and_run_as_root "$_MARIADB_REPO_SETUP_URL" --mariadb-server-version="mariadb-$_MARIADB_VERSION" ;;
+            fetch_and_run_as_root "$MARIADB_REPO_SETUP_URL" \
+                --mariadb-server-version="mariadb-$MARIADB_VERSION" ;;
     esac
 }
 
+# One MariaDB, PostgreSQL and Redis per bench user (rootless, systemctl --user),
+# shared across that user's benches. The dev headers are for the Python client
+# libraries frappe's virtualenv compiles during `bench init`.
 install_database_engines() {
-    # Dev headers for building the Python client libraries (mysqlclient,
-    # psycopg) that frappe's virtualenv compiles during `bench init` — listed
-    # here so bench init never has to install a package itself.
     case "$DISTRO" in
         macos)
-            # Versions pinned to match the runtime's own defaults
-            # (MariaDBManager/PostgresManager _DEFAULT_VERSION), so the formula
-            # this installs is the same one BrewPackageManager would lazily
-            # reach for later.
-            pkg_install "mariadb@$_MARIADB_VERSION" "postgresql@$_POSTGRES_VERSION" redis ;;
+            pkg_install "mariadb@$MARIADB_VERSION" "postgresql@$POSTGRES_VERSION" redis ;;
         debian|ubuntu)
             pkg_install mariadb-server mariadb-client libmariadb-dev postgresql postgresql-client libpq-dev pkg-config redis-server ;;
         fedora)
-            # Fedora 41+ ships valkey in place of redis (same alias the runtime uses).
+            # Fedora 41+ ships valkey in place of redis (the alias the runtime resolves).
             pkg_install mariadb-server mariadb mariadb-connector-c-devel postgresql-server postgresql libpq-devel pkgconf-pkg-config valkey ;;
         arch)
             pkg_install mariadb mariadb-clients mariadb-libs postgresql postgresql-libs pkgconf redis ;;
     esac
 }
 
-# ── production stack ──────────────────────────────────────────────────────────
-# nginx, certbot and supervisor are what `bench setup production` needs. Same
-# reasoning as the database engines: installed here, as root, so deploying a
-# bench never has to install a package as the bench user — which cannot,
-# by design.
+# What `bench setup production` needs. Installing the WAF module up front keeps
+# enabling the WAF later a non-root operation too.
 install_production_packages() {
     case "$DISTRO" in
         macos)  pkg_install nginx certbot ;;
         debian|ubuntu)
-            # libnginx-mod-http-modsecurity is the WAF module; installing it
-            # up front keeps enabling the WAF later a non-root operation.
             pkg_install nginx certbot supervisor libnginx-mod-http-modsecurity ;;
         fedora) pkg_install nginx certbot supervisor ;;
         arch)   pkg_install nginx certbot supervisor ;;
     esac
 }
 
-# Distro packages auto-start/enable a system-wide service on the default
-# port (3306/5432). bench never uses that — it runs a per-user instance
-# instead — so free the ports right away rather than have every `bench
-# init` fight over them. nginx and supervisor are stopped for the same
-# reason: `bench setup production` starts nginx itself (a grant covers it),
-# and benches are supervised by their own config, not the distro's.
-disable_system_services() {
-    case "$DISTRO" in
-        macos|unknown) ;;
-        *)
-            for service in mariadb postgresql redis-server redis valkey nginx supervisor; do
-                run_sudo systemctl disable --now "$service" 2>/dev/null || true
-            done
-            ;;
-    esac
-}
-
-# ── Node.js ───────────────────────────────────────────────────────────────────
-# System-wide, root/bootstrap only — same reasoning as the database engines:
-# installed once up front so the bench user never needs privileges of its own.
-# NodeSource pins Node 24 on the deb/rpm distros; Arch ships a current Node in
-# its own repos.
-install_node_nodesource() {
-    kind="$1"; shift
-    fetch_and_run_as_root "https://${kind}.nodesource.com/setup_24.x"
-    run_sudo "$@"
-}
-
+# NodeSource pins Node 24 on deb/rpm distros; Arch ships a current Node itself.
 install_node() {
     command -v node >/dev/null 2>&1 && return 0
+    # An unknown distro only gets Node when apt is there to install it.
+    if [ "$DISTRO" = "unknown" ] && ! command -v apt-get >/dev/null 2>&1; then
+        return 0
+    fi
+    echo "Installing Node.js..."
     case "$DISTRO" in
-        macos)  echo "Installing Node.js..."; pkg_install node ;;
-        debian|ubuntu)
-            echo "Installing Node.js..."
-            install_node_nodesource deb apt-get install -y nodejs ;;
+        macos)  pkg_install node ;;
+        arch)   pkg_install nodejs npm ;;
         fedora)
-            echo "Installing Node.js..."
-            install_node_nodesource rpm dnf install -y nodejs ;;
-        arch)   echo "Installing Node.js..."; pkg_install nodejs npm ;;
+            fetch_and_run_as_root "https://rpm.nodesource.com/setup_24.x"
+            run_sudo dnf install -y nodejs ;;
         *)
-            # Same fallback as before this script knew about distros: NodeSource
-            # when apt exists, otherwise leave Node to the operator.
-            if command -v apt-get >/dev/null 2>&1; then
-                echo "Installing Node.js..."
-                install_node_nodesource deb apt-get install -y nodejs
-            fi ;;
+            fetch_and_run_as_root "https://deb.nodesource.com/setup_24.x"
+            run_sudo apt-get install -y nodejs ;;
     esac
 }
 
-bootstrap() {
+# The distro packages auto-start services on their default ports. Benches run
+# their own instances, so free the ports and the memory right away. nginx is
+# started by `bench setup production`, which a sudoers grant already allows.
+disable_system_services() {
+    case "$DISTRO" in
+        macos|unknown) return 0 ;;
+    esac
+    for service in mariadb postgresql redis-server redis valkey nginx supervisor; do
+        run_sudo systemctl disable --now "$service" 2>/dev/null || true
+    done
+}
+
+install_system_packages() {
     [ "$DISTRO" = "unknown" ] && return 0
-    # Root always bootstraps (idempotent, and bare containers need it before
-    # useradd); a normal user only when a base tool is actually missing
-    # (bootstrap_needed is platform-aware: brew on macOS, sudo elsewhere).
-    if [ "$(id -u)" -ne 0 ]; then
-        bootstrap_needed || return 0
+    # Root always runs this (idempotent, and bare containers need it before
+    # useradd); the bench user only when a base tool is genuinely missing.
+    if ! is_root; then
+        base_tools_present && return 0
         if ! command -v sudo >/dev/null 2>&1; then
-            # A non-root user can't install packages without sudo. Re-run as
-            # root first — that path installs sudo and prepares the bench user.
             echo "sudo is not installed and you are not root, so base packages cannot"
-            echo "be installed. Re-run this installer as root first, then as the bench"
-            echo "user:"
+            echo "be installed. Re-run this installer as root first, then as the bench user:"
             echo ""
             echo "   wget -qO- $INSTALL_URL | sh   # as root"
             exit 1
@@ -354,23 +288,26 @@ bootstrap() {
     install_node
 }
 
-bootstrap
-
-# The group conventionally granted admin rights, so the bench user can
-# authenticate sudo interactively later if they ever need it (e.g. `bench
-# setup production`). Nothing in this installer's own bench-user path needs
-# sudo — base tools, database engines and Node.js are all installed
-# system-wide above, before the bench user is ever created.
-admin_group() {
-    case "$DISTRO" in
-        debian|ubuntu|unknown) echo sudo ;;
-        *) echo wheel ;;
-    esac
+base_tools_present() {
+    if [ "$DISTRO" = "macos" ]; then
+        tools="git brew python3"
+    else
+        tools="git curl bash sudo python3"
+    fi
+    for tool in $tools; do
+        command -v "$tool" >/dev/null 2>&1 || return 1
+    done
+    return 0
 }
 
-# Bench services run as `systemctl --user` units, so the bench user's systemd
-# instance must stay alive with no login session. Enabling lingering also
-# starts it, creating the D-Bus socket every `systemctl --user` call needs.
+# ── host provisioning (root only) ─────────────────────────────────────────────
+# Each of these exists so the bench user never has to ask for a password later.
+# All are idempotent: re-running the installer repairs a host in place.
+
+bench_home() {
+    getent passwd "$1" | cut -d: -f6
+}
+
 systemd_booted() {
     [ -d /run/systemd/system ] && command -v loginctl >/dev/null 2>&1
 }
@@ -379,40 +316,94 @@ linger_enabled() {
     [ "$(loginctl show-user "$1" --property=Linger 2>/dev/null)" = "Linger=yes" ]
 }
 
-# nginx reads each bench's vhost from a file the bench user owns. Root drops
-# the one glob that pulls them in, so publishing a vhost afterwards is an
-# ordinary file write instead of a privileged symlink into /etc/nginx.
+# The group conventionally granted admin rights, so the bench user can
+# authenticate sudo interactively if it ever needs to.
+admin_group() {
+    case "$DISTRO" in
+        debian|ubuntu|unknown) echo sudo ;;
+        *) echo wheel ;;
+    esac
+}
+
+create_bench_user() {
+    id "$1" >/dev/null 2>&1 && return 0
+    echo "Creating user '$1'..."
+    useradd -m -s /bin/bash "$1"
+    usermod -aG "$(admin_group)" "$1" 2>/dev/null || true
+}
+
+# Bench services are `systemctl --user` units, which need this user's systemd
+# instance alive with no login session. Enabling lingering also starts it,
+# creating the D-Bus socket every systemctl --user call talks to.
+enable_linger() {
+    systemd_booted || return 0
+    linger_enabled "$1" && return 0
+    echo "Enabling systemd lingering for '$1'..."
+    loginctl enable-linger "$1"
+}
+
+# nginx reads each bench's vhost from a file the bench user owns. Dropping the
+# one glob that pulls them in makes publishing a vhost an ordinary file write
+# rather than a privileged symlink into /etc/nginx.
 install_nginx_include() {
-    bench_home="$(getent passwd "$1" | cut -d: -f6)"
-    [ -n "$bench_home" ] && [ -d /etc/nginx/conf.d ] || return 0
+    home="$(bench_home "$1")"
+    [ -n "$home" ] && [ -d /etc/nginx/conf.d ] || return 0
     echo "Installing the nginx include for '$1'..."
     cat > /etc/nginx/conf.d/00-pilot.conf <<EOF
-include $bench_home/pilot/nginx/*.conf;
-include $bench_home/pilot/benches/*/config/nginx/include.conf;
+include $home/pilot/nginx/*.conf;
+include $home/pilot/benches/*/config/nginx/include.conf;
 EOF
     chmod 644 /etc/nginx/conf.d/00-pilot.conf
-    # The distro's stock default site also claims default_server on :80;
-    # nginx rejects a duplicate, so drop it and let a bench's vhost win.
+    # The stock default site also claims default_server on :80 and nginx
+    # rejects the duplicate, so let a bench's vhost win.
     rm -f /etc/nginx/sites-enabled/default
-    # Older installs symlinked each bench into conf.d. The glob above now
-    # loads the same file, and nginx rejects the duplicate server blocks, so
-    # a re-run has to clear the symlinks it supersedes.
+    # Older installs symlinked each bench into conf.d. The glob above loads the
+    # same file now, and nginx rejects the duplicate server blocks.
     for link in /etc/nginx/conf.d/*.conf; do
         [ -L "$link" ] || continue
         case "$(readlink "$link")" in
-            "$bench_home"/pilot/benches/*) rm -f "$link" ;;
+            "$home"/pilot/benches/*) rm -f "$link" ;;
         esac
     done
 }
 
-# Reloading nginx and running certbot are the two things a deployed bench needs
-# root for, every time. Granting them here is what keeps `bench setup
-# production` from having to ask: writing to /etc/sudoers.d is itself a
-# root-only act, so the runtime could never do it unprompted.
-#
-# These mirror NginxManager.setup_sudoers and LetsEncryptManager.setup_sudoers.
-# They only have to be functionally equivalent, not textually identical - both
-# check whether the grant already works before rewriting it.
+# nginx workers must run as the bench user to read its sites.
+set_nginx_worker_user() {
+    conf=/etc/nginx/nginx.conf
+    [ "$DISTRO" != "macos" ] && [ -f "$conf" ] || return 0
+    grep -q "^[[:space:]]*user[[:space:]]\{1,\}$1;" "$conf" && return 0
+    echo "Setting the nginx worker user to '$1'..."
+    if grep -q "^[[:space:]]*user[[:space:]]" "$conf"; then
+        sed -i "s/^[[:space:]]*user[[:space:]].*;/user $1;/" "$conf"
+    else
+        sed -i "1i user $1;" "$conf"
+    fi
+}
+
+# logrotate ignores a config it does not own, so the bench user cannot write
+# one. This single glob covers every bench and monitor, present and future.
+install_logrotate() {
+    home="$(bench_home "$1")"
+    [ -n "$home" ] && [ -d /etc/logrotate.d ] || return 0
+    echo "Installing log rotation for '$1'..."
+    cat > /etc/logrotate.d/pilot <<EOF
+$home/pilot/logs/*.log $home/pilot/benches/*/logs/*.log {
+    size 500M
+    rotate 3
+    compress
+    missingok
+    notifempty
+    copytruncate
+    su $1 $1
+}
+EOF
+    chmod 644 /etc/logrotate.d/pilot
+}
+
+# Reloading nginx and running certbot need root every time a bench deploys or a
+# cert renews. These mirror NginxManager.setup_sudoers and
+# LetsEncryptManager.setup_sudoers, which check whether a grant works before
+# rewriting it — so the two only have to agree in effect, not in text.
 install_sudoers_grants() {
     [ -d /etc/sudoers.d ] || return 0
     command -v visudo >/dev/null 2>&1 || return 0
@@ -436,8 +427,8 @@ install_sudoers_grants() {
 "$1 ALL=(ALL) NOPASSWD: $certbot_bin certonly --webroot -w $webroot * --cert-name * --expand --email * --agree-tos --non-interactive --deploy-hook $hook,$certbot_bin certonly --webroot -w $webroot -d * --email * --agree-tos --non-interactive --deploy-hook $hook,$certbot_bin renew --quiet,$mkdir_bin -p $webroot,$test_bin -f $live/*/fullchain.pem -a -f $live/*/privkey.pem,$openssl_bin x509 -noout -ext subjectAltName -in $live/*/fullchain.pem,$openssl_bin x509 -enddate -noout -in $live/*/fullchain.pem"
 }
 
-# Validate before installing: a malformed file in /etc/sudoers.d breaks sudo
-# for everyone, including the recovery path.
+# A malformed file in /etc/sudoers.d breaks sudo for every user, including the
+# recovery path, so validate before installing.
 write_sudoers_file() {
     staged="$(mktemp)"
     echo "$2" > "$staged"
@@ -449,68 +440,22 @@ write_sudoers_file() {
     rm -f "$staged"
 }
 
-# logrotate refuses to read a config it doesn't own, so these can't be written
-# by the bench user at runtime. One root-owned config globbing the log dirs
-# covers every bench and every monitor, present and future.
-install_logrotate() {
-    bench_home="$(getent passwd "$1" | cut -d: -f6)"
-    [ -n "$bench_home" ] && [ -d /etc/logrotate.d ] || return 0
-    echo "Installing log rotation for '$1'..."
-    cat > /etc/logrotate.d/pilot <<EOF
-$bench_home/pilot/logs/*.log $bench_home/pilot/benches/*/logs/*.log {
-    size 500M
-    rotate 3
-    compress
-    missingok
-    notifempty
-    copytruncate
-    su $1 $1
-}
-EOF
-    chmod 644 /etc/logrotate.d/pilot
-}
-
-# nginx workers must run as the bench user to read its sites. Doing it here
-# keeps `bench setup production` out of /etc/nginx/nginx.conf entirely.
-set_nginx_worker_user() {
-    conf=/etc/nginx/nginx.conf
-    [ "$DISTRO" != "macos" ] && [ -f "$conf" ] || return 0
-    grep -q "^[[:space:]]*user[[:space:]]\{1,\}$1;" "$conf" && return 0
-    echo "Setting the nginx worker user to '$1'..."
-    if grep -q "^[[:space:]]*user[[:space:]]" "$conf"; then
-        sed -i "s/^[[:space:]]*user[[:space:]].*;/user $1;/" "$conf"
-    else
-        sed -i "1i user $1;" "$conf"
-    fi
-}
-
-# ── Path A: running as root → create the bench user, then stop ───────────────
-# We do NOT switch users on the fly. We prepare the account and ask the operator
-# to re-run the installer as that user.
-if [ "$(id -u)" -eq 0 ]; then
+# We never switch users mid-run: prepare the account, then ask the operator to
+# come back as that user.
+prepare_host() {
     echo "Running as root. Preparing the '$BENCH_USER' user for bench..."
-
-    if ! id "$BENCH_USER" >/dev/null 2>&1; then
-        echo "Creating user '$BENCH_USER'..."
-        useradd -m -s /bin/bash "$BENCH_USER"
-        usermod -aG "$(admin_group)" "$BENCH_USER" 2>/dev/null || true
-    fi
-
-    if systemd_booted && ! linger_enabled "$BENCH_USER"; then
-        echo "Enabling systemd lingering for '$BENCH_USER'..."
-        loginctl enable-linger "$BENCH_USER"
-    fi
-
+    create_bench_user "$BENCH_USER"
+    enable_linger "$BENCH_USER"
     install_nginx_include "$BENCH_USER"
     set_nginx_worker_user "$BENCH_USER"
     install_logrotate "$BENCH_USER"
     install_sudoers_grants "$BENCH_USER"
-    install_sudoers_grants "$BENCH_USER"
 
     echo ""
     echo "========================================================================"
-    echo " User '$BENCH_USER' is ready — base tools and database engines are"
-    echo " installed system-wide, so day-to-day bench commands never need root."
+    echo " User '$BENCH_USER' is ready — base tools, database engines and the"
+    echo " production stack are installed system-wide, so day-to-day bench"
+    echo " commands never need root."
     echo ""
     echo " bench must NOT be installed as root. Switch to '$BENCH_USER' and run"
     echo " the installer again:"
@@ -518,38 +463,44 @@ if [ "$(id -u)" -eq 0 ]; then
     echo "   su - $BENCH_USER"
     echo "   curl -fsSL $INSTALL_URL | bash"
     echo "========================================================================"
-    exit 0
-fi
+}
 
-# ── Path B: running as a normal user → clone and install ─────────────────────
-# All system-wide, privileged setup (base tools, database engines, Node.js)
-# already happened in bootstrap() above — as root, or earlier in this same
-# run if a base tool was missing — so nothing below here needs sudo.
-# Lingering is normally enabled by the root pass above. If this user was
-# prepared some other way, only root can turn it on — fail here rather than
-# midway through `bench init`, where systemctl --user has no bus to talk to.
-if systemd_booted && ! linger_enabled "$(id -un)"; then
-    if ! sudo -n loginctl enable-linger "$(id -un)" 2>/dev/null; then
-        echo "systemd lingering is not enabled for '$(id -un)', and this user cannot" >&2
-        echo "enable it without a password. Bench services run as systemctl --user" >&2
-        echo "units, which need it." >&2
-        echo "" >&2
-        echo "Run this as root, then re-run the installer:" >&2
-        echo "" >&2
-        echo "   loginctl enable-linger $(id -un)" >&2
-        exit 1
-    fi
-fi
+# ── bench user install ────────────────────────────────────────────────────────
+# Nothing below here needs privileges: prepare_host granted them all already.
 
-echo "Setting up your environment..."
+# Only root can turn lingering on. Fail now rather than midway through
+# `bench init`, where systemctl --user finds no bus to talk to.
+require_linger() {
+    systemd_booted || return 0
+    linger_enabled "$(id -un)" && return 0
+    sudo -n loginctl enable-linger "$(id -un)" 2>/dev/null && return 0
+    echo "systemd lingering is not enabled for '$(id -un)', and this user cannot" >&2
+    echo "enable it without a password. Bench services run as systemctl --user" >&2
+    echo "units, which need it." >&2
+    echo "" >&2
+    echo "Run this as root, then re-run the installer:" >&2
+    echo "" >&2
+    echo "   loginctl enable-linger $(id -un)" >&2
+    exit 1
+}
 
-# ── fetch pilot: release tarball (default) or git clone (--dev) ────────────────
 # The release tarball ships the compiled admin frontend and a VERSION file;
-# --dev clones the source so contributors always build the frontend locally.
-install_release_tarball() {
-    releases_api="https://api.github.com/repos/frappe/pilot/releases?per_page=1"
+# --dev clones the source so contributors build the frontend locally.
+fetch_pilot() {
+    if [ -n "$DEV_MODE" ]; then
+        if [ -d "$PILOT_DIR/.git" ]; then
+            echo "Updating pilot (dev)..."
+            git -C "$PILOT_DIR" pull
+        else
+            echo "Cloning pilot ($BRANCH_NAME branch)..."
+            git clone -b "$BRANCH_NAME" "$REPO_URL" "$PILOT_DIR"
+        fi
+        return
+    fi
+
     echo "Fetching the latest pilot release..."
-    asset_url=$(curl -fsSL --proto '=https' --tlsv1.2 "$releases_api" \
+    asset_url=$(curl -fsSL --proto '=https' --tlsv1.2 \
+        "https://api.github.com/repos/frappe/pilot/releases?per_page=1" \
         | grep -o 'https://[^"]*/pilot\.tar\.gz' | head -n1)
     if [ -z "$asset_url" ]; then
         echo "Could not find a pilot.tar.gz release asset." >&2
@@ -558,35 +509,20 @@ install_release_tarball() {
     fi
     tmp="$(mktemp)"
     curl -fsSL --proto '=https' --tlsv1.2 "$asset_url" -o "$tmp"
-    # tar only writes archived paths, so an existing benches/ (local data) is left intact.
+    # tar only writes archived paths, so an existing benches/ is left intact.
     mkdir -p "$PILOT_DIR"
     tar -xzf "$tmp" -C "$PILOT_DIR"
     rm -f "$tmp"
 }
 
-if [ -n "$DEV_MODE" ]; then
-    if [ -d "$PILOT_DIR/.git" ]; then
-        echo "Updating pilot (dev)..."
-        git -C "$PILOT_DIR" pull
-    else
-        echo "Cloning pilot ($BRANCH_NAME branch)..."
-        git clone -b "$BRANCH_NAME" "$REPO_URL" "$PILOT_DIR"
-    fi
-else
-    install_release_tarball
-fi
-
-chmod +x "$PILOT_DIR/bench"
-
-# ── uv ────────────────────────────────────────────────────────────────────────
-if ! command -v uv >/dev/null 2>&1; then
+ensure_uv() {
+    command -v uv >/dev/null 2>&1 && return 0
     echo "Installing uv..."
     curl -LsSf https://astral.sh/uv/install.sh | sh
     export PATH="$HOME/.local/bin:$PATH"
-fi
+}
 
-# ── timezone data ─────────────────────────────────────────────────────────────
-# Required by Python's zoneinfo module on systems without system tzdata.
+# Python's zoneinfo needs this on systems without system tzdata.
 ensure_tzdata() {
     case "$DISTRO" in
         macos) return 0 ;;
@@ -597,80 +533,83 @@ ensure_tzdata() {
     pkg_install tzdata
 }
 
-ensure_tzdata
+# Sets RC_FILE to the rc it touched, for the closing hint.
+add_bench_to_path() {
+    RC_FILE=""
+    case "$SHELL" in
+        */fish)       RC_FILE="$HOME/.config/fish/config.fish" ;;
+        */zsh)        RC_FILE="$HOME/.zshrc" ;;
+        # POSIX login shells read ~/.profile.
+        */ash|*/sh|"") RC_FILE="$HOME/.profile" ;;
+        *)            RC_FILE="$HOME/.bashrc" ;;
+    esac
+    mkdir -p "$(dirname "$RC_FILE")"
+    if ! grep -qF 'pilot' "$RC_FILE" 2>/dev/null; then
+        case "$SHELL" in
+            */fish) echo "fish_add_path \$HOME/pilot" >> "$RC_FILE" ;;
+            *)      echo "export PATH=\"\$HOME/pilot:\$PATH\"" >> "$RC_FILE" ;;
+        esac
+        echo "Added bench to PATH in $RC_FILE"
+    fi
 
-# ── add bench to PATH ─────────────────────────────────────────────────────────
-add_to_path() {
-    rc="$1"
-    line="export PATH=\"\$HOME/pilot:\$PATH\""
-    if ! grep -qF 'pilot' "$rc" 2>/dev/null; then
-        echo "$line" >> "$rc"
-        echo "Added bench to PATH in $rc"
+    export PATH="$PILOT_DIR:$PATH"
+    # fish rc syntax is not sh, so never source it back into this shell.
+    case "$SHELL" in */fish) RC_FILE=""; return ;; esac
+    # Best-effort: shell-specific rc syntax may not parse here, which is fine —
+    # the export above already applies and a new terminal reads the rc.
+    if [ -f "$RC_FILE" ]; then
+        # shellcheck disable=SC1090
+        . "$RC_FILE" 2>/dev/null || true
     fi
 }
 
-RC_FILE=""
-case "$SHELL" in
-    */fish)
-        FISH_CONFIG="$HOME/.config/fish/config.fish"
-        mkdir -p "$(dirname "$FISH_CONFIG")"
-        if ! grep -qF 'pilot' "$FISH_CONFIG" 2>/dev/null; then
-            echo "fish_add_path \$HOME/pilot" >> "$FISH_CONFIG"
-            echo "Added bench to PATH in $FISH_CONFIG"
-        fi
-        ;;
-    */zsh)
-        RC_FILE="$HOME/.zshrc"
-        add_to_path "$RC_FILE"
-        ;;
-    */ash|*/sh|"")
-        # POSIX login shells read ~/.profile.
-        RC_FILE="$HOME/.profile"
-        add_to_path "$RC_FILE"
-        ;;
-    *)
-        RC_FILE="$HOME/.bashrc"
-        add_to_path "$RC_FILE"
-        ;;
-esac
-
-export PATH="$PILOT_DIR:$PATH"
-
-# Best-effort: load the updated rc into this session. Shell-specific syntax (or a
-# zsh rc sourced under bash) may fail — that's fine, the PATH export above already
-# applies and a new terminal picks up the rc.
-if [ -n "$RC_FILE" ] && [ -f "$RC_FILE" ]; then
-    # shellcheck disable=SC1090
-    . "$RC_FILE" 2>/dev/null || true
-fi
-
-# ── admin venv ────────────────────────────────────────────────────────────────
-ADMIN_VENV="$PILOT_DIR/.admin-venv"
-if [ ! -f "$ADMIN_VENV/bin/python" ]; then
+ensure_admin_venv() {
+    admin_venv="$PILOT_DIR/.admin-venv"
+    [ -f "$admin_venv/bin/python" ] && return 0
     echo "Setting up admin environment..."
-    uv venv "$ADMIN_VENV" --quiet
+    uv venv "$admin_venv" --quiet
     if command -v python3 >/dev/null 2>&1; then
-        ADMIN_DEPS=$(python3 -c "
-import tomllib, sys
+        admin_deps=$(python3 -c "
+import tomllib
 with open('$PILOT_DIR/pyproject.toml', 'rb') as f:
-    d = tomllib.load(f)
-deps = d.get('project', {}).get('optional-dependencies', {}).get('admin', [])
-print(' '.join(deps))
+    project = tomllib.load(f)
+print(' '.join(project.get('project', {}).get('optional-dependencies', {}).get('admin', [])))
 " 2>/dev/null)
     fi
-    if [ -z "$ADMIN_DEPS" ]; then
-        ADMIN_DEPS="flask>=3.0 psutil>=5.9 pymysql>=1.1 gunicorn>=21.2 pyjwt[crypto]>=2.8"
+    if [ -z "$admin_deps" ]; then
+        admin_deps="flask>=3.0 psutil>=5.9 pymysql>=1.1 gunicorn>=21.2 pyjwt[crypto]>=2.8"
     fi
-    # shellcheck disable=SC2086 # ADMIN_DEPS is a space-separated list
-    uv pip install --python "$ADMIN_VENV/bin/python" --quiet $ADMIN_DEPS
+    # shellcheck disable=SC2086 # admin_deps is a space-separated list
+    uv pip install --python "$admin_venv/bin/python" --quiet $admin_deps
     echo "Admin environment ready."
+}
+
+install_for_user() {
+    echo "Setting up your environment..."
+    require_linger
+    fetch_pilot
+    chmod +x "$PILOT_DIR/bench"
+    ensure_uv
+    ensure_tzdata
+    add_bench_to_path
+    ensure_admin_venv
+
+    echo ""
+    echo "bench installed to $PILOT_DIR"
+    echo ""
+    echo "Quick start:"
+    echo "  bench new my-bench"
+    echo "  bench start"
+    echo ""
+    echo "If 'bench' is not found, open a new terminal or run: . ${RC_FILE:-$HOME/.bashrc}"
+}
+
+# ── run ───────────────────────────────────────────────────────────────────────
+install_system_packages
+
+if is_root; then
+    prepare_host
+    exit 0
 fi
 
-echo ""
-echo "bench installed to $PILOT_DIR"
-echo ""
-echo "Quick start:"
-echo "  bench new my-bench"
-echo "  bench start"
-echo ""
-echo "If 'bench' is not found, open a new terminal or run: . ${RC_FILE:-$HOME/.bashrc}"
+install_for_user

--- a/install.sh
+++ b/install.sh
@@ -405,6 +405,50 @@ EOF
     done
 }
 
+# Reloading nginx and running certbot are the two things a deployed bench needs
+# root for, every time. Granting them here is what keeps `bench setup
+# production` from having to ask: writing to /etc/sudoers.d is itself a
+# root-only act, so the runtime could never do it unprompted.
+#
+# These mirror NginxManager.setup_sudoers and LetsEncryptManager.setup_sudoers.
+# They only have to be functionally equivalent, not textually identical - both
+# check whether the grant already works before rewriting it.
+install_sudoers_grants() {
+    [ -d /etc/sudoers.d ] || return 0
+    command -v visudo >/dev/null 2>&1 || return 0
+    nginx_bin="$(command -v nginx || echo /usr/sbin/nginx)"
+    certbot_bin="$(command -v certbot || echo /usr/bin/certbot)"
+    openssl_bin="$(command -v openssl || echo /usr/bin/openssl)"
+    systemctl_bin="$(command -v systemctl || echo /bin/systemctl)"
+    mkdir_bin="$(command -v mkdir || echo /bin/mkdir)"
+    test_bin="$(command -v test || echo /usr/bin/test)"
+    webroot=/var/www/letsencrypt
+    live=/etc/letsencrypt/live
+    hook="systemctl reload nginx"
+
+    echo "Granting '$1' passwordless sudo for nginx and certbot..."
+    write_sudoers_file "$1-pilot-nginx" \
+"$1 ALL=(ALL) NOPASSWD: $nginx_bin -t,$nginx_bin -T,$systemctl_bin start nginx,$systemctl_bin stop nginx,$systemctl_bin reload nginx"
+    # Domain and email tokens stay wildcarded (sites arrive long after this is
+    # written), but each wildcard is anchored between fixed literal text, so no
+    # extra flag can be smuggled in before or after the match.
+    write_sudoers_file "$1-pilot-certbot" \
+"$1 ALL=(ALL) NOPASSWD: $certbot_bin certonly --webroot -w $webroot * --cert-name * --expand --email * --agree-tos --non-interactive --deploy-hook $hook,$certbot_bin certonly --webroot -w $webroot -d * --email * --agree-tos --non-interactive --deploy-hook $hook,$certbot_bin renew --quiet,$mkdir_bin -p $webroot,$test_bin -f $live/*/fullchain.pem -a -f $live/*/privkey.pem,$openssl_bin x509 -noout -ext subjectAltName -in $live/*/fullchain.pem,$openssl_bin x509 -enddate -noout -in $live/*/fullchain.pem"
+}
+
+# Validate before installing: a malformed file in /etc/sudoers.d breaks sudo
+# for everyone, including the recovery path.
+write_sudoers_file() {
+    staged="$(mktemp)"
+    echo "$2" > "$staged"
+    if visudo -cf "$staged" >/dev/null 2>&1; then
+        install -m 440 "$staged" "/etc/sudoers.d/$1"
+    else
+        echo "Refusing to install a malformed sudoers grant ($1)." >&2
+    fi
+    rm -f "$staged"
+}
+
 # logrotate refuses to read a config it doesn't own, so these can't be written
 # by the bench user at runtime. One root-owned config globbing the log dirs
 # covers every bench and every monitor, present and future.
@@ -460,6 +504,7 @@ if [ "$(id -u)" -eq 0 ]; then
     install_nginx_include "$BENCH_USER"
     set_nginx_worker_user "$BENCH_USER"
     install_logrotate "$BENCH_USER"
+    install_sudoers_grants "$BENCH_USER"
     install_sudoers_grants "$BENCH_USER"
 
     echo ""

--- a/install.sh
+++ b/install.sh
@@ -460,6 +460,7 @@ if [ "$(id -u)" -eq 0 ]; then
     install_nginx_include "$BENCH_USER"
     set_nginx_worker_user "$BENCH_USER"
     install_logrotate "$BENCH_USER"
+    install_sudoers_grants "$BENCH_USER"
 
     echo ""
     echo "========================================================================"

--- a/install.sh
+++ b/install.sh
@@ -402,6 +402,17 @@ EOF
     chmod 644 /etc/logrotate.d/pilot
 }
 
+# `command -v` returns the bare name for shell builtins like `test`, but a
+# sudoers Cmnd must be a fully-qualified path or visudo rejects the whole file.
+# Mirror the runtime's shutil.which by taking only an absolute PATH match.
+resolve_binary() {
+    resolved="$(command -v "$1" 2>/dev/null || true)"
+    case "$resolved" in
+        /*) echo "$resolved" ;;
+        *) echo "$2" ;;
+    esac
+}
+
 # Reloading nginx and running certbot need root every time a bench deploys or a
 # cert renews. These mirror NginxManager.setup_sudoers and
 # LetsEncryptManager.setup_sudoers, which check whether a grant works before
@@ -409,12 +420,12 @@ EOF
 install_sudoers_grants() {
     [ -d /etc/sudoers.d ] || return 0
     command -v visudo >/dev/null 2>&1 || return 0
-    nginx_bin="$(command -v nginx || echo /usr/sbin/nginx)"
-    certbot_bin="$(command -v certbot || echo /usr/bin/certbot)"
-    openssl_bin="$(command -v openssl || echo /usr/bin/openssl)"
-    systemctl_bin="$(command -v systemctl || echo /bin/systemctl)"
-    mkdir_bin="$(command -v mkdir || echo /bin/mkdir)"
-    test_bin="$(command -v test || echo /usr/bin/test)"
+    nginx_bin="$(resolve_binary nginx /usr/sbin/nginx)"
+    certbot_bin="$(resolve_binary certbot /usr/bin/certbot)"
+    openssl_bin="$(resolve_binary openssl /usr/bin/openssl)"
+    systemctl_bin="$(resolve_binary systemctl /bin/systemctl)"
+    mkdir_bin="$(resolve_binary mkdir /bin/mkdir)"
+    test_bin="$(resolve_binary test /usr/bin/test)"
     webroot=/var/www/letsencrypt
     live=/etc/letsencrypt/live
     hook="systemctl reload nginx"

--- a/install.sh
+++ b/install.sh
@@ -379,6 +379,22 @@ linger_enabled() {
     [ "$(loginctl show-user "$1" --property=Linger 2>/dev/null)" = "Linger=yes" ]
 }
 
+# nginx reads each bench's vhost from a file the bench user owns. Root drops
+# the one glob that pulls them in, so publishing a vhost afterwards is an
+# ordinary file write instead of a privileged symlink into /etc/nginx.
+install_nginx_include() {
+    bench_home="$(getent passwd "$1" | cut -d: -f6)"
+    [ -n "$bench_home" ] && [ -d /etc/nginx/conf.d ] || return 0
+    echo "Installing the nginx include for '$1'..."
+    cat > /etc/nginx/conf.d/00-pilot.conf <<EOF
+include $bench_home/pilot/benches/*/config/nginx/include.conf;
+EOF
+    chmod 644 /etc/nginx/conf.d/00-pilot.conf
+    # The distro's stock default site also claims default_server on :80;
+    # nginx rejects a duplicate, so drop it and let a bench's vhost win.
+    rm -f /etc/nginx/sites-enabled/default
+}
+
 # ── Path A: running as root → create the bench user, then stop ───────────────
 # We do NOT switch users on the fly. We prepare the account and ask the operator
 # to re-run the installer as that user.
@@ -395,6 +411,8 @@ if [ "$(id -u)" -eq 0 ]; then
         echo "Enabling systemd lingering for '$BENCH_USER'..."
         loginctl enable-linger "$BENCH_USER"
     fi
+
+    install_nginx_include "$BENCH_USER"
 
     echo ""
     echo "========================================================================"

--- a/install.sh
+++ b/install.sh
@@ -405,6 +405,20 @@ EOF
     done
 }
 
+# nginx workers must run as the bench user to read its sites. Doing it here
+# keeps `bench setup production` out of /etc/nginx/nginx.conf entirely.
+set_nginx_worker_user() {
+    conf=/etc/nginx/nginx.conf
+    [ "$DISTRO" != "macos" ] && [ -f "$conf" ] || return 0
+    grep -q "^[[:space:]]*user[[:space:]]\{1,\}$1;" "$conf" && return 0
+    echo "Setting the nginx worker user to '$1'..."
+    if grep -q "^[[:space:]]*user[[:space:]]" "$conf"; then
+        sed -i "s/^[[:space:]]*user[[:space:]].*;/user $1;/" "$conf"
+    else
+        sed -i "1i user $1;" "$conf"
+    fi
+}
+
 # ── Path A: running as root → create the bench user, then stop ───────────────
 # We do NOT switch users on the fly. We prepare the account and ask the operator
 # to re-run the installer as that user.
@@ -423,6 +437,7 @@ if [ "$(id -u)" -eq 0 ]; then
     fi
 
     install_nginx_include "$BENCH_USER"
+    set_nginx_worker_user "$BENCH_USER"
 
     echo ""
     echo "========================================================================"

--- a/install.sh
+++ b/install.sh
@@ -405,6 +405,27 @@ EOF
     done
 }
 
+# logrotate refuses to read a config it doesn't own, so these can't be written
+# by the bench user at runtime. One root-owned config globbing the log dirs
+# covers every bench and every monitor, present and future.
+install_logrotate() {
+    bench_home="$(getent passwd "$1" | cut -d: -f6)"
+    [ -n "$bench_home" ] && [ -d /etc/logrotate.d ] || return 0
+    echo "Installing log rotation for '$1'..."
+    cat > /etc/logrotate.d/pilot <<EOF
+$bench_home/pilot/logs/*.log $bench_home/pilot/benches/*/logs/*.log {
+    size 500M
+    rotate 3
+    compress
+    missingok
+    notifempty
+    copytruncate
+    su $1 $1
+}
+EOF
+    chmod 644 /etc/logrotate.d/pilot
+}
+
 # nginx workers must run as the bench user to read its sites. Doing it here
 # keeps `bench setup production` out of /etc/nginx/nginx.conf entirely.
 set_nginx_worker_user() {
@@ -438,6 +459,7 @@ if [ "$(id -u)" -eq 0 ]; then
 
     install_nginx_include "$BENCH_USER"
     set_nginx_worker_user "$BENCH_USER"
+    install_logrotate "$BENCH_USER"
 
     echo ""
     echo "========================================================================"

--- a/install.sh
+++ b/install.sh
@@ -394,6 +394,15 @@ EOF
     # The distro's stock default site also claims default_server on :80;
     # nginx rejects a duplicate, so drop it and let a bench's vhost win.
     rm -f /etc/nginx/sites-enabled/default
+    # Older installs symlinked each bench into conf.d. The glob above now
+    # loads the same file, and nginx rejects the duplicate server blocks, so
+    # a re-run has to clear the symlinks it supersedes.
+    for link in /etc/nginx/conf.d/*.conf; do
+        [ -L "$link" ] || continue
+        case "$(readlink "$link")" in
+            "$bench_home"/pilot/benches/*) rm -f "$link" ;;
+        esac
+    done
 }
 
 # ── Path A: running as root → create the bench user, then stop ───────────────

--- a/install.sh
+++ b/install.sh
@@ -9,9 +9,11 @@ set -e
 # As that user it installs bench itself, needing no privileges at all.
 
 # ── configuration ─────────────────────────────────────────────────────────────
-INSTALL_URL="https://raw.githubusercontent.com/frappe/pilot/main/install.sh"
-# Overridable so smoke tests can install from a local checkout.
-REPO_URL="${PILOT_REPO_URL:-https://github.com/frappe/pilot}"
+# All three point at the same GitHub repo; override PILOT_GITHUB_SLUG to install
+# from a fork (releases + self-reference URL follow it).
+GITHUB_SLUG="${PILOT_GITHUB_SLUG:-frappe/pilot}"
+INSTALL_URL="https://raw.githubusercontent.com/$GITHUB_SLUG/main/install.sh"
+REPO_URL="${PILOT_REPO_URL:-https://github.com/$GITHUB_SLUG}"
 BRANCH_NAME="${PILOT_BRANCH:-main}"
 PILOT_DIR="$HOME/pilot"
 BENCH_USER="${BENCH_USER:-frappe}"
@@ -500,7 +502,7 @@ fetch_pilot() {
 
     echo "Fetching the latest pilot release..."
     asset_url=$(curl -fsSL --proto '=https' --tlsv1.2 \
-        "https://api.github.com/repos/frappe/pilot/releases?per_page=1" \
+        "https://api.github.com/repos/$GITHUB_SLUG/releases?per_page=1" \
         | grep -o 'https://[^"]*/pilot\.tar\.gz' | head -n1)
     if [ -z "$asset_url" ]; then
         echo "Could not find a pilot.tar.gz release asset." >&2

--- a/install.sh
+++ b/install.sh
@@ -557,11 +557,12 @@ add_path_line() {
 
 # Sets RC_FILE to the rc it touched, for the closing hint.
 add_bench_to_path() {
-    export_line='export PATH="$HOME/pilot:$PATH"'
+    # Escaped so $HOME lands literally in the rc file and expands at shell start.
+    export_line="export PATH=\"\$HOME/pilot:\$PATH\""
     case "$SHELL" in
         */fish)
             RC_FILE="$HOME/.config/fish/config.fish"
-            add_path_line "$RC_FILE" 'fish_add_path $HOME/pilot' ;;
+            add_path_line "$RC_FILE" "fish_add_path \$HOME/pilot" ;;
         */zsh)
             RC_FILE="$HOME/.zshrc"
             add_path_line "$RC_FILE" "$export_line" ;;

--- a/install.sh
+++ b/install.sh
@@ -546,24 +546,36 @@ ensure_tzdata() {
     pkg_install tzdata
 }
 
+# Appends the given PATH line to a file once, if not already there.
+add_path_line() {
+    file="$1"; line="$2"
+    mkdir -p "$(dirname "$file")"
+    grep -qF 'pilot' "$file" 2>/dev/null && return 0
+    echo "$line" >> "$file"
+    echo "Added bench to PATH in $file"
+}
+
 # Sets RC_FILE to the rc it touched, for the closing hint.
 add_bench_to_path() {
-    RC_FILE=""
+    export_line='export PATH="$HOME/pilot:$PATH"'
     case "$SHELL" in
-        */fish)       RC_FILE="$HOME/.config/fish/config.fish" ;;
-        */zsh)        RC_FILE="$HOME/.zshrc" ;;
+        */fish)
+            RC_FILE="$HOME/.config/fish/config.fish"
+            add_path_line "$RC_FILE" 'fish_add_path $HOME/pilot' ;;
+        */zsh)
+            RC_FILE="$HOME/.zshrc"
+            add_path_line "$RC_FILE" "$export_line" ;;
         # POSIX login shells read ~/.profile.
-        */ash|*/sh|"") RC_FILE="$HOME/.profile" ;;
-        *)            RC_FILE="$HOME/.bashrc" ;;
+        */ash|*/sh|"")
+            RC_FILE="$HOME/.profile"
+            add_path_line "$RC_FILE" "$export_line" ;;
+        *)
+            # bash reads ~/.bashrc when interactive but ~/.profile on login
+            # (and non-interactive login, e.g. `su - user -c`), so cover both.
+            RC_FILE="$HOME/.bashrc"
+            add_path_line "$RC_FILE" "$export_line"
+            add_path_line "$HOME/.profile" "$export_line" ;;
     esac
-    mkdir -p "$(dirname "$RC_FILE")"
-    if ! grep -qF 'pilot' "$RC_FILE" 2>/dev/null; then
-        case "$SHELL" in
-            */fish) echo "fish_add_path \$HOME/pilot" >> "$RC_FILE" ;;
-            *)      echo "export PATH=\"\$HOME/pilot:\$PATH\"" >> "$RC_FILE" ;;
-        esac
-        echo "Added bench to PATH in $RC_FILE"
-    fi
 
     export PATH="$PILOT_DIR:$PATH"
     # fish rc syntax is not sh, so never source it back into this shell.

--- a/install.sh
+++ b/install.sh
@@ -387,6 +387,7 @@ install_nginx_include() {
     [ -n "$bench_home" ] && [ -d /etc/nginx/conf.d ] || return 0
     echo "Installing the nginx include for '$1'..."
     cat > /etc/nginx/conf.d/00-pilot.conf <<EOF
+include $bench_home/pilot/nginx/*.conf;
 include $bench_home/pilot/benches/*/config/nginx/include.conf;
 EOF
     chmod 644 /etc/nginx/conf.d/00-pilot.conf

--- a/pilot/config/monitor.py
+++ b/pilot/config/monitor.py
@@ -1,24 +1,32 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
+
+
+def _log_dir() -> Path:
+    """Monitor logs live beside the install, not in root-owned /var/log."""
+    from pilot.utils import cli_root
+
+    return cli_root() / "logs"
 
 
 @dataclass
 class MonitorConfig:
-    system_log_path: Path = Path("/var/log/bench-system-stats.log")
-    db_log_path: Path = Path("/var/log/bench-db-stats.log")
-    slow_query_log_path: Path = Path("/var/log/bench-slow-queries.json")
-    authority_file_path: Path = Path("/var/log/.bench-authority")
+    system_log_path: Path = field(default_factory=lambda: _log_dir() / "bench-system-stats.log")
+    db_log_path: Path = field(default_factory=lambda: _log_dir() / "bench-db-stats.log")
+    slow_query_log_path: Path = field(default_factory=lambda: _log_dir() / "bench-slow-queries.json")
+    authority_file_path: Path = field(default_factory=lambda: _log_dir() / ".bench-authority")
     system_log_max_size: str = "500M"
     application_log_max_size: str = "500M"
     log_path: Path | None = None  # set by `bench setup production`
 
     @classmethod
     def from_dict(cls, data: dict) -> "MonitorConfig":
+        log_dir = _log_dir()
         return cls(
-            system_log_path=Path(data.get("system_log_path", "/var/log/bench-system-stats.log")),
-            db_log_path=Path(data.get("db_log_path", "/var/log/bench-db-stats.log")),
-            slow_query_log_path=Path(data.get("slow_query_log_path", "/var/log/bench-slow-queries.json")),
-            authority_file_path=Path(data.get("authority_file_path", "/var/log/.bench-authority")),
+            system_log_path=Path(data.get("system_log_path", log_dir / "bench-system-stats.log")),
+            db_log_path=Path(data.get("db_log_path", log_dir / "bench-db-stats.log")),
+            slow_query_log_path=Path(data.get("slow_query_log_path", log_dir / "bench-slow-queries.json")),
+            authority_file_path=Path(data.get("authority_file_path", log_dir / ".bench-authority")),
             system_log_max_size=data.get("system_log_max_size", "500M"),
             application_log_max_size=data.get("application_log_max_size", "500M"),
             log_path=Path(data["log_path"]) if "log_path" in data else None,
@@ -26,4 +34,4 @@ class MonitorConfig:
 
     @staticmethod
     def default_log_path(bench_name: str) -> Path:
-        return Path(f"/var/log/{bench_name}-stats.log")
+        return _log_dir() / f"{bench_name}-stats.log"

--- a/pilot/core/bench/setup.py
+++ b/pilot/core/bench/setup.py
@@ -189,8 +189,8 @@ class ProductionSetup:
         if not sys.stdin.isatty():
             raise BenchError(
                 "Deploying to production needs root (nginx, certbot, systemd) and there's no "
-                "terminal to prompt for a sudo password. Run this interactively, or configure "
-                "passwordless sudo for this user first."
+                "terminal to prompt for a sudo password. Re-run the installer as root to grant "
+                "this user what production needs, then deploy again."
             )
 
     def _check_admin_domain(self) -> None:

--- a/pilot/core/bench/setup.py
+++ b/pilot/core/bench/setup.py
@@ -177,10 +177,13 @@ class ProductionSetup:
             sys.exit(1)
 
     def _check_sudo_available(self) -> None:
-        """Fail early when production setup cannot get root privileges."""
+        """Fail early when production setup cannot get the privileges it needs.
+        The installer's scoped nginx/certbot grants are enough and need no tty;
+        only fall back to a password prompt when they are absent."""
+        from pilot.managers.nginx import NginxManager
         from pilot.managers.platform import has_passwordless_sudo, is_root, which
 
-        if is_root() or has_passwordless_sudo():
+        if is_root() or has_passwordless_sudo() or NginxManager(self.bench).has_passwordless_sudo:
             return
         if which("sudo") is None:
             raise BenchError(

--- a/pilot/core/server/monitoring_config.py
+++ b/pilot/core/server/monitoring_config.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import contextlib
-import getpass
 import os
 import typing
 from pathlib import Path
 
 from pilot.exceptions import BenchError
-from pilot.managers.platform import _privileged, is_linux
+from pilot.managers.platform import is_linux
 from pilot.utils import cli_root, iter_sibling_benches, run_command
 
 if typing.TYPE_CHECKING:
@@ -35,8 +33,8 @@ Type=oneshot
 WorkingDirectory={cli_root}
 Environment=PYTHONPATH={cli_root}
 ExecStart={python} -m pilot.core.server.monitoring
-StandardOutput=append:/var/log/bench-monitor.log
-StandardError=append:/var/log/bench-monitor.error.log
+StandardOutput=append:{cli_root}/logs/bench-monitor.log
+StandardError=append:{cli_root}/logs/bench-monitor.error.log
 
 [Install]
 WantedBy=default.target
@@ -60,15 +58,6 @@ class MonitorConfigurator:
         self._install_user_unit()
         self._write_timer_unit()
         self._install_user_timer_unit()
-
-        # Best-effort: both are idempotent preconditions that may already be
-        # satisfied, so a failure here isn't fatal.
-        for command in (
-            ["loginctl", "enable-linger", getpass.getuser()],
-            ["systemctl", "start", f"user@{os.getuid()}.service"],
-        ):
-            with contextlib.suppress(Exception):
-                run_command(_privileged(command))
 
         env = self._systemctl_env()
         run_command(self._systemctl("daemon-reload"), env=env)
@@ -97,29 +86,7 @@ class MonitorConfigurator:
         if not is_linux():
             raise BenchError("Monitoring is only supported on linux based machines.")
 
-        log_dir = self.log_path.parent
-        log_dir.mkdir(parents=True, exist_ok=True)
-        run_command(_privileged(["chown", f"{os.getuid()}:{os.getgid()}", str(log_dir)]))
-        self.setup_log_rotation()
-
-    def setup_log_rotation(self) -> None:
-        bench = self._require_bench()
-        monitor_config = bench.config.monitor
-        self._write_logrotate_config(
-            f"/etc/logrotate.d/{bench.config.name}-stats",
-            self.log_path,
-            monitor_config.application_log_max_size,
-        )
-        self._write_logrotate_config(
-            "/etc/logrotate.d/bench-system-stats",
-            self.system_log_path,
-            monitor_config.system_log_max_size,
-        )
-        self._write_logrotate_config(
-            "/etc/logrotate.d/bench-db-stats",
-            self.db_log_path,
-            monitor_config.system_log_max_size,
-        )
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
 
     def is_system_log_authority(self) -> bool:
         bench = self._require_bench()
@@ -179,22 +146,6 @@ class MonitorConfigurator:
         if link.is_symlink() or link.exists():
             link.unlink()
         link.symlink_to(target.resolve())
-
-    def _write_logrotate_config(self, target: str, log_path: Path, max_size: str) -> None:
-        config = f"""\
-{log_path} {{
-    size {max_size}
-    rotate 3
-    compress
-    missingok
-    notifempty
-    copytruncate
-}}
-"""
-        staged = self.monitor_service_path.parent / Path(target).name
-        staged.write_text(config)
-        run_command(_privileged(["cp", str(staged), target]))
-        staged.unlink()
 
     def _require_bench(self) -> "Bench":
         assert self.bench is not None, "MonitorConfigurator needs a bench for this operation"

--- a/pilot/core/server/monitoring_config.py
+++ b/pilot/core/server/monitoring_config.py
@@ -54,6 +54,8 @@ class MonitorConfigurator:
         self.user_unit_dir = Path.home() / ".config" / "systemd" / "user"
 
     def install(self) -> None:
+        # systemd cannot open the unit's append: targets if this is missing.
+        (cli_root() / "logs").mkdir(parents=True, exist_ok=True)
         self._write_unit()
         self._install_user_unit()
         self._write_timer_unit()

--- a/pilot/core/site/uptime_monitoring_config.py
+++ b/pilot/core/site/uptime_monitoring_config.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-import contextlib
-import getpass
 import os
 import typing
 from pathlib import Path
 
 from pilot.exceptions import BenchError
-from pilot.managers.platform import _privileged, is_linux
+from pilot.managers.platform import is_linux
 from pilot.utils import cli_root, run_command
 
 if typing.TYPE_CHECKING:
@@ -35,8 +33,8 @@ Type=oneshot
 WorkingDirectory={cli_root}
 Environment=PYTHONPATH={cli_root}
 ExecStart={python} -m pilot.core.site.uptime_monitoring
-StandardOutput=append:/var/log/site-uptime.log
-StandardError=append:/var/log/site-uptime.error.log
+StandardOutput=append:{cli_root}/logs/site-uptime.log
+StandardError=append:{cli_root}/logs/site-uptime.error.log
 
 [Install]
 WantedBy=default.target
@@ -64,15 +62,6 @@ class UptimeMonitorConfigurator:
         self._write_timer_unit()
         self._install_user_timer_unit()
 
-        # Best-effort: linger/user-instance may already be enabled from
-        # MonitorConfigurator's own install(), so a failure here isn't fatal.
-        for command in (
-            ["loginctl", "enable-linger", getpass.getuser()],
-            ["systemctl", "start", f"user@{os.getuid()}.service"],
-        ):
-            with contextlib.suppress(Exception):
-                run_command(_privileged(command))
-
         env = self._systemctl_env()
         run_command(self._systemctl("daemon-reload"), env=env)
         run_command(self._systemctl("enable", "--now", self.timer_unit_name), env=env)
@@ -85,18 +74,7 @@ class UptimeMonitorConfigurator:
         if not is_linux():
             raise BenchError("Uptime monitoring is only supported on linux based machines.")
 
-        log_dir = self.log_path.parent
-        log_dir.mkdir(parents=True, exist_ok=True)
-        run_command(_privileged(["chown", f"{os.getuid()}:{os.getgid()}", str(log_dir)]))
-        self.setup_log_rotation()
-
-    def setup_log_rotation(self) -> None:
-        bench = self._require_bench()
-        self._write_logrotate_config(
-            f"/etc/logrotate.d/{bench.config.name}-site-uptime",
-            self.log_path,
-            "20M",
-        )
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
 
     def _systemctl_env(self) -> dict:
         env = dict(os.environ)
@@ -135,22 +113,6 @@ class UptimeMonitorConfigurator:
         if link.is_symlink() or link.exists():
             link.unlink()
         link.symlink_to(target.resolve())
-
-    def _write_logrotate_config(self, target: str, log_path: Path, max_size: str) -> None:
-        config = f"""\
-{log_path} {{
-    size {max_size}
-    rotate 3
-    compress
-    missingok
-    notifempty
-    copytruncate
-}}
-"""
-        staged = self.uptime_service_path.parent / Path(target).name
-        staged.write_text(config)
-        run_command(_privileged(["cp", str(staged), target]))
-        staged.unlink()
 
     def _require_bench(self) -> "Bench":
         assert self.bench is not None, "UptimeMonitorConfigurator needs a bench for this operation"

--- a/pilot/core/site/uptime_monitoring_config.py
+++ b/pilot/core/site/uptime_monitoring_config.py
@@ -57,6 +57,8 @@ class UptimeMonitorConfigurator:
         self.user_unit_dir = Path.home() / ".config" / "systemd" / "user"
 
     def install(self) -> None:
+        # systemd cannot open the unit's append: targets if this is missing.
+        (cli_root() / "logs").mkdir(parents=True, exist_ok=True)
         self._write_unit()
         self._install_user_unit()
         self._write_timer_unit()

--- a/pilot/managers/letsencrypt.py
+++ b/pilot/managers/letsencrypt.py
@@ -85,6 +85,8 @@ class LetsEncryptManager:
     def setup_sudoers(self) -> None:
         """Give certbot passwordless sudo for exactly the commands issuing and
         renewing certs needs. Idempotent: same deterministic content every call."""
+        if self.has_passwordless_sudo:
+            return
         bench_user = pwd.getpwuid(self.bench.path.stat().st_uid).pw_name
         certbot = which("certbot") or "/usr/bin/certbot"
         openssl = which("openssl") or "/usr/bin/openssl"

--- a/pilot/managers/nginx/__init__.py
+++ b/pilot/managers/nginx/__init__.py
@@ -200,6 +200,8 @@ class NginxManager:
     def setup_sudoers(self):
         """Give nginx passwordless sudo for exactly the commands reload needs.
         Idempotent: same deterministic content every call."""
+        if self.has_passwordless_sudo:
+            return
         bench_user = pwd.getpwuid(self.bench.path.stat().st_uid).pw_name
         systemctl = which("systemctl") or "/bin/systemctl"
         nginx = which("nginx") or "/usr/sbin/nginx"

--- a/pilot/managers/nginx/__init__.py
+++ b/pilot/managers/nginx/__init__.py
@@ -4,6 +4,7 @@ import pwd
 import re
 import shutil
 import sys
+from fnmatch import fnmatch
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
     from pilot.core.bench import Bench
 
 _NGINX_CONF = Path("/etc/nginx/nginx.conf")
+_PILOT_INCLUDE = Path("/etc/nginx/conf.d/00-pilot.conf")
 _USER_DIRECTIVE = re.compile(r"^[ \t]*user[ \t]+[^;\n]+;", re.MULTILINE)
 
 _SHARED_ERROR_DIR = Path("/usr/share/nginx/bench-error-pages")
@@ -294,15 +296,32 @@ class NginxManager:
         configured = self.bench.config.nginx.config_dir
         return configured if configured != Path("") else default_nginx_config_dir()
 
+    @property
+    def include_path(self) -> Path:
+        return self.bench.config_path / "nginx" / "include.conf"
+
+    @property
+    def has_shared_include(self) -> bool:
+        """True when the installer's 00-pilot.conf already globs this bench in,
+        so publishing a vhost needs no privileges at all."""
+        try:
+            directives = _PILOT_INCLUDE.read_text()
+        except OSError:
+            return False
+        patterns = re.findall(r"^\s*include\s+([^;]+);", directives, re.MULTILINE)
+        return any(fnmatch(str(self.include_path), pattern.strip()) for pattern in patterns)
+
     def install_config(self) -> None:
         nginx_dir = self.config_dir
         symlink_path = nginx_dir / f"{self.bench.config.name}.conf"
-        source_path = self.bench.config_path / "nginx" / "include.conf"
 
-        self._prune_dangling_symlinks(nginx_dir)
+        # A symlink from before the shared include would load the same vhost
+        # twice, so it goes either way.
         if symlink_path.exists() or symlink_path.is_symlink():
             run_command(_privileged(["unlink", str(symlink_path)]))
-        run_command(_privileged(["ln", "-s", str(source_path), str(symlink_path)]))
+        if not self.has_shared_include:
+            self._prune_dangling_symlinks(nginx_dir)
+            run_command(_privileged(["ln", "-s", str(self.include_path), str(symlink_path)]))
         self._set_worker_user()
         if self.bench.config.waf.enabled:
             self._ensure_modsecurity_module()
@@ -366,12 +385,19 @@ class NginxManager:
 
     def _reload_or_rollback(self, symlink_path: Path) -> None:
         """A bad config for this bench must not take nginx down for every
-        other bench on the box - undo the symlink and re-raise."""
+        other bench on the box - unpublish it and re-raise."""
         try:
             self.reload()
         except Exception:
-            run_command(_privileged(["unlink", str(symlink_path)]))
+            self._unpublish(symlink_path)
             raise
+
+    def _unpublish(self, symlink_path: Path) -> None:
+        """Take this bench's vhost out of nginx's view, however it got there."""
+        if self.has_shared_include:
+            self.include_path.rename(self.include_path.with_name("include.conf.broken"))
+        elif symlink_path.exists() or symlink_path.is_symlink():
+            run_command(_privileged(["unlink", str(symlink_path)]))
 
     def _set_worker_user(self) -> None:
         """Run nginx workers as the bench owner. Idempotent."""
@@ -387,10 +413,8 @@ class NginxManager:
         self._stage_and_copy(updated, _NGINX_CONF)
 
     def uninstall_config(self) -> None:
-        """Remove this bench's vhost symlink and reload. Certs are kept."""
-        symlink_path = self.config_dir / f"{self.bench.config.name}.conf"
-        if symlink_path.exists() or symlink_path.is_symlink():
-            run_command(_privileged(["unlink", str(symlink_path)]))
+        """Take this bench's vhost out of nginx and reload. Certs are kept."""
+        self._unpublish(self.config_dir / f"{self.bench.config.name}.conf")
         self.reload()
 
     def reload(self) -> None:

--- a/pilot/managers/nginx/__init__.py
+++ b/pilot/managers/nginx/__init__.py
@@ -61,6 +61,13 @@ ERROR_PAGES = {
 LETSENCRYPT_LIVE = Path("/etc/letsencrypt/live")
 
 
+def _shared_nginx_dir() -> Path:
+    """Host-wide nginx artifacts the bench user owns, globbed in by 00-pilot.conf."""
+    from pilot.utils import cli_root
+
+    return cli_root() / "nginx"
+
+
 def render_error_html(code: int, title: str, message: str) -> str:
     return _ERROR_PAGE_TEMPLATE.render(code=code, title=title, message=message)
 
@@ -247,6 +254,15 @@ class NginxManager:
 
     def install_default_server(self) -> None:
         """Install the shared catch-all vhost and error pages. Idempotent."""
+        if self.has_shared_include:
+            error_dir = _shared_nginx_dir() / "error_pages"
+            error_dir.mkdir(parents=True, exist_ok=True)
+            for code, (title, message) in ERROR_PAGES.items():
+                (error_dir / f"{code}.html").write_text(render_error_html(code, title, message))
+            catchall = _shared_nginx_dir() / "00-bench-default.conf"
+            catchall.write_text(self._renderer.generate_server_config(error_dir))
+            return
+
         staging = self.bench.config_path / "nginx"
         for code, (title, message) in ERROR_PAGES.items():
             staged = staging / f"_catchall_{code}.html"

--- a/pilot/managers/nginx/__init__.py
+++ b/pilot/managers/nginx/__init__.py
@@ -342,27 +342,7 @@ class NginxManager:
         if self.bench.config.waf.enabled:
             self._ensure_modsecurity_module()
         self.install_default_server()
-        self._write_nginx_logrotate()
         self._reload_or_rollback(symlink_path)
-
-    def _write_nginx_logrotate(self) -> None:
-        """Idempotent: same deterministic content every call. copytruncate avoids
-        needing to signal nginx to reopen the logs, matching how the bench monitor
-        rotates its own stats logs."""
-        target = Path(f"/etc/logrotate.d/{self.bench.config.name}-nginx")
-        access_log = self.bench.logs_path / "nginx-access.log"
-        error_log = self.bench.logs_path / "nginx-error.log"
-        config = f"""\
-{access_log} {error_log} {{
-    size 50M
-    rotate 3
-    compress
-    missingok
-    notifempty
-    copytruncate
-}}
-"""
-        self._stage_and_copy(config, target)
 
     def _stage_and_copy(self, content: str, target: Path, validate: list[str] | None = None) -> None:
         """Sudo-copy content into a root-owned target via a bench-owned staging file."""

--- a/pilot/managers/nginx/waf_render.py
+++ b/pilot/managers/nginx/waf_render.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pilot.managers.waf import SHARED_MODSEC_DIR
+from pilot.managers.waf import shared_modsec_dir
 
 if TYPE_CHECKING:
     from pilot.config import WafCondition, WafConfig, WafRule
@@ -45,10 +45,10 @@ class ModSecurityRenderer:
     def render_main(self, modsec_dir: Path) -> str:
         return (
             f"Include {modsec_dir}/modsecurity.conf\n"
-            f"Include {SHARED_MODSEC_DIR}/crs-setup.conf\n"
+            f"Include {shared_modsec_dir()}/crs-setup.conf\n"
             f"Include {modsec_dir}/overrides.conf\n"
             f"Include {modsec_dir}/custom_rules.conf\n"
-            f"Include {SHARED_MODSEC_DIR}/rules/*.conf\n"
+            f"Include {shared_modsec_dir()}/rules/*.conf\n"
             f"Include {modsec_dir}/exclusions.conf\n"
         )
 

--- a/pilot/managers/processes/systemd.py
+++ b/pilot/managers/processes/systemd.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import getpass
 import os
 import subprocess
 from pathlib import Path
@@ -59,7 +60,6 @@ class SystemdProcessManager(ManagedProcessManager):
 
     @override
     def install_config(self) -> None:
-        import getpass
 
         self.user_unit_dir.mkdir(parents=True, exist_ok=True)
         defs = self._prod_process_definitions()
@@ -88,16 +88,7 @@ class SystemdProcessManager(ManagedProcessManager):
                 dst.unlink()
             dst.symlink_to(src)
 
-        subprocess.run(
-            _privileged(["loginctl", "enable-linger", getpass.getuser()]),
-            capture_output=True,
-            check=False,
-        )
-        subprocess.run(
-            _privileged(["systemctl", "start", f"user@{os.getuid()}.service"]),
-            capture_output=True,
-            check=False,
-        )
+        self._ensure_linger()
 
         env = self._systemctl_env()
         run_command(self._systemctl("daemon-reload"), env=env)
@@ -105,6 +96,25 @@ class SystemdProcessManager(ManagedProcessManager):
         subprocess.run(self._systemctl("reset-failed", *units), capture_output=True, env=env)
         run_command(self._systemctl("enable", self._target_name()), env=env)
         self._activate_admin_socket(env)
+
+    @staticmethod
+    def _ensure_linger() -> None:
+        """Units must survive logout. The installer enables this, so only reach
+        for sudo - which cannot prompt from a task - when it somehow did not."""
+        user = getpass.getuser()
+        state = subprocess.run(
+            ["loginctl", "show-user", user, "--property=Linger"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if state.stdout.strip() == "Linger=yes":
+            return
+        for command in (
+            ["loginctl", "enable-linger", user],
+            ["systemctl", "start", f"user@{os.getuid()}.service"],
+        ):
+            subprocess.run(_privileged(command), capture_output=True, check=False)
 
     @override
     def reload_manager_config(self) -> None:

--- a/pilot/managers/waf.py
+++ b/pilot/managers/waf.py
@@ -9,15 +9,18 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pilot.managers.packages import get_package_manager
-from pilot.managers.platform import _privileged, is_linux
-from pilot.utils import run_command
+from pilot.managers.platform import is_linux
 
 if TYPE_CHECKING:
     from pilot.core.bench import Bench
 
-# Shared, read-only CRS assets; every bench's generated main.conf Includes these,
-# so the layout is fixed and identical across distros.
-SHARED_MODSEC_DIR = Path("/usr/share/nginx/modsecurity-crs")
+# Shared, read-only CRS assets; every bench's generated main.conf Includes these.
+# Bench-user owned, so installing them never needs privileges.
+def shared_modsec_dir() -> Path:
+    from pilot.utils import cli_root
+
+    return cli_root() / "modsecurity-crs"
+
 MODSEC_MODULE_NAME = "ngx_http_modsecurity_module.so"
 _MODULE_DIRS = ("/usr/lib/nginx/modules", "/usr/lib64/nginx/modules")
 
@@ -65,7 +68,8 @@ class WafManager:
 
     @staticmethod
     def crs_available() -> bool:
-        return (SHARED_MODSEC_DIR / "crs-setup.conf").exists() and (SHARED_MODSEC_DIR / "rules").is_dir()
+        shared = shared_modsec_dir()
+        return (shared / "crs-setup.conf").exists() and (shared / "rules").is_dir()
 
     @classmethod
     def is_installed(cls) -> bool:
@@ -94,11 +98,10 @@ class WafManager:
             extracted = next(entry for entry in tmp_path.iterdir() if entry.is_dir())
             staged_setup = tmp_path / "crs-setup.conf"
             shutil.copy(extracted / "crs-setup.conf.example", staged_setup)
-            run_command(_privileged(["mkdir", "-p", str(SHARED_MODSEC_DIR)]))
-            run_command(_privileged(["cp", str(staged_setup), str(SHARED_MODSEC_DIR / "crs-setup.conf")]))
-            run_command(
-                _privileged(["cp", "-rT", str(extracted / "rules"), str(SHARED_MODSEC_DIR / "rules")])
-            )
+            shared = shared_modsec_dir()
+            shared.mkdir(parents=True, exist_ok=True)
+            shutil.copy(staged_setup, shared / "crs-setup.conf")
+            shutil.copytree(extracted / "rules", shared / "rules", dirs_exist_ok=True)
 
     @staticmethod
     def _verify_checksum(archive: Path) -> None:

--- a/tests/pilot/managers/test_letsencrypt.py
+++ b/tests/pilot/managers/test_letsencrypt.py
@@ -28,6 +28,7 @@ def test_setup_sudoers_grants_only_certbot_and_cert_reads(tmp_path: Path) -> Non
         patch("pwd.getpwuid") as mock_getpwuid,
         patch("pilot.managers.sudoers.stage_and_copy") as mock_stage,
         patch("pilot.managers.sudoers.run_command") as mock_run,
+        patch.object(LetsEncryptManager, "has_passwordless_sudo", False),
     ):
         mock_getpwuid.return_value.pw_name = "runner"
         manager.setup_sudoers()

--- a/tests/pilot/managers/test_nginx_config.py
+++ b/tests/pilot/managers/test_nginx_config.py
@@ -440,6 +440,7 @@ def test_install_config_rolls_back_symlink_when_reload_fails(tmp_path: Path) -> 
     bench = _make_bench(tmp_path, _BASE_DATA)
     manager = NginxManager(bench)
     symlink_path = tmp_path / "test-bench.conf"
+    symlink_path.symlink_to(tmp_path / "include.conf")
 
     with (
         patch.object(manager, "reload", side_effect=CommandError("nginx -t failed", returncode=1)),

--- a/tests/pilot/managers/test_nginx_config.py
+++ b/tests/pilot/managers/test_nginx_config.py
@@ -490,6 +490,7 @@ def test_setup_sudoers_grants_only_start_stop_reload(tmp_path: Path) -> None:
         patch("pwd.getpwuid") as mock_getpwuid,
         patch("pilot.managers.sudoers.stage_and_copy") as mock_stage,
         patch("pilot.managers.sudoers.run_command") as mock_run,
+        patch.object(NginxManager, "has_passwordless_sudo", False),
     ):
         mock_getpwuid.return_value.pw_name = "runner"
         manager.setup_sudoers()

--- a/tests/pilot/managers/test_nginx_config.py
+++ b/tests/pilot/managers/test_nginx_config.py
@@ -451,24 +451,6 @@ def test_install_config_rolls_back_symlink_when_reload_fails(tmp_path: Path) -> 
 
     mock_run.assert_called_once()
     assert mock_run.call_args[0][0][-2:] == ["unlink", str(symlink_path)]
-
-
-def test_write_nginx_logrotate_content(tmp_path: Path) -> None:
-    bench = _make_bench(tmp_path, _BASE_DATA)
-    manager = NginxManager(bench)
-
-    with patch.object(manager, "_stage_and_copy") as mock_stage:
-        manager._write_nginx_logrotate()
-
-    mock_stage.assert_called_once()
-    content, target = mock_stage.call_args[0]
-    assert target == Path("/etc/logrotate.d/test-bench-nginx")
-    assert str(bench.logs_path / "nginx-access.log") in content
-    assert str(bench.logs_path / "nginx-error.log") in content
-    assert "copytruncate" in content
-    assert "rotate 3" in content
-
-
 def test_stage_and_copy_creates_missing_nginx_config_dir(tmp_path: Path) -> None:
     """install() runs setup_sudoers() before generate_config() ever mkdirs
     config/nginx - staging must not assume that directory already exists."""
@@ -525,25 +507,6 @@ def test_setup_sudoers_grants_only_start_stop_reload(tmp_path: Path) -> None:
 
     mock_run.assert_called_once()
     assert mock_run.call_args.args[0][-3:] == ["chmod", "440", str(sudoers_file)]
-
-
-def test_install_config_writes_nginx_logrotate(tmp_path: Path) -> None:
-    bench = _make_bench(tmp_path, _BASE_DATA)
-    manager = NginxManager(bench)
-
-    with (
-        patch.object(manager, "_write_nginx_logrotate") as mock_logrotate,
-        patch.object(manager, "install_default_server"),
-        patch.object(manager, "_set_worker_user"),
-        patch.object(manager, "_reload_or_rollback"),
-        patch.object(manager, "_prune_dangling_symlinks"),
-        patch("pilot.managers.nginx.run_command"),
-    ):
-        manager.install_config()
-
-    mock_logrotate.assert_called_once()
-
-
 def test_prune_dangling_symlinks_removes_only_broken_ones(tmp_path: Path) -> None:
     nginx_dir = tmp_path / "conf.d"
     nginx_dir.mkdir()

--- a/tests/pilot/managers/test_waf_manager.py
+++ b/tests/pilot/managers/test_waf_manager.py
@@ -29,11 +29,11 @@ def _crs_tarball() -> bytes:
 
 
 @pytest.fixture
-def fake_download(monkeypatch):
-    """Make urlretrieve write chosen bytes, and record any privileged commands so a
-    test can assert none ran."""
-    ran: list = []
-    monkeypatch.setattr(waf, "run_command", lambda cmd: ran.append(cmd))
+def fake_download(monkeypatch, tmp_path):
+    """Make urlretrieve write chosen bytes, and land the CRS under a temp root."""
+    import pilot.utils
+
+    monkeypatch.setattr(pilot.utils, "cli_root", lambda: tmp_path)
 
     def _install(payload: bytes, expected_sha: str | None = None):
         if expected_sha is not None:
@@ -43,27 +43,26 @@ def fake_download(monkeypatch):
             Path(dest).write_bytes(payload)
 
         monkeypatch.setattr(waf.urllib.request, "urlretrieve", _urlretrieve)
-        return ran
+        return tmp_path / "modsecurity-crs"
 
     return _install
 
 
 def test_install_crs_rejects_tampered_archive(fake_download) -> None:
-    ran = fake_download(b"not the real crs")  # hash won't match the pin
+    shared = fake_download(b"not the real crs")  # hash won't match the pin
     with pytest.raises(RuntimeError, match="checksum mismatch"):
         WafManager()._install_crs()
-    assert ran == []  # nothing extracted, nothing copied under /usr/share
+    assert not shared.exists()  # nothing extracted, nothing installed
 
 
 def test_install_crs_accepts_matching_archive(fake_download) -> None:
     payload = _crs_tarball()
-    ran = fake_download(payload, expected_sha=hashlib.sha256(payload).hexdigest())
+    shared = fake_download(payload, expected_sha=hashlib.sha256(payload).hexdigest())
 
     WafManager()._install_crs()
 
-    # crs-setup.conf + rules/ copied into the shared dir via privileged commands.
-    assert any("crs-setup.conf" in " ".join(map(str, cmd)) for cmd in ran)
-    assert any(str(waf.SHARED_MODSEC_DIR / "rules") in " ".join(map(str, cmd)) for cmd in ran)
+    assert (shared / "crs-setup.conf").exists()
+    assert (shared / "rules" / "REQUEST-942.conf").exists()
 
 
 def test_pinned_digest_is_a_sha256() -> None:


### PR DESCRIPTION
`bench init` and `bench setup production` reached for sudo at runtime, as a user with no passwordless sudo by design — the wizard died at step 3/11 on a fresh host, and deploys prompted for a password the admin UI could never answer.

Every privileged operation now happens once in the installer's root pass, or through a scoped sudoers grant.

- Install nginx, certbot, supervisor and the modsecurity module as root
- Publish vhosts through a root-owned `00-pilot.conf` globbing bench-owned files
- Move the catch-all vhost and error pages to `~/pilot/nginx/`
- Move the CRS ruleset to `~/pilot/modsecurity-crs/`
- Set the nginx worker user at install time
- Move monitor logs to `~/pilot/logs/`, rotated by one root-owned config
- Install the nginx and certbot sudoers grants at install time
- Skip rewriting a grant that already works
- Only enable lingering when it is actually missing

Behaviour changes: per-bench logrotate sizes are no longer honoured (500M default for all); monitor logs move out of `/var/log`; existing hosts need an installer re-run as root to migrate, or the first deploy drops the old symlink with one sudo call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)