### PR TITLE
fix: admin bench create/drop accept install.sh's scoped nginx sudo grant

### DIFF
--- a/admin/backend/api/v1/benches/__init__.py
+++ b/admin/backend/api/v1/benches/__init__.py
@@ -174,9 +174,11 @@ def _delete_bench_locked(target_dir: Path, toml_path: Path, name: str):
             503,
         )
     if target_config.production.enabled:
-        from pilot.managers.platform import has_passwordless_sudo
+        from pilot.managers.nginx import NginxManager
+        from pilot.managers.platform import has_passwordless_sudo, is_root
 
-        if not has_passwordless_sudo():
+        bench = Bench(target_config, target_dir)
+        if not (is_root() or has_passwordless_sudo() or NginxManager(bench).has_passwordless_sudo):
             return error_response(
                 "privileged_operation_unavailable",
                 "Dropping a production bench requires non-interactive system privileges.",

--- a/admin/backend/api/v1/benches/create.py
+++ b/admin/backend/api/v1/benches/create.py
@@ -101,9 +101,11 @@ def _validate_admin_domain(new_dir: Path, name: str, admin_domain: str):
 
 
 def _validate_production_privileges():
-    from pilot.managers.platform import has_passwordless_sudo
+    from pilot.managers.platform import has_passwordless_sudo, is_root, which
+    from pilot.managers.sudoers import has_passwordless_sudo_for
 
-    if has_passwordless_sudo():
+    nginx = which("nginx") or "/usr/sbin/nginx"
+    if is_root() or has_passwordless_sudo() or has_passwordless_sudo_for([nginx, "-t"]):
         return None
     return error_response(
         "privileged_operation_unavailable",

--- a/tests/admin/backend/test_admin_app.py
+++ b/tests/admin/backend/test_admin_app.py
@@ -332,6 +332,7 @@ def test_api_benches_create_does_not_prompt_for_system_privileges(tmp_path: Path
             return_value=True,
         ),
         patch("pilot.managers.platform.has_passwordless_sudo", return_value=False),
+        patch("pilot.managers.sudoers.has_passwordless_sudo_for", return_value=False),
         patch("admin.backend.api.v1.benches.create.Bench.create_at") as create,
         patch(
             "pilot.core.adapters.domain_provider.DomainRouteProvider.wildcard_domains",
@@ -344,6 +345,18 @@ def test_api_benches_create_does_not_prompt_for_system_privileges(tmp_path: Path
     assert resp.get_json()["error"]["code"] == "privileged_operation_unavailable"
     assert not (benches_dir / "fresh").exists()
     create.assert_not_called()
+
+
+def test_validate_production_privileges_allows_scoped_nginx_sudo_grant() -> None:
+    """install.sh grants passwordless sudo for exactly `nginx -t` etc, not a bare
+    `sudo -n true` - the scoped grant alone must be enough to create a bench."""
+    from admin.backend.api.v1.benches.create import _validate_production_privileges
+
+    with (
+        patch("pilot.managers.platform.has_passwordless_sudo", return_value=False),
+        patch("pilot.managers.sudoers.has_passwordless_sudo_for", return_value=True),
+    ):
+        assert _validate_production_privileges() is None
 
 
 def test_api_benches_create_reports_busy_without_waiting(tmp_path: Path) -> None:
@@ -770,6 +783,7 @@ def test_api_benches_drop_does_not_prompt_for_system_privileges(tmp_path: Path) 
 
     with (
         patch("pilot.managers.platform.has_passwordless_sudo", return_value=False),
+        patch("pilot.managers.nginx.has_passwordless_sudo_for", return_value=False),
         patch("admin.backend.api.v1.benches.Bench.drop") as drop,
     ):
         resp = client.delete("/api/v1/benches/prod-bench")
@@ -777,6 +791,24 @@ def test_api_benches_drop_does_not_prompt_for_system_privileges(tmp_path: Path) 
     assert resp.status_code == 409
     assert resp.get_json()["error"]["code"] == "privileged_operation_unavailable"
     drop.assert_not_called()
+
+
+def test_api_benches_drop_allows_scoped_nginx_sudo_grant(tmp_path: Path) -> None:
+    """install.sh grants passwordless sudo for exactly `nginx -t` etc, not a bare
+    `sudo -n true` - the scoped grant alone must be enough to drop a bench."""
+    benches_dir = tmp_path / "benches"
+    client = _client(benches_dir / "current")
+    _write_prod_bench_toml(benches_dir / "prod-bench", "prod-bench")
+
+    with (
+        patch("pilot.managers.platform.has_passwordless_sudo", return_value=False),
+        patch("pilot.managers.nginx.has_passwordless_sudo_for", return_value=True),
+        patch("admin.backend.api.v1.benches.Bench.drop") as drop,
+    ):
+        resp = client.delete("/api/v1/benches/prod-bench")
+
+    assert resp.status_code == 204
+    drop.assert_called_once()
 
 
 def test_create_site_does_not_carry_db_type(tmp_path: Path) -> None:


### PR DESCRIPTION
Both checks only tried a bare `sudo -n true`, which install.sh never grants (it scopes NOPASSWD to exact nginx/certbot commands). The CLI path (`pilot/core/bench/setup.py`) already falls back to the scoped `NginxManager.has_passwordless_sudo` check; these two Admin API call sites were missing it, so creating/dropping a bench from the UI failed on any host provisioned by install.sh.