### PR TITLE
fix: safer db provisioning and port defaults

### DIFF
--- a/admin/backend/api/v1/setup/database.py
+++ b/admin/backend/api/v1/setup/database.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pilot.config import BenchConfig
+from pilot.config import BenchConfig, MariaDBConfig
 
 if TYPE_CHECKING:
     from pilot.managers.database import MariaDBManager, PostgresManager
@@ -21,7 +21,7 @@ def database_validation(bench_root: Path, data: dict):
     if "existing" in data and not isinstance(data["existing"], bool):
         raise ValueError("existing must be a boolean.")
 
-    default_port = 3306 if engine == "mariadb" else 5432
+    default_port = MariaDBConfig().port if engine == "mariadb" else 5432
     port = data.get("port", default_port)
     if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
         raise ValueError("port must be an integer between 1 and 65535.")
@@ -107,7 +107,7 @@ def _mariadb_config(
         root_password=password,
         admin_user=admin_user,
         host=host or "localhost",
-        port=int(port or 3306),
+        port=int(port or MariaDBConfig().port),
         existing=existing,
     )
     toml_path = bench_root / "bench.toml"

--- a/admin/backend/api/v1/setup/database.py
+++ b/admin/backend/api/v1/setup/database.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pilot.config import BenchConfig, MariaDBConfig
+from pilot.config import BenchConfig, MariaDBConfig, PostgresConfig
 
 if TYPE_CHECKING:
     from pilot.managers.database import MariaDBManager, PostgresManager
@@ -21,7 +21,7 @@ def database_validation(bench_root: Path, data: dict):
     if "existing" in data and not isinstance(data["existing"], bool):
         raise ValueError("existing must be a boolean.")
 
-    default_port = MariaDBConfig().port if engine == "mariadb" else 5432
+    default_port = MariaDBConfig().port if engine == "mariadb" else PostgresConfig().port
     port = data.get("port", default_port)
     if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
         raise ValueError("port must be an integer between 1 and 65535.")
@@ -47,7 +47,6 @@ def database_validation(bench_root: Path, data: dict):
         )
         return engine, MariaDBManager(config), password, existing
 
