### PR TITLE
fix(admin): reload site uptime chart when site name changes

### DIFF
--- a/admin/frontend/dashboard/src/components/dashboard/SiteUptime.vue
+++ b/admin/frontend/dashboard/src/components/dashboard/SiteUptime.vue
@@ -139,6 +139,6 @@ async function load() {
   }
 }
 
-watch(() => props.window, load)
+watch(() => [props.siteName, props.window], load)
 onMounted(load)
 </script>


### PR DESCRIPTION
## Summary
- `SiteUptime.vue` only watched `props.window`, so renaming a site never reloaded its uptime chart, while the sibling `SiteInsights.vue` charts already watch both `siteName` and `window`.
- Now watches `[siteName, window]`, matching the existing pattern.
