### PR TITLE
fix: point default-branch references at develop

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@ name: E2E (Admin UI)
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
   # Heavy (bench init clones the framework); allow manual runs too.
   workflow_dispatch:
 

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -2,7 +2,7 @@ name: Install Script Smoke Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [develop]
     paths:
       - install.sh
       - scripts/smoke_install.sh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,9 +2,9 @@ name: Integration Test
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
 
 jobs:
   integration:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,9 +2,9 @@ name: Unit Tests
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
   pull_request:
-    branches: [main]
+    branches: [develop]
 
 jobs:
   unit:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Pilot makes it simple to run Frappe on your own servers. Use the Admin UI to man
 Run the installer as your normal user:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/frappe/pilot/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/frappe/pilot/develop/install.sh | bash
 ```
 
 On a root-only VPS, run it as root; the installer creates a non-root bench user.
@@ -47,7 +47,7 @@ This installs the latest release (prebuilt admin UI, no build step). Contributor
 who want a source checkout that compiles the admin UI locally can pass `--dev`:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/frappe/pilot/main/install.sh | bash -s -- --dev
+curl -fsSL https://raw.githubusercontent.com/frappe/pilot/develop/install.sh | bash -s -- --dev
 ```
 
 ## Basic Usage

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,7 @@ admin/frontend/in-app-embed/  Desk Cloud Settings IIFE (served at /embed/cloud-s
   Admin UI in `admin/backend/static/dist/` and a `VERSION` file. The frontend
   source ships too, but released installs never build it or install its Node
   deps — they serve the bundled dist. A missing dist is a hard error.
-- **Dev** (`--dev`): a `git clone` of `main`, with no `VERSION` file. Node.js is
+- **Dev** (`--dev`): a `git clone` of `develop`, with no `VERSION` file. Node.js is
   required; the Admin UI is compiled from `admin/frontend/` and rebuilt when the
   source changes.
 

--- a/install.sh
+++ b/install.sh
@@ -12,14 +12,14 @@ set -e
 # All three point at the same GitHub repo; override PILOT_GITHUB_SLUG to install
 # from a fork (releases + self-reference URL follow it).
 GITHUB_SLUG="${PILOT_GITHUB_SLUG:-frappe/pilot}"
-INSTALL_URL="https://raw.githubusercontent.com/$GITHUB_SLUG/main/install.sh"
+INSTALL_URL="https://raw.githubusercontent.com/$GITHUB_SLUG/develop/install.sh"
 REPO_URL="${PILOT_REPO_URL:-https://github.com/$GITHUB_SLUG}"
-BRANCH_NAME="${PILOT_BRANCH:-main}"
+BRANCH_NAME="${PILOT_BRANCH:-develop}"
 PILOT_DIR="$HOME/pilot"
 BENCH_USER="${BENCH_USER:-frappe}"
 # Lets an unattended run answer sudo, which `curl | sh` cannot prompt for.
 SUDO_PASS="${SUDO_PASS:-}"
-# The default install pulls a prebuilt release tarball; --dev clones main and
+# The default install pulls a prebuilt release tarball; --dev clones develop and
 # compiles the admin frontend from source.
 DEV_MODE="${PILOT_DEV:-}"
 

--- a/scripts/smoke_install.sh
+++ b/scripts/smoke_install.sh
@@ -19,7 +19,7 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 mkdir "$WORK_DIR/src"
 tar -C "$REPO_ROOT" --exclude .git --exclude node_modules --exclude .admin-venv \
     -cf - . | tar -C "$WORK_DIR/src" -xf -
-git -C "$WORK_DIR/src" init --quiet --initial-branch main
+git -C "$WORK_DIR/src" init --quiet --initial-branch develop
 git -C "$WORK_DIR/src" add --all
 git -C "$WORK_DIR/src" -c user.email=smoke@test -c user.name=smoke \
     commit --quiet --message "smoke test snapshot"
@@ -29,7 +29,7 @@ echo "=== smoke test: $IMAGE ==="
 docker run --rm -i -v "$WORK_DIR/src:/pilot-src:ro" "$IMAGE" sh -s <<'CONTAINER' | tee "$WORK_DIR/log"
 set -e
 export PILOT_REPO_URL="file:///pilot-src"
-export PILOT_BRANCH="main"
+export PILOT_BRANCH="develop"
 
 # Parallel downloads can saturate the link and starve DNS on slow hosts;
 # serialize them for a deterministic test run.

--- a/scripts/smoke_install_macos.sh
+++ b/scripts/smoke_install_macos.sh
@@ -6,7 +6,7 @@
 # Node for real.
 #
 # The working tree (including uncommitted changes) is committed into a
-# throwaway git repo on a hardcoded "main" branch and cloned from there, the
+# throwaway git repo on a hardcoded "develop" branch and cloned from there, the
 # same way scripts/smoke_install.sh does — a checkout in CI is detached HEAD,
 # so `git rev-parse --abbrev-ref HEAD` would otherwise hand install.sh the
 # literal branch name "HEAD".
@@ -22,13 +22,13 @@ trap 'rm -rf "$WORK_DIR"' EXIT
 mkdir "$WORK_DIR/src"
 tar -C "$REPO_ROOT" --exclude .git --exclude node_modules --exclude .admin-venv \
     -cf - . | tar -C "$WORK_DIR/src" -xf -
-git -C "$WORK_DIR/src" init --quiet --initial-branch main
+git -C "$WORK_DIR/src" init --quiet --initial-branch develop
 git -C "$WORK_DIR/src" add --all
 git -C "$WORK_DIR/src" -c user.email=smoke@test -c user.name=smoke \
     commit --quiet --message "smoke test snapshot"
 
 export PILOT_REPO_URL="file://$WORK_DIR/src"
-export PILOT_BRANCH="main"
+export PILOT_BRANCH="develop"
 
 echo "=== macOS smoke test ==="
 # --dev clones the mounted source checkout; the default path would fetch a


### PR DESCRIPTION
The default branch moved from `main` to `develop`, but nothing that hardcoded `main` followed.

### `install.sh` was broken

- `BRANCH_NAME` defaulted to `main`, so `--dev` ran `git clone -b main` against a branch that no longer exists.
- `INSTALL_URL` pointed at a `raw.githubusercontent.com/.../main/install.sh` path that now 404s. It is echoed to users in the root-run hint and the release-fallback hint, so the suggested recovery command was dead too.

The README's two `curl` install one-liners hit that same dead URL.

### CI was running on nothing

`unit-tests`, `integration`, `e2e`, and `install-smoke` all triggered on `push`/`pull_request` to `main` only. `release.yml` is tag-driven and needed no change.

### Smoke scripts

`scripts/smoke_install.sh` and `scripts/smoke_install_macos.sh` were self-consistent on `main` rather than broken — they create the throwaway branch and set `PILOT_BRANCH` to match. Moved both to `develop` so they exercise the branch `install.sh` actually defaults to.

Also updated the `--dev` install-mode description in `docs/architecture.md`.

### Deliberately left alone

`main` as a bench name in docs and examples (`name = "main"`, `bench -b main`, `Bench("main")`), nginx `modsecurity/main.conf`, and Python/JS `main` entry points.

`pilot/commands/apps/download.py` still falls back to `"main"` when `bench get-app <repo>` is called without `--branch`, while `apps/new.py` already defaults new app scaffolds to `develop`. That is a real inconsistency, but it governs arbitrary user-supplied app repos rather than this repo's branch, so it is out of scope here. `App` already has `_detect_default_branch()`, so resolving the remote's actual default would be a better fix than swapping one hardcoded name for another.

### Verification

- `sh -n install.sh`, `bash -n` on both smoke scripts — pass.
- All five workflow YAMLs parse with the expected `develop` triggers.
- Repo-wide sweep for `pilot/main`, `branches: [main]`, `initial-branch main`, and `PILOT_BRANCH` returns only the corrected lines.

No Python changed, so `ruff`/`pytest` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
