### PR TITLE
fix: show the declined-domain provider message to the caller

### DIFF
--- a/admin/backend/api/v1/sites/domains.py
+++ b/admin/backend/api/v1/sites/domains.py
@@ -224,19 +224,19 @@ def remove_domain(name: str, domain: str):
     return accepted_task_response(bench_root, task_id)
 
 
-def _domain_conflict():
-    return error_response("domain_conflict", "The domain conflicts with the current site state.", 409)
-
-
 def _domain_failure(error: BenchError, message: str):
     if isinstance(error, ConfigError):
         raise error
     if isinstance(error, DomainConflictError):
-        return _domain_conflict()
+        return error_response(
+            "domain_conflict",
+            str(error) or "The domain conflicts with the current site state.",
+            409,
+        )
     if isinstance(error, DomainProviderError):
         return error_response(
             "domain_provider_unavailable",
-            "The domain provider is unavailable.",
+            str(error) or "The domain provider is unavailable.",
             503,
         )
     return internal_error(message)

--- a/docs/domain-provider.md
+++ b/docs/domain-provider.md
@@ -92,7 +92,7 @@ Prefer fail-soft behavior here. A non-zero exit breaks nginx setup.
 
 ## Errors
 
-Use one error mechanism: exit non-zero and write the message to stderr. Pilot shows stderr to the user and ignores stdout on failure.
+Use one error mechanism: exit non-zero and write the message to stderr. Pilot shows stderr to the user, so keep it free of internal detail (API URLs, request IDs, account names) - write that to your own logs instead.
 
 ```sh
 echo "subdomain 'app' is already taken" >&2

--- a/tests/admin/backend/api/test_api_error_mapping.py
+++ b/tests/admin/backend/api/test_api_error_mapping.py
@@ -114,13 +114,11 @@ def test_database_runtime_errors_are_safe_server_failures(tmp_path: Path) -> Non
 @pytest.mark.parametrize(
     ("error", "status", "code"),
     [
-        (DomainConflictError("duplicate"), 409, "domain_conflict"),
-        (DomainProviderError("secret provider stderr"), 503, "domain_provider_unavailable"),
         (ConfigError("secret config detail"), 503, "configuration_unavailable"),
         (BenchError("secret internal detail"), 500, "internal_error"),
     ],
 )
-def test_domain_failures_preserve_their_semantics(
+def test_unrelated_failures_stay_generic(
     tmp_path: Path,
     error: Exception,
     status: int,
@@ -140,3 +138,33 @@ def test_domain_failures_preserve_their_semantics(
     assert response.status_code == status
     assert response.get_json()["error"]["code"] == code
     assert b"secret" not in response.data
+
+
+@pytest.mark.parametrize(
+    ("error", "status", "code"),
+    [
+        (DomainConflictError("app.example.com is already taken"), 409, "domain_conflict"),
+        (DomainProviderError("provider quota exceeded"), 503, "domain_provider_unavailable"),
+    ],
+)
+def test_domain_failures_surface_the_provider_message(
+    tmp_path: Path,
+    error: Exception,
+    status: int,
+    code: str,
+) -> None:
+    bench_root = tmp_path / "bench"
+    client = _client(bench_root)
+    site_dir = bench_root / "sites" / "site.test"
+    site_dir.mkdir(parents=True)
+    (site_dir / "site_config.json").write_text("{}")
+    site_domains = Mock()
+    site_domains.names.side_effect = error
+
+    with patch("admin.backend.api.v1.sites.domains._site_domains", return_value=site_domains):
+        response = client.get("/api/v1/sites/site.test/domains")
+
+    assert response.status_code == status
+    body = response.get_json()
+    assert body["error"]["code"] == code
+    assert body["error"]["message"] == str(error)


### PR DESCRIPTION
Show the actual domain-conflict/provider-error message to the caller instead of one fixed generic string per class (ConfigError/BenchError untouched, still generic).