### PR TITLE
fix(admin): serve bundled admin UI on released installs instead of rebuilding

### DIFF
--- a/admin/backend/frontend.py
+++ b/admin/backend/frontend.py
@@ -12,11 +12,14 @@ _MIN_NODE = (20, 11)
 
 
 def ensure_admin_frontend(on_progress: Callable[[str], None] = lambda message: None) -> None:
-    """Build the admin UI from source in dev checkouts; released installs ship it prebuilt."""
+    """Build the admin UI from source in dev checkouts; released installs ship it prebuilt.
+    Released tarballs carry the source too, so the version - not source presence -
+    decides: only dev builds compile, releases always serve the bundled dist."""
+    from pilot import is_dev_build
     from pilot.utils import cli_root
 
     root = cli_root()
-    if _has_frontend_source(root):
+    if is_dev_build and _has_frontend_source(root):
         build_admin_frontend(on_progress=on_progress)
         return
     if _has_admin_dist(root):

--- a/pilot/core/bench/runtime.py
+++ b/pilot/core/bench/runtime.py
@@ -144,15 +144,17 @@ class BenchRuntime:
 
     def _ensure_admin_dist(self, on_progress: Callable[[str], None]) -> None:
         from admin.backend.frontend import build_admin_frontend
+        from pilot import is_dev_build
         from pilot.utils import cli_root
 
         root = cli_root()
         dist = root / "admin" / "backend" / "static" / "dist"
         frontend = root / "admin" / "frontend"
-        has_source = (frontend / "package.json").exists()
+        # Releases ship the source too; only dev builds may (re)compile it.
+        can_build = is_dev_build and (frontend / "package.json").exists()
 
         if not (dist / "assets").exists():
-            if not has_source:
+            if not can_build:
                 raise BenchError(
                     "Admin UI is missing from this release. Reinstall bench-cli, "
                     "or run it from a source checkout."
@@ -161,7 +163,7 @@ class BenchRuntime:
             build_admin_frontend(on_progress=on_progress)
             return
 
-        if has_source and self._admin_source_is_newer(frontend, dist):
+        if can_build and self._admin_source_is_newer(frontend, dist):
             self._rebuild_admin(on_progress)
 
     def _rebuild_admin(self, on_progress: Callable[[str], None]) -> None:

--- a/tests/admin/backend/test_frontend.py
+++ b/tests/admin/backend/test_frontend.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import pilot
+from admin.backend import frontend
+from pilot.exceptions import BenchError
+
+
+def _layout(root: Path, *, source: bool, dist: bool) -> None:
+    if source:
+        pkg = root / "admin" / "frontend" / "package.json"
+        pkg.parent.mkdir(parents=True, exist_ok=True)
+        pkg.write_text("{}")
+    if dist:
+        assets = root / "admin" / "backend" / "static" / "dist" / "assets"
+        assets.mkdir(parents=True, exist_ok=True)
+
+
+def _ensure(root: Path, *, is_dev: bool) -> object:
+    with (
+        patch.object(pilot, "is_dev_build", is_dev),
+        patch("pilot.utils.cli_root", return_value=root),
+        patch.object(frontend, "build_admin_frontend") as build,
+    ):
+        frontend.ensure_admin_frontend()
+    return build
+
+
+def test_released_install_serves_dist_without_building(tmp_path: Path) -> None:
+    _layout(tmp_path, source=True, dist=True)
+    build = _ensure(tmp_path, is_dev=False)
+    build.assert_not_called()
+
+
+def test_dev_build_compiles_from_source(tmp_path: Path) -> None:
+    _layout(tmp_path, source=True, dist=True)
+    build = _ensure(tmp_path, is_dev=True)
+    build.assert_called_once()
+
+
+def test_released_install_without_dist_raises(tmp_path: Path) -> None:
+    _layout(tmp_path, source=True, dist=False)
+    with (
+        patch.object(pilot, "is_dev_build", False),
+        patch("pilot.utils.cli_root", return_value=tmp_path),
+        pytest.raises(BenchError, match="missing from this release"),
+    ):
+        frontend.ensure_admin_frontend()


### PR DESCRIPTION
## What

Released installs were rebuilding the admin UI on every `bench init` and `bench setup production`, even though the release tarball already ships it prebuilt.

## Why

The code decided "should I build?" by checking if the frontend source exists. But the release tarball ships the source too — so a released install looked like a dev checkout and rebuilt every time.

## Fix

Decide by **version**, not source presence:
- Dev build (no `VERSION` file) → build from source.
- Released build → serve the prebuilt `dist/`, never rebuild.

Source stays in the tarball. `bench build-admin` still builds on demand.

Tested in `tests/admin/backend/test_frontend.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)