### PR TITLE
fix(admin): restore the `bench admin generate-session` verb

### DIFF
--- a/admin/backend/api/v1/auth.py
+++ b/admin/backend/api/v1/auth.py
@@ -95,7 +95,7 @@ def create_session():
     if error is not None:
         return error
 
-    # A sign-in link is minted on the server by `pilot generate-session`, so whoever holds
+    # A sign-in link is minted on the server by `bench admin generate-session`, so whoever holds
     # one already had shell access. Requiring a device there would only lock out recovery.
     if not redeemed_jti and (blocked := _second_factor_error(bench, str(data.get("otp", "")))):
         return blocked

--- a/admin/frontend/dashboard/src/router.js
+++ b/admin/frontend/dashboard/src/router.js
@@ -123,7 +123,7 @@ export const router = createRouter({
 
 router.beforeEach(async (to) => {
   // A `?sid=<token>` on the URL is a one-time sign-in link (see
-  // `pilot generate-session`). Exchange it for a real session cookie and
+  // `bench admin generate-session`). Exchange it for a real session cookie and
   // re-navigate to the same place with the token stripped, instead of
   // dragging it along into a /login redirect. Errors (expired/already-used
   // link) are swallowed - the next pass through this guard will see no

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -68,6 +68,7 @@ These commands control the task worker, not individual Frappe workers.
 - `bench admin upgrade`: update bench-cli to the latest version, run pending upgrade patches (pre_update before, post_update after), and restart the admin service.
 - `bench admin enroll`: exchange the bootstrap token for this bench's Central credential.
 - `bench admin set-central-config`: store Central endpoint and Pilot auth token.
+- `bench admin generate-session`: mint a 5-minute one-time `?sid=` sign-in token, or the full sign-in URL with `--full-path`.
 - `bench admin issue-site-token`: issue a scoped site-to-bench API token.
 - `bench admin run-patches [--phase pre_update|post_update|all]`: run pending bench-cli upgrade patches by hand (see [Configuration](configuration.md#common-config)); `bench admin upgrade` already runs both phases automatically.
 

--- a/pilot/commands/admin/generate_session.py
+++ b/pilot/commands/admin/generate_session.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import urllib.parse
+from dataclasses import dataclass
+from typing import Annotated, ClassVar
+
+from pilot.commands import Arg, Command
+from pilot.exceptions import BenchError
+
+
+@dataclass(kw_only=True)
+class GenerateSessionCommand(Command):
+    name: ClassVar[str] = "generate-session"
+    group: ClassVar[str] = "admin"
+    help: ClassVar[str] = "Issue a 5-minute one-time sign-in token (use --full-path for a sign-in URL)."
+
+    full_path: Annotated[bool, Arg(help="Print the full admin URL with ?sid= instead of the bare token.")] = (
+        False
+    )
+
+    def run(self) -> None:
+        from admin.backend.internal.session import Session
+        from pilot.utils import admin_url
+
+        if not self.bench.config.admin.password:
+            raise BenchError("Admin has no password set; configure [admin].password in bench.toml first.")
+        token = Session(self.bench).issue_login_token()
+        if self.full_path:
+            self.report(f"{admin_url(self.bench.config)}/?sid={urllib.parse.quote(token, safe='')}")
+        else:
+            self.report(token)

--- a/tests/admin/backend/test_admin_session.py
+++ b/tests/admin/backend/test_admin_session.py
@@ -1127,7 +1127,7 @@ def test_a_wrong_password_is_rejected_before_the_code_is_considered(tmp_path: Pa
 
 
 def test_login_link_bypasses_the_second_factor(tmp_path: Path) -> None:
-    """`pilot generate-session` runs on the server, so its holder already had shell access."""
+    """`bench admin generate-session` runs on the server, so its holder already had shell access."""
     client = _client(tmp_path)
     client.set_cookie("sid", _session_token())
     _enroll_device(client)

--- a/tests/pilot/commands/test_generate_session_command.py
+++ b/tests/pilot/commands/test_generate_session_command.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+from admin.backend.internal.session import Session
+from pilot.commands.admin.generate_session import GenerateSessionCommand
+from pilot.config import BenchConfig
+from pilot.core.bench import Bench
+from pilot.exceptions import BenchError
+from pilot.utils import admin_url
+
+
+def _bench(tmp_path: Path, password: str = "secret", **admin_settings) -> Bench:
+    toml_path = tmp_path / "bench.toml"
+    toml_path.write_text(BenchConfig.from_flat(tmp_path.name, {"admin_password": password}).dumps())
+    config = BenchConfig.from_file(toml_path)
+    for key, value in admin_settings.items():
+        setattr(config.admin, key, value)
+    config.write(toml_path)
+    return Bench(BenchConfig.from_file(toml_path), tmp_path)
+
+
+def test_prints_a_bare_token_by_default(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    bench = _bench(tmp_path)
+
+    GenerateSessionCommand(bench=bench).run()
+
+    token = capsys.readouterr().out.strip()
+    assert Session(bench).verify_token(token)["scope"] == "bench"
+
+
+def test_bare_token_is_single_use_and_short_lived(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    bench = _bench(tmp_path)
+
+    GenerateSessionCommand(bench=bench).run()
+
+    claims = Session(bench).verify_token(capsys.readouterr().out.strip())
+    assert claims["jti"]  # the ?sid= redemption path burns this jti
+    assert claims["exp"] - claims["iat"] == Session.LOGIN_TTL
+
+
+def test_full_path_prints_the_sign_in_url(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    bench = _bench(tmp_path)
+
+    GenerateSessionCommand(bench=bench, full_path=True).run()
+
+    url = capsys.readouterr().out.strip()
+    prefix, _, token = url.partition("/?sid=")
+    assert prefix == admin_url(bench.config)
+    assert Session(bench).verify_token(urllib.parse.unquote(token))["scope"] == "bench"
+
+
+def test_full_path_uses_the_admin_domain_in_production(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+    bench = _bench(tmp_path, domain="admin.example.com", tls=True)
+    bench.config.production.enabled = True
+
+    GenerateSessionCommand(bench=bench, full_path=True).run()
+
+    assert capsys.readouterr().out.startswith("https://admin.example.com/?sid=")
+
+
+def test_requires_an_admin_password(tmp_path: Path) -> None:
+    with pytest.raises(BenchError, match="no password set"):
+        GenerateSessionCommand(bench=_bench(tmp_path, password="")).run()


### PR DESCRIPTION
### What

Re-adds `bench admin generate-session`, which mints a short-lived, single-use `?sid=` sign-in link for the admin console. `--full-path` prints the full sign-in URL; the bare invocation prints just the token.

### Why

`be2f2177` ("feat: Restructure session management and remove CLI based session creation") removed the CLI command. That removal was explicit, so this PR is a deliberate argument to reverse it — the commit removed only the **minting** half of the sign-in-link feature, and everything downstream was kept:

- `Session.issue_login_token()` and `LOGIN_TTL` remain, and gained a unit test in that same commit — while becoming unreachable from any CLI or HTTP surface. Today the only references in the tree are the definition and its own test.
- `POST /api/v1/auth/session` still accepts `sid`, still enforces single use via the login jti, and still intentionally bypasses the second factor for a redeemed link — justified in a comment precisely on the grounds that the link "is minted on the server".
- The dashboard router still exchanges `?sid=` for a session cookie.

No replacement command or endpoint was introduced, so there is currently no way to produce a link, and operators fall back to sharing the static `[admin].password` — the exact thing the one-click handoff was meant to replace.

If the removal was intended as permanent, the consistent cleanup is the opposite direction: drop `issue_login_token`, the `sid` branch in `_validate_login`, and the router guard. This PR assumes the feature was meant to stay. Happy to flip it to the removal PR instead if that is the call.

Note `cb385fc3` ("refactor: group admin commands under `bench admin` namespace") had already carried this command over to the new group, listing `generate-admin-session -> admin generate-session` in its commit body — so the grouped name here matches the intended one.

### Notes

- Mints through the existing `Session.issue_login_token()`; no second token path.
- Registered under the `admin` group via the normal discovery mechanism (`registry._discover()` walks `pilot.commands`), so no manual registration was needed. There is no top-level alias — an unrecognised leading verb is a Frappe passthrough, so grouped commands are group-only by design.
- The original's `_jwt_secret()` helper was deliberately **not** restored: `Session._encode()` now calls `ensure_jwt_secret()` internally and performs the identical write-back, so restoring it would duplicate the secret path. Everything else matches the original — the `--full-path` flag, `admin_url(config)` rendering, `urllib.parse.quote(token, safe='')` escaping, the output contract, and the "no admin password" `BenchError`.
- Comments in `auth.py` and the dashboard router still referenced the pre-regroup invocation and now name the current one.

### Tests

New `tests/pilot/commands/test_generate_session_command.py` covers the bare-token form, the `--full-path` URL shape, the production `https://<admin.domain>` variant, TTL/jti claims, and the missing-password error.

Results: new file 5 passed; targeted run across `tests/pilot/commands/`, `tests/pilot/test_cli.py` and both session test files, 282 passed. Full suite 1985 passed / 1 failed, and 4 `ruff` errors — the failure (`test_cancel_kills_nested_command_session`) and all 4 lint errors reproduce on a clean tree and are pre-existing. Also verified manually against a scratch bench.

One environment note for reviewers: the default `uv run` env lacks PyJWT, so anything touching `verify_token` errors out there; CI installs `.[test,admin,type-check]`.
