### PR TITLE
fix(admin): stop frontend builds from dirtying the working tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,12 +58,10 @@ htmlcov/
 *~
 
 # Admin
-admin/frontend/dashboard/node_modules/
-admin/frontend/editor/node_modules/
+admin/frontend/**/node_modules/
 admin/backend/static/dashboard/
 admin/backend/static/editor/
-admin/frontend/dashboard/components.d.ts
-admin/frontend/editor/components.d.ts
+admin/frontend/**/components.d.ts
 *.timestamp-*
 .env
 .env.local

--- a/admin/backend/frontend.py
+++ b/admin/backend/frontend.py
@@ -42,8 +42,9 @@ def _build_frontend(frontend: Path, label: str, on_progress: Callable[[str], Non
 
     on_progress(f"Building {label} frontend at {frontend}...")
     if _is_npm_install_stale(frontend):
-        on_progress(f"Running npm install for {label}...")
-        run_command(["npm", "install"], cwd=frontend, stream_output=True)
+        install = ["npm", "ci"] if (frontend / "package-lock.json").exists() else ["npm", "install"]
+        on_progress(f"Running {' '.join(install)} for {label}...")
+        run_command(install, cwd=frontend, stream_output=True)
     on_progress(f"Running npm run build for {label}")
     run_command(["npm", "run", "build"], cwd=frontend, stream_output=True)
 

--- a/docs/admin-ui.md
+++ b/docs/admin-ui.md
@@ -54,3 +54,5 @@ Post-save changes such as restarts, firewall sync, WAF sync, or S3 credential sy
 ## Local Work
 
 Use the repo scripts and package metadata for exact frontend commands. After API shape changes, update the API client and run the relevant frontend checks.
+
+Dev builds install dependencies with `npm ci` whenever `package-lock.json` is present, so the lockfile is never rewritten by a build and the working tree stays clean. `npm ci` requires `package.json` and `package-lock.json` to agree: after editing dependencies, run `npm install` yourself and commit the updated lockfile, otherwise the next build fails. Frontends without a lockfile still fall back to `npm install`.

--- a/tests/admin/backend/test_frontend.py
+++ b/tests/admin/backend/test_frontend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -8,6 +9,8 @@ import pytest
 import pilot
 from admin.backend import frontend
 from pilot.exceptions import BenchError
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _layout(root: Path, *, source: bool, dist: bool) -> None:
@@ -50,3 +53,42 @@ def test_released_install_without_dist_raises(tmp_path: Path) -> None:
         pytest.raises(BenchError, match="missing from this release"),
     ):
         frontend.ensure_admin_frontend()
+
+
+def _install_command(tmp_path: Path, *, lockfile: bool) -> list[str]:
+    """Run a stale build and return the install command it chose."""
+    source = tmp_path / "dashboard"
+    source.mkdir()
+    (source / "package.json").write_text("{}")
+    if lockfile:
+        (source / "package-lock.json").write_text("{}")
+    with patch("pilot.utils.run_command") as run_command:
+        frontend._build_frontend(source, "dashboard", lambda message: None)
+    return run_command.call_args_list[0].args[0]
+
+
+def test_locked_frontend_installs_without_rewriting_lockfile(tmp_path: Path) -> None:
+    assert _install_command(tmp_path, lockfile=True) == ["npm", "ci"]
+
+
+def test_frontend_without_lockfile_falls_back_to_npm_install(tmp_path: Path) -> None:
+    assert _install_command(tmp_path, lockfile=False) == ["npm", "install"]
+
+
+@pytest.mark.skipif(not (REPO_ROOT / ".git").exists(), reason="not a git checkout")
+def test_build_artifacts_ignored_at_every_frontend_depth() -> None:
+    artifacts = [
+        "admin/frontend/node_modules/vue",
+        "admin/frontend/components.d.ts",
+        "admin/frontend/dashboard/node_modules/vue",
+        "admin/frontend/dashboard/components.d.ts",
+        "admin/frontend/editor/node_modules/vue",
+        "admin/frontend/editor/components.d.ts",
+    ]
+    ignored = subprocess.run(
+        ["git", "check-ignore", *artifacts],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    ).stdout.split()
+    assert sorted(ignored) == sorted(artifacts)


### PR DESCRIPTION
## Problem

After every `git pull && bench build`, the working tree comes back dirty:

```
 M admin/frontend/dashboard/package-lock.json
 M admin/frontend/editor/package-lock.json
?? admin/frontend/components.d.ts
?? admin/frontend/node_modules/
```

Two independent causes.

## 1. `npm install` rewrites the lockfiles

`_build_frontend` shells out to `npm install`, which mutates `package-lock.json` on every run — in practice npm re-marks platform-optional deps as `"dev": true`, producing a ~150-line diff nobody authored.

Switched to `npm ci` when a lockfile exists (falling back to `npm install` when it doesn't). `npm ci` installs strictly from the lock and never writes it back. This also matches what the e2e harness already does in `tests/e2e/harness/bench.py`.

## 2. Ignore rules were hardcoded per app

The admin section of `.gitignore` listed `dashboard/` and `editor/` paths explicitly, so any build output landing directly under `admin/frontend/` was untracked. Replaced the four per-app lines with two `**` patterns covering both levels.

## Verification

- `git check-ignore -v` confirms the new patterns match `node_modules/` and `components.d.ts` at both `admin/frontend/` and `admin/frontend/{dashboard,editor}/`.
- `ruff check` passes.