### PR TITLE
fix: bench creation from a production sibling inherits its TLS choice

### DIFF
--- a/admin/backend/api/v1/benches/create.py
+++ b/admin/backend/api/v1/benches/create.py
@@ -37,6 +37,11 @@ def create_bench_locked(
     if response is not None:
         return response
 
+    if admin_tls is None and production_parent:
+        # admin.tls is per-bench, not inherited by BenchCreator (see common_config.toml
+        # split) - so match the parent's own choice unless the caller says otherwise.
+        admin_tls = BenchConfig.read(bench_root, validate=False).admin.tls
+
     try:
         Bench.create_at(
             new_dir,

--- a/tests/admin/backend/test_admin_app.py
+++ b/tests/admin/backend/test_admin_app.py
@@ -310,11 +310,15 @@ def test_api_benches_create_routes_wizard_at_domain_when_production(tmp_path: Pa
     # crash-loop and permanently rate-limit the units. WizardSetupTask starts
     # it once init actually finishes, not this view.
     mock_apply.assert_not_called()
+    # The wizard itself is always reached over http - no cert can exist yet, since
+    # Let's Encrypt's HTTP-01 challenge needs nginx serving plain http first.
     assert data["scheme"] == "http"
     fresh_toml = (benches_dir / "fresh" / "bench.toml").read_text()
-    # admin.tls is a per-bench choice, not inherited from a production sibling -
-    # the new bench starts on plain HTTP until its own wizard/setup requests TLS.
-    assert "tls = false" in fresh_toml
+    # admin.tls isn't auto-inherited by BenchCreator (it moved out with the
+    # common_config.toml split), so the caller matches the parent's own choice
+    # instead - the eventual production+TLS switch happens once the wizard's
+    # init + SetupProductionCommand finish.
+    assert "tls = true" in fresh_toml
     # production.enabled stays false until the wizard's init + SetupProductionCommand
     # actually finish - a half-built deployment must never look "done" to the switcher.
     assert "enabled = false" in fresh_toml.split("[production]")[1].split("[")[0]


### PR DESCRIPTION
Regression from 53458f5e (common_config.toml split): admin.tls became bench-specific/not-inherited, but nothing replaced the old sibling lookup and the Admin UI never sends `admin_tls` when creating a bench. New benches from a production+TLS parent silently landed on `tls=false`. `create_bench_locked` now matches the parent's `admin.tls` when unspecified and the parent is production.