### PR TITLE
fix: map domain-provider exit 2 to a declined conflict, not unavailable

### DIFF
--- a/pilot/core/adapters/domain_provider.py
+++ b/pilot/core/adapters/domain_provider.py
@@ -138,6 +138,8 @@ class DomainRouteProvider:
             return False, None
         argv = [exe, action, *([site] if site else []), *([domain] if domain else [])]
         result = subprocess.run(argv, capture_output=True, text=True)
+        if result.returncode == 2:
+            raise DomainConflictError(result.stderr.strip() or f"{domain or site} was declined.")
         if result.returncode != 0:
             raise DomainProviderError(result.stderr.strip() or f"{_PROVIDER_BIN} {action} failed.")
         # Do not parse status text from mutating verbs.

--- a/tests/pilot/core/test_domain_controller.py
+++ b/tests/pilot/core/test_domain_controller.py
@@ -9,7 +9,7 @@ import pytest
 from pilot.config import BenchConfig, SiteConfig
 from pilot.core.adapters.domain_provider import DomainRouteProvider
 from pilot.core.bench import Bench
-from pilot.exceptions import BenchError
+from pilot.exceptions import BenchError, DomainConflictError, DomainProviderError
 from pilot.managers.nginx import NginxConfigRenderer
 
 _BENCH_DATA: dict = {
@@ -142,6 +142,32 @@ def test_provider_failure_raises_with_stderr(tmp_path: Path, monkeypatch) -> Non
 
     with pytest.raises(BenchError, match="proxy-servers declined"):
         DomainRouteProvider.proxy_servers()
+
+
+_TRANSPORT_FAILURE_PROVIDER = """#!/usr/bin/env python3
+import sys
+sys.stderr.write("provider config missing")
+sys.exit(1)
+"""
+
+
+def test_register_declined_raises_domain_conflict(tmp_path: Path, monkeypatch) -> None:
+    _install_provider(tmp_path, monkeypatch)
+    monkeypatch.setenv("PROVIDER_FAIL", "register")
+    bench = _make_bench(tmp_path)
+    _write_site(bench, "mysite")
+
+    with pytest.raises(DomainConflictError, match="register declined"):
+        DomainRouteProvider(bench).register("mysite", "app.example.com")
+
+
+def test_register_transport_failure_raises_domain_provider_error(tmp_path: Path, monkeypatch) -> None:
+    _install_provider(tmp_path, monkeypatch, body=_TRANSPORT_FAILURE_PROVIDER)
+    bench = _make_bench(tmp_path)
+    _write_site(bench, "mysite")
+
+    with pytest.raises(DomainProviderError, match="provider config missing"):
+        DomainRouteProvider(bench).register("mysite", "app.example.com")
 
 
 def test_host_queries_empty_without_provider(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- A `bench-domain-provider` exiting 2 ("declined": taken, reserved, invalid, or not yet pointed here per docs/domain-provider.md) was raising `DomainProviderError`, same as a genuine transport/config failure — so the Admin UI showed "The domain provider is unavailable." for both cases.
- Exit 2 now raises `DomainConflictError`, which the Admin API already maps to a distinct 409 without leaking provider stderr (verified against the existing `test_domain_failures_preserve_their_semantics` security test).

## Test plan
- [x] `uv run pytest tests/pilot/core/test_domain_controller.py tests/admin/backend/api/test_api_error_mapping.py`
- [x] `uv run ruff check pilot admin tests`