### PR TITLE
fix: generate DB credentials at bench init, not bench new

### DIFF
--- a/pilot/core/bench/creator.py
+++ b/pilot/core/bench/creator.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import secrets
 import socket
 from collections.abc import Callable
 from pathlib import Path
@@ -15,9 +14,8 @@ if TYPE_CHECKING:
 
 class BenchCreator:
     """Creates a bench. Host-shared settings (MariaDB/Postgres server, ACME
-    email, admin JWKS trust) live in common_config.toml and are merged in
-    automatically by BenchConfig - only a first-ever database needs seeding
-    here."""
+    email, admin JWKS trust) live in common_config.toml. Database credentials
+    are generated at `bench init`, not here - see BenchInitializer."""
 
     def __init__(
         self,
@@ -73,34 +71,9 @@ class BenchCreator:
             "admin_tls": bool(self.admin_tls),
             "db_type": self.db_type,
         }
-        self._add_database_settings(settings)
         if self.process_manager:
             settings["production_process_manager"] = self.process_manager
         return settings
-
-    def _add_database_settings(self, settings: dict) -> None:
-        """Pick a fresh port/password only the first time this host
-        provisions the server; later benches inherit them automatically
-        through BenchConfig's merge with common_config.toml."""
-        from pilot.config import BenchConfig, MariaDBConfig, PostgresConfig
-
-        defaults = BenchConfig.default(benches_root=self.target_directory.parent)
-        if self.db_type == "mariadb" and not defaults.mariadb.root_password:
-            settings["mariadb_port"] = self._pick_free_port(MariaDBConfig().port)
-            settings["mariadb_password"] = secrets.token_hex(nbytes=8)
-        if self.db_type == "postgres" and not defaults.postgres.root_password:
-            settings["postgres_port"] = self._pick_free_port(PostgresConfig().port)
-            settings["postgres_password"] = secrets.token_hex(nbytes=8)
-
-    def _pick_free_port(self, port: int) -> int:
-        """Pick the first free port at or after `port`, for the first bench on this host."""
-        from pilot.managers.platform import is_macos
-
-        if is_macos():
-            return port
-        while self._port_is_live(port):
-            port += 1
-        return port
 
     def _pick_port_offset(self, bench_path: Path) -> int:
         """Pick the first base-port offset unused by configs or live processes."""