-    from pilot.config import PostgresConfig
     from pilot.managers.database import PostgresManager
 
     config = PostgresConfig(

--- a/pilot/config/mariadb.py
+++ b/pilot/config/mariadb.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 class MariaDBConfig:
     # existing is a deliberate user choice, never inferred from host (see MariaDBManager).
     host: str = "localhost"
-    port: int = 3306
+    # Avoids clashing with a stock MariaDB/MySQL install on the well-known 3306.
+    port: int = 3310
     root_password: str = ""
     admin_user: str = "root"
     socket_path: str = ""

--- a/pilot/config/postgres.py
+++ b/pilot/config/postgres.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 @dataclass
 class PostgresConfig:
     host: str = "localhost"
-    port: int = 5432
+    # Avoids clashing with a stock PostgreSQL install on the well-known 5432.
+    port: int = 5450
     root_password: str = ""
     admin_user: str = "postgres"
     existing: bool = False

--- a/pilot/managers/database/base.py
+++ b/pilot/managers/database/base.py
@@ -32,6 +32,7 @@ class UserOwnedDBManager(SystemdUserMixin):
             if self.is_reachable():
                 return
             time.sleep(0.5)
+        raise DatabaseError(f"{self._DISPLAY_NAME} did not become reachable within {timeout:.0f}s.")
 
     def install(self) -> None:
         if self.is_installed():
@@ -78,6 +79,19 @@ class UserOwnedDBManager(SystemdUserMixin):
             run_command(["brew", "services", action, self._brew_package()])
         else:
             run_command(self._systemctl(action, self._UNIT_NAME), env=self._systemctl_env())
+
+    def _reset_failed_state(self) -> None:
+        """Clear a stuck failed/rate-limited unit before (re)starting it.
+
+        A never-loaded unit makes this exit non-zero ("not loaded") - that's
+        not a failure worth raising on, so this doesn't use run_command.
+        """
+        subprocess.run(
+            self._systemctl("reset-failed", self._UNIT_NAME),
+            env=self._systemctl_env(),
+            capture_output=True,
+            timeout=5,
+        )
 
     def _brew_package(self) -> str:
         return self._installed_brew_formula() or f"{self._BREW_FORMULA_BASE}@{self._DEFAULT_VERSION}"

--- a/pilot/managers/database/mariadb.py
+++ b/pilot/managers/database/mariadb.py
@@ -59,7 +59,7 @@ class MariaDBManager(UserOwnedDBManager):
     def is_provisioned(self) -> bool:
         if is_macos():
             return self.is_running() and not self.is_unsecured()
-        return super().is_provisioned()
+        return super().is_provisioned() and self.my_cnf_path.exists()
 
     def _provision_macos(self):
         if not self.is_running():
@@ -77,9 +77,11 @@ class MariaDBManager(UserOwnedDBManager):
             self._initialize_data_dir()
             self._write_config()
             self._install_unit()
+            self._reset_failed_state()
             run_command(self._systemctl("enable", "--now", self._UNIT_NAME), env=self._systemctl_env())
 
         elif not self.is_running():
+            self._reset_failed_state()
             run_command(self._systemctl("start", self._UNIT_NAME), env=self._systemctl_env())
 
         self._wait_until_reachable()

--- a/pilot/managers/database/postgres.py
+++ b/pilot/managers/database/postgres.py
@@ -54,7 +54,7 @@ class PostgresManager(UserOwnedDBManager):
     def is_provisioned(self) -> bool:
         if is_macos():
             return self.is_running() and not self.is_unsecured()
-        return super().is_provisioned()
+        return super().is_provisioned() and (self.config_dir / "postgresql.conf").exists()
 
     def is_unsecured(self) -> bool:
         """True when the admin role has no password in pg_authid."""
@@ -105,8 +105,10 @@ class PostgresManager(UserOwnedDBManager):
             run_command([self._server_binary("initdb"), "-D", str(self.data_dir)])
             self._move_generated_config_into_config_dir()
             self._install_unit()
+            self._reset_failed_state()
             run_command(self._systemctl("enable", "--now", self._UNIT_NAME), env=self._systemctl_env())
         elif not self.is_running():
+            self._reset_failed_state()
             run_command(self._systemctl("start", self._UNIT_NAME), env=self._systemctl_env())
 
     def _move_generated_config_into_config_dir(self) -> None:

--- a/tests/admin/backend/api/test_setup_api.py
+++ b/tests/admin/backend/api/test_setup_api.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from admin.backend.app import create_app
-from pilot.config import BenchConfig
+from pilot.config import BenchConfig, MariaDBConfig
 from pilot.internal.tasks.store import TaskStore
 from pilot.managers.task.models import TaskStatus
 
@@ -273,7 +273,7 @@ def test_database_validation_uses_one_engine_neutral_resource(tmp_path: Path) ->
     config = manager_class.call_args.args[0]
     assert config.root_password == "secret"
     assert config.admin_user == "root"
-    assert config.port == 3306
+    assert config.port == MariaDBConfig().port
 
 
 def test_database_validation_supports_existing_postgres(tmp_path: Path) -> None:

--- a/tests/pilot/commands/test_commands.py
+++ b/tests/pilot/commands/test_commands.py
@@ -8,7 +8,15 @@ from unittest.mock import ANY, MagicMock, PropertyMock, patch
 
 import pytest
 
-from pilot.config import AppConfig, BenchConfig, MariaDBConfig, RedisConfig, WorkerConfig, WorkerGroup
+from pilot.config import (
+    AppConfig,
+    BenchConfig,
+    MariaDBConfig,
+    PostgresConfig,
+    RedisConfig,
+    WorkerConfig,
+    WorkerGroup,
+)
 from pilot.config.common import CommonConfig
 from pilot.core.bench import Bench
 from pilot.exceptions import BenchAlreadyExistsError, BenchError
@@ -199,7 +207,7 @@ def test_new_command_postgres_port_is_not_offset_between_benches(
 
     with open(benches_dir / "second" / "bench.toml", "rb") as f:
         data = tomllib.load(f)
-    assert CommonConfig.read(benches_dir).postgres.port == 5432
+    assert CommonConfig.read(benches_dir).postgres.port == PostgresConfig().port
     assert data["bench"]["http_port"] == 8001  # other ports still offset
 
 
@@ -210,14 +218,15 @@ def test_new_command_postgres_port_ignores_live_scan_on_macos(
     from pilot.commands.bench.create import NewCommand
 
     monkeypatch.setattr("builtins.input", lambda _: "")
-    # 5432 reads as live, which would normally push the picker to 5433+.
-    monkeypatch.setattr("pilot.utils._port_is_live", lambda port: port == 5432)
+    default_port = PostgresConfig().port
+    # The default port reads as live, which would normally push the picker up.
+    monkeypatch.setattr("pilot.utils._port_is_live", lambda port: port == default_port)
     target = tmp_path / "benches" / "pg"
     with patch("pilot.managers.platform.is_macos", return_value=True):
         NewCommand(target_directory=target, bench_name="pg", database="postgres").run()
         _ensure_database_credentials(target)
 
-    assert CommonConfig.read(tmp_path / "benches").postgres.port == 5432
+    assert CommonConfig.read(tmp_path / "benches").postgres.port == default_port
 
 
 def test_new_command_mariadb_bench_has_no_password_yet(

--- a/tests/pilot/commands/test_commands.py
+++ b/tests/pilot/commands/test_commands.py
@@ -251,7 +251,7 @@ def test_new_command_mariadb_port_is_not_offset_between_benches(
 
     with open(benches_dir / "second" / "bench.toml", "rb") as f:
         data = tomllib.load(f)
-    assert CommonConfig.read(benches_dir).mariadb.port == 3306
+    assert CommonConfig.read(benches_dir).mariadb.port == MariaDBConfig().port
     assert data["bench"]["http_port"] == 8001  # other ports still offset
 
 
@@ -262,14 +262,15 @@ def test_new_command_mariadb_port_ignores_live_scan_on_macos(
     from pilot.commands.bench.create import NewCommand
 
     monkeypatch.setattr("builtins.input", lambda _: "")
-    # 3306 reads as live, which would normally push the picker to 3307+.
-    monkeypatch.setattr("pilot.utils._port_is_live", lambda port: port == 3306)
+    default_port = MariaDBConfig().port
+    # The default port reads as live, which would normally push the picker up.
+    monkeypatch.setattr("pilot.utils._port_is_live", lambda port: port == default_port)
     target = tmp_path / "benches" / "m"
     with patch("pilot.managers.platform.is_macos", return_value=True):
         NewCommand(target_directory=target, bench_name="m").run()
         _ensure_database_credentials(target)
 
-    assert CommonConfig.read(tmp_path / "benches").mariadb.port == 3306
+    assert CommonConfig.read(tmp_path / "benches").mariadb.port == default_port
 
 
 def test_new_command_second_mariadb_bench_inherits_password(

--- a/tests/pilot/config/test_bench_toml_builder.py
+++ b/tests/pilot/config/test_bench_toml_builder.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-from pilot.config import BenchConfig
+from pilot.config import BenchConfig, MariaDBConfig
 
 
 def test_default_ports_returns_all_fields() -> None:
@@ -56,7 +56,7 @@ def test_mariadb_port_not_offset() -> None:
     # It lives in common_config.toml, not bench.toml, so it's checked on the
     # in-memory config rather than the rendered TOML.
     config = BenchConfig.from_flat("my-bench", port_offset=1)
-    assert config.mariadb.port == 3306
+    assert config.mariadb.port == MariaDBConfig().port
 
 
 def test_port_fields_not_settable_via_settings(tmp_path: Path) -> None:

--- a/tests/pilot/config/test_config.py
+++ b/tests/pilot/config/test_config.py
@@ -6,6 +6,7 @@ import pytest
 from pilot.config import (
     BenchConfig,
     FirewallRule,
+    PostgresConfig,
     ProductionConfig,
     WafCondition,
     WafRule,
@@ -238,7 +239,7 @@ def test_central_config_round_trips_through_typed_writer() -> None:
 def test_postgres_defaults_when_section_absent() -> None:
     config = load_from_dict(copy.deepcopy(MINIMAL_VALID_DATA))
     assert config.postgres.host == "localhost"
-    assert config.postgres.port == 5432
+    assert config.postgres.port == PostgresConfig().port
     assert config.postgres.admin_user == "postgres"
     assert config.postgres.root_password == ""
 

--- a/tests/pilot/managers/test_mariadb_manager.py
+++ b/tests/pilot/managers/test_mariadb_manager.py
@@ -25,6 +25,10 @@ def test_socket_path_honors_explicit_value() -> None:
     assert MariaDBManager(MariaDBConfig(socket_path="/tmp/custom.sock")).socket_path == "/tmp/custom.sock"
 
 
+def test_default_port_avoids_standard_mysql_port() -> None:
+    assert MariaDBConfig().port == 3310
+
+
 def test_existing_defaults_to_false() -> None:
     assert MariaDBConfig().existing is False
 
@@ -119,6 +123,45 @@ def test_is_provisioned_on_macos_checks_live_server_not_a_marker_file() -> None:
         patch.object(m, "is_unsecured", return_value=False),
     ):
         assert m.is_provisioned() is True  # up and already secured
+
+
+def test_is_provisioned_false_when_data_dir_wiped_but_unit_still_exists(tmp_path) -> None:
+    """A stale systemd unit outliving a deleted state dir must not look provisioned."""
+    m = _manager()
+    with (
+        patch(f"{MODULE}.is_macos", return_value=False),
+        patch.object(type(m), "state_dir", new_callable=PropertyMock, return_value=tmp_path),
+        patch(f"{BASE_MODULE}.UserOwnedDBManager.is_provisioned", return_value=True),
+    ):
+        assert m.is_provisioned() is False
+
+
+def test_wait_until_reachable_raises_after_timeout() -> None:
+    m = _manager()
+    with (
+        patch.object(m, "is_reachable", return_value=False),
+        patch(f"{BASE_MODULE}.time.sleep"),
+        pytest.raises(DatabaseError, match="did not become reachable"),
+    ):
+        m._wait_until_reachable(timeout=0.01)
+
+
+def test_provision_resets_failed_state_before_restarting_stopped_unit() -> None:
+    m = _manager()
+    with (
+        patch(f"{MODULE}.is_macos", return_value=False),
+        patch.object(m, "install"),
+        patch.object(m, "is_provisioned", return_value=True),
+        patch.object(m, "is_running", return_value=False),
+        patch.object(m, "_wait_until_reachable"),
+        patch.object(m, "secure_installation"),
+        patch(f"{MODULE}.run_command") as rc,
+        patch(f"{BASE_MODULE}.subprocess.run") as reset_run,
+    ):
+        m.provision()
+    reset_run.assert_called_once()
+    assert reset_run.call_args.args[0] == ["systemctl", "--user", "reset-failed", "pilot-mariadb.service"]
+    assert rc.call_args.args[0] == ["systemctl", "--user", "start", "pilot-mariadb.service"]
 
 
 def test_provision_reuses_already_provisioned_server() -> None:

--- a/tests/pilot/managers/test_postgres_manager.py
+++ b/tests/pilot/managers/test_postgres_manager.py
@@ -339,6 +339,31 @@ def test_provision_user_owned_reuses_already_provisioned_server() -> None:
     rc.assert_not_called()
 
 
+def test_is_provisioned_false_when_data_dir_wiped_but_unit_still_exists(tmp_path) -> None:
+    """A stale systemd unit outliving a deleted state dir must not look provisioned."""
+    m = _mgr()
+    with (
+        patch(f"{MODULE}.is_macos", return_value=False),
+        patch.object(type(m), "state_dir", new_callable=PropertyMock, return_value=tmp_path),
+        patch(f"{BASE_MODULE}.UserOwnedDBManager.is_provisioned", return_value=True),
+    ):
+        assert m.is_provisioned() is False
+
+
+def test_provision_user_owned_resets_failed_state_before_restarting_stopped_unit() -> None:
+    m = _mgr()
+    with (
+        patch.object(m, "is_provisioned", return_value=True),
+        patch.object(m, "is_running", return_value=False),
+        patch(f"{MODULE}.run_command") as rc,
+        patch(f"{BASE_MODULE}.subprocess.run") as reset_run,
+    ):
+        m._provision_user_owned()
+    reset_run.assert_called_once()
+    assert reset_run.call_args.args[0] == ["systemctl", "--user", "reset-failed", "pilot-postgres.service"]
+    assert rc.call_args.args[0] == ["systemctl", "--user", "start", "pilot-postgres.service"]
+
+
 def test_run_sql_as_superuser_uses_local_psql() -> None:
     m = _mgr(port=5440)
     with (


### PR DESCRIPTION
- MariaDB/Postgres default ports: 3310/5450 instead of 3306/5432
- Fix stale systemd unit surviving a deleted state dir
- Raise on unreachable timeout instead of failing silently