### PR TITLE
fix(admin): skip frontend Node deps on released installs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,19 @@ admin/backend/
 admin/frontend/  Vue Admin UI
 ```
 
+## Install Modes
+
+`install.sh` installs one of two ways, distinguished at runtime by a repo-root
+`VERSION` file (`pilot.is_dev_build`):
+
+- **Released** (default): a prebuilt release tarball. It carries the compiled
+  Admin UI in `admin/backend/static/dist/` and a `VERSION` file. The frontend
+  source ships too, but released installs never build it or install its Node
+  deps — they serve the bundled dist. A missing dist is a hard error.
+- **Dev** (`--dev`): a `git clone` of `main`, with no `VERSION` file. Node.js is
+  required; the Admin UI is compiled from `admin/frontend/` and rebuilt when the
+  source changes.
+
 ## Main Objects
 
 `Server` is the host entry point. It resolves the fixed benches directory, returns benches with `Server().bench("name")`, and owns host-wide SSH keys and monitoring concerns.

--- a/pilot/managers/environment.py
+++ b/pilot/managers/environment.py
@@ -79,8 +79,7 @@ class AdminEnvManager:
         from pilot import is_dev_build
 
         frontend = self.venv_path.parent / "admin" / "frontend"
-        # Only dev builds compile the frontend; releases serve the prebuilt dist
-        # and never need its Node deps, even though the source ships with them.
+        # Releases ship the source but serve the prebuilt dist, so they skip its Node deps.
         if not is_dev_build or not (frontend / "package.json").exists():
             return
         if (frontend / "node_modules").exists():

--- a/pilot/managers/environment.py
+++ b/pilot/managers/environment.py
@@ -76,9 +76,13 @@ class AdminEnvManager:
         print("done")
 
     def _ensure_frontend_deps(self) -> None:
+        from pilot import is_dev_build
+
         frontend = self.venv_path.parent / "admin" / "frontend"
-        if not (frontend / "package.json").exists():
-            return  # not running from the bench-cli source tree
+        # Only dev builds compile the frontend; releases serve the prebuilt dist
+        # and never need its Node deps, even though the source ships with them.
+        if not is_dev_build or not (frontend / "package.json").exists():
+            return
         if (frontend / "node_modules").exists():
             return
         print("  Installing admin frontend Node.js dependencies...", flush=True)

--- a/tests/pilot/managers/test_admin_env.py
+++ b/tests/pilot/managers/test_admin_env.py
@@ -77,3 +77,27 @@ def test_ensure_reinstalls_when_deps_change(tmp_path: Path, uv_runs) -> None:
 
     installed = [call.args[0] for call in uv_runs.call_args_list if "pip" in call.args[0]]
     assert installed and "flask" in installed[0]
+
+
+def _with_frontend_source(root: Path) -> None:
+    frontend = root / "admin" / "frontend"
+    frontend.mkdir(parents=True)
+    (frontend / "package.json").write_text("{}")
+
+
+def test_released_install_skips_frontend_deps(tmp_path: Path, uv_runs) -> None:
+    _existing_venv(tmp_path)
+    _with_frontend_source(tmp_path)
+    with patch("pilot.is_dev_build", False):
+        _make_manager(tmp_path).ensure()
+
+    assert not [call for call in uv_runs.call_args_list if call.args[0][:1] == ["npm"]]
+
+
+def test_dev_build_installs_frontend_deps(tmp_path: Path, uv_runs) -> None:
+    _existing_venv(tmp_path)
+    _with_frontend_source(tmp_path)
+    with patch("pilot.is_dev_build", True):
+        _make_manager(tmp_path).ensure()
+
+    assert [call for call in uv_runs.call_args_list if call.args[0][:1] == ["npm"]]


### PR DESCRIPTION
## What

`bench init` on a released install still ran `npm install` for the admin frontend, even though released installs serve the prebuilt UI and never compile it. Verified on a fresh `v0.0.4-pre-alpha` install.

## Why

Follow-up to #269. That PR stopped the `npm run build`, but a sibling method — `_ensure_frontend_deps` — still keyed off source presence. The release tarball ships the frontend source, so it pulled `node_modules` that a released install never uses.

## Fix

Gate it on `is_dev_build`, same as the build path: only dev builds install frontend Node deps; releases skip them.

Tested in `tests/pilot/managers/test_admin_env.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)