--- a/pilot/core/bench/initializer.py
+++ b/pilot/core/bench/initializer.py
@@ -38,6 +38,7 @@ class BenchInitializer:
         steps: list[tuple[str, Callable[[], None]]] = [
             ("Validate bench.toml", self.bench.config.validate),
             ("Ensure admin password", self._ensure_admin_password),
+            ("Ensure database credentials", self._ensure_database_credentials),
             ("Install system packages", self._install_system_packages),
             ("Create bench directory structure", self._create_bench_structure),
             ("Create Python virtualenv", lambda: self._create_virtualenv(python_env_manager)),
@@ -104,6 +105,23 @@ class BenchInitializer:
         if not admin.enabled or admin.password:
             return
         admin.password = secrets.token_hex(nbytes=5)
+        self.bench.config.write(self.bench.path)
+
+    def _ensure_database_credentials(self) -> None:
+        """Generate a root password and free port for a fresh shared DB server,
+        the first time any bench on this host provisions one. Later benches on
+        the same host inherit them from common_config.toml instead."""
+        if self.bench.config.db_type not in ("mariadb", "postgres"):
+            return
+        import secrets
+
+        from pilot.utils import pick_free_port
+
+        db = self.bench.config.mariadb if self.bench.config.db_type == "mariadb" else self.bench.config.postgres
+        if db.existing or db.root_password:
+            return
+        db.port = pick_free_port(db.port)
+        db.root_password = secrets.token_hex(nbytes=8)
         self.bench.config.write(self.bench.path)
 
     def _configure_redis(self) -> None:

--- a/pilot/utils.py
+++ b/pilot/utils.py
@@ -71,6 +71,27 @@ def benches_dir() -> Path:
     return cli_root() / "benches"
 
 
+def pick_free_port(port: int) -> int:
+    """First free TCP port at or after `port` (unchanged on macOS)."""
+    from pilot.managers.platform import is_macos
+
+    if is_macos():
+        return port
+    while _port_is_live(port):
+        port += 1
+    return port
+
+
+def _port_is_live(port: int) -> bool:
+    import socket
+
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+            return True
+    except OSError:
+        return False
+
+
 @dataclass(frozen=True)
 class ArchiveLimits:
     max_members: int = 100_000

--- a/tests/pilot/commands/test_commands.py
+++ b/tests/pilot/commands/test_commands.py
@@ -32,6 +32,15 @@ def make_bench(tmp_path: Path) -> Bench:
     return Bench(config, tmp_path)
 
 
+def _ensure_database_credentials(bench_dir: Path) -> None:
+    """The DB-credential step of `bench init` (see BenchInitializer) - database
+    ports/passwords are generated there, not by `bench new`."""
+    from pilot.core.bench import Bench
+    from pilot.core.bench.initializer import BenchInitializer
+
+    BenchInitializer(Bench(bench_dir))._ensure_database_credentials()
+
+
 def test_new_command_creates_directory_and_toml(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from pilot.commands.bench.create import NewCommand
 
@@ -136,20 +145,21 @@ def test_new_command_first_bench_has_no_jwks_url(tmp_path: Path, monkeypatch: py
     assert BenchConfig.read(target).admin.jwks_url == ""
 
 
-def test_new_command_postgres_bench(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Postgres benches record db_type and a provisioning password."""
+def test_new_command_postgres_bench_has_no_password_yet(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`bench new` alone must not provision the shared DB server - only `bench
+    init` does (BenchInitializer._ensure_database_credentials)."""
     from pilot.commands.bench.create import NewCommand
-    from pilot.core.bench.creator import BenchCreator
 
     monkeypatch.setattr("builtins.input", lambda _: "")
-    monkeypatch.setattr(BenchCreator, "_port_is_live", staticmethod(lambda port: False))
     benches_dir = tmp_path / "benches"
     NewCommand(target_directory=benches_dir / "pg", bench_name="pg", database="postgres").run()
 
     with open(benches_dir / "pg" / "bench.toml", "rb") as f:
         data = tomllib.load(f)
     assert data["bench"]["db_type"] == "postgres"
-    assert CommonConfig.read(benches_dir).postgres.root_password  # generated for provisioning
+    assert not CommonConfig.read(benches_dir).postgres.root_password
 
 
 def test_new_command_second_postgres_bench_inherits_password(
@@ -157,14 +167,16 @@ def test_new_command_second_postgres_bench_inherits_password(
 ) -> None:
     """Second Postgres bench reuses the shared server password."""
     from pilot.commands.bench.create import NewCommand
-    from pilot.core.bench.creator import BenchCreator
 
     monkeypatch.setattr("builtins.input", lambda _: "")
-    monkeypatch.setattr(BenchCreator, "_port_is_live", staticmethod(lambda port: False))
+    monkeypatch.setattr("pilot.utils._port_is_live", lambda port: False)
     benches_dir = tmp_path / "benches"
     NewCommand(target_directory=benches_dir / "pg1", bench_name="pg1", database="postgres").run()
+    _ensure_database_credentials(benches_dir / "pg1")
     password = CommonConfig.read(benches_dir).postgres.root_password
+    assert password
     NewCommand(target_directory=benches_dir / "pg2", bench_name="pg2", database="postgres").run()
+    _ensure_database_credentials(benches_dir / "pg2")
 
     assert CommonConfig.read(benches_dir).postgres.root_password == password
     assert BenchConfig.read(benches_dir / "pg2").postgres.root_password == password
@@ -179,8 +191,10 @@ def test_new_command_postgres_port_is_not_offset_between_benches(
 
     monkeypatch.setattr("builtins.input", lambda _: "")
     monkeypatch.setattr(BenchCreator, "_port_is_live", staticmethod(lambda port: False))
+    monkeypatch.setattr("pilot.utils._port_is_live", lambda port: False)
     benches_dir = tmp_path / "benches"
     NewCommand(target_directory=benches_dir / "first", bench_name="first", database="postgres").run()
+    _ensure_database_credentials(benches_dir / "first")
     NewCommand(target_directory=benches_dir / "second", bench_name="second", database="postgres").run()
 
     with open(benches_dir / "second" / "bench.toml", "rb") as f:
@@ -194,32 +208,30 @@ def test_new_command_postgres_port_ignores_live_scan_on_macos(
 ) -> None:
     """macOS Postgres uses Homebrew's default service port."""
     from pilot.commands.bench.create import NewCommand
-    from pilot.core.bench.creator import BenchCreator
 
     monkeypatch.setattr("builtins.input", lambda _: "")
     # 5432 reads as live, which would normally push the picker to 5433+.
-    monkeypatch.setattr(BenchCreator, "_port_is_live", staticmethod(lambda port: port == 5432))
+    monkeypatch.setattr("pilot.utils._port_is_live", lambda port: port == 5432)
+    target = tmp_path / "benches" / "pg"
     with patch("pilot.managers.platform.is_macos", return_value=True):
-        NewCommand(target_directory=tmp_path / "benches" / "pg", bench_name="pg", database="postgres").run()
+        NewCommand(target_directory=target, bench_name="pg", database="postgres").run()
+        _ensure_database_credentials(target)
 
     assert CommonConfig.read(tmp_path / "benches").postgres.port == 5432
 
 
-def test_new_command_mariadb_bench_has_no_postgres_password(
+def test_new_command_mariadb_bench_has_no_password_yet(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from pilot.commands.bench.create import NewCommand
-    from pilot.core.bench.creator import BenchCreator
 
     monkeypatch.setattr("builtins.input", lambda _: "")
-    monkeypatch.setattr(BenchCreator, "_port_is_live", staticmethod(lambda port: False))
     NewCommand(target_directory=tmp_path / "benches" / "m", bench_name="m").run()
 
     with open(tmp_path / "benches" / "m" / "bench.toml", "rb") as f:
         data = tomllib.load(f)
     assert data["bench"]["db_type"] == "mariadb"
-    # not provisioned for mariadb benches
-    assert not CommonConfig.read(tmp_path / "benches").postgres.root_password
+    assert not CommonConfig.read(tmp_path / "benches").mariadb.root_password
 
 
 def test_new_command_mariadb_port_is_not_offset_between_benches(
@@ -231,8 +243,10 @@ def test_new_command_mariadb_port_is_not_offset_between_benches(
 
     monkeypatch.setattr("builtins.input", lambda _: "")
     monkeypatch.setattr(BenchCreator, "_port_is_live", staticmethod(lambda port: False))
+    monkeypatch.setattr("pilot.utils._port_is_live", lambda port: False)
     benches_dir = tmp_path / "benches"
     NewCommand(target_directory=benches_dir / "first", bench_name="first").run()
+    _ensure_database_credentials(benches_dir / "first")
     NewCommand(target_directory=benches_dir / "second", bench_name="second").run()
 
     with open(benches_dir / "second" / "bench.toml", "rb") as f:
@@ -246,13 +260,14 @@ def test_new_command_mariadb_port_ignores_live_scan_on_macos(
 ) -> None:
     """macOS MariaDB uses Homebrew's default service port."""
     from pilot.commands.bench.create import NewCommand
-    from pilot.core.bench.creator import BenchCreator
 
     monkeypatch.setattr("builtins.input", lambda _: "")
     # 3306 reads as live, which would normally push the picker to 3307+.
-    monkeypatch.setattr(BenchCreator, "_port_is_live", staticmethod(lambda port: port == 3306))
+    monkeypatch.setattr("pilot.utils._port_is_live", lambda port: port == 3306)
+    target = tmp_path / "benches" / "m"
     with patch("pilot.managers.platform.is_macos", return_value=True):
-        NewCommand(target_directory=tmp_path / "benches" / "m", bench_name="m").run()
+        NewCommand(target_directory=target, bench_name="m").run()
+        _ensure_database_credentials(target)
 
     assert CommonConfig.read(tmp_path / "benches").mariadb.port == 3306
 
@@ -262,18 +277,19 @@ def test_new_command_second_mariadb_bench_inherits_password(
 ) -> None:
     """Second MariaDB bench reuses the shared server password."""
     from pilot.commands.bench.create import NewCommand
-    from pilot.core.bench.creator import BenchCreator
 
     monkeypatch.setattr("builtins.input", lambda _: "")
-    monkeypatch.setattr(BenchCreator, "_port_is_live", staticmethod(lambda port: False))
+    monkeypatch.setattr("pilot.utils._port_is_live", lambda port: False)
     benches_dir = tmp_path / "benches"
     NewCommand(target_directory=benches_dir / "m1", bench_name="m1").run()
+    _ensure_database_credentials(benches_dir / "m1")
     password = CommonConfig.read(benches_dir).mariadb.root_password
     # Random, not the old guessable hardcoded default.
     assert password != "root"
     assert len(password) == 16  # secrets.token_hex(nbytes=8)
 
     NewCommand(target_directory=benches_dir / "m2", bench_name="m2").run()
+    _ensure_database_credentials(benches_dir / "m2")
     assert CommonConfig.read(benches_dir).mariadb.root_password == password
     assert BenchConfig.read(benches_dir / "m2").mariadb.root_password == password
 

--- a/tests/pilot/commands/test_init_command.py
+++ b/tests/pilot/commands/test_init_command.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -47,3 +47,48 @@ def test_raises_when_existing_credentials_are_wrong() -> None:
         _initializer()._provision_or_verify(manager, "MariaDB")
 
     manager.provision.assert_not_called()
+
+
+def test_ensure_database_credentials_generates_for_a_fresh_server() -> None:
+    bench = MagicMock()
+    bench.config.db_type = "mariadb"
+    bench.config.mariadb.existing = False
+    bench.config.mariadb.root_password = ""
+    bench.config.mariadb.port = 3306
+
+    with patch("pilot.utils.pick_free_port", return_value=3306):
+        BenchInitializer(bench)._ensure_database_credentials()
+
+    assert bench.config.mariadb.root_password
+    bench.config.write.assert_called_once_with(bench.path)
+
+
+def test_ensure_database_credentials_skips_when_already_set() -> None:
+    bench = MagicMock()
+    bench.config.db_type = "mariadb"
+    bench.config.mariadb.existing = False
+    bench.config.mariadb.root_password = "already-set"
+
+    BenchInitializer(bench)._ensure_database_credentials()
+
+    bench.config.write.assert_not_called()
+
+
+def test_ensure_database_credentials_skips_for_an_existing_server() -> None:
+    bench = MagicMock()
+    bench.config.db_type = "mariadb"
+    bench.config.mariadb.existing = True
+    bench.config.mariadb.root_password = ""
+
+    BenchInitializer(bench)._ensure_database_credentials()
+
+    bench.config.write.assert_not_called()
+
+
+def test_ensure_database_credentials_skips_sqlite() -> None:
+    bench = MagicMock()
+    bench.config.db_type = "sqlite"
+
+    BenchInitializer(bench)._ensure_database_credentials()
+
+    bench.config.write.assert_not_called()


### PR DESCRIPTION
BenchCreator wrote a mariadb/postgres root password into common_config.toml the moment `bench new` ran, before any server was installed. `local_database_credentials()` (used by the setup wizard) treats a populated common_config.toml as "a local DB server already exists" and offers "use existing database" - so a fresh single-bench host wrongly showed that. Credential generation now happens in BenchInitializer, right before the DB is actually provisioned, gated the same way (first bench only).