### PR TITLE
fix: New Site and App failures and Site Drop

### DIFF
--- a/admin/backend/api/v1/settings/__init__.py
+++ b/admin/backend/api/v1/settings/__init__.py
@@ -142,6 +142,15 @@ def _saved_llm_api_key() -> str:
         return ""
 
 
+def _saved_llm_api_base() -> str:
+    """The endpoint already stored in bench.toml - listing models must hit the same
+    server the assistant will, not the provider's default."""
+    try:
+        return BenchConfig.read(Path(current_app.config["BENCH_ROOT"])).llm.api_base
+    except Exception:
+        return ""
+
+
 @settings_bp.post("/llm/models")
 def llm_models():
     """Models available for a provider — powers the model combobox. POST so the
@@ -157,8 +166,10 @@ def llm_models():
     if not api_key and models_need_api_key(provider):
         api_key = _saved_llm_api_key()
 
+    api_base = str(payload.get("api_base", "")).strip() or _saved_llm_api_base()
+
     try:
-        return jsonify(models_for(provider, api_key))
+        return jsonify(models_for(provider, api_key, api_base))
     except ValueError as exc:
         return error_response("llm_models_unavailable", str(exc), 400)
 

--- a/admin/backend/api/v1/settings/config.py
+++ b/admin/backend/api/v1/settings/config.py
@@ -236,5 +236,8 @@ class ConfigPatcher:
         if not llm_config.model:
             return "llm.model is required. Select a model for the provider."
         if requires_api_base(llm_config.provider) and not llm_config.api_base:
-            return "llm.api_base is required for a self-hosted provider."
+            return (
+                f"llm.api_base is required for {llm_config.provider!r} - it is served from "
+                "your own endpoint, so there is no default to fall back to."
+            )
         return None

--- a/admin/backend/api/v1/tasks.py
+++ b/admin/backend/api/v1/tasks.py
@@ -220,10 +220,17 @@ def debug_task(task_id: str):
         return error_response("ai_not_configured", "Connect an AI assistant in Settings first.", 409)
 
     output = "".join(reader.iter_output(task_id)) if task.output_path.exists() else ""
+    refresh = request.args.get("refresh") == "1"
 
     def generate():
         try:
-            for text in stream_task_debug(config.llm, task, output, bench_root=bench_root):
+            for text in stream_task_debug(
+                config.llm,
+                task,
+                output,
+                bench_root=bench_root,
+                refresh=refresh,
+            ):
                 yield sse_message({"type": "delta", "text": text})
             yield sse_message({"type": "done"})
         except LLMError as error:

--- a/admin/backend/api/v1/tasks.py
+++ b/admin/backend/api/v1/tasks.py
@@ -18,7 +18,11 @@ from admin.backend.api.responses import (
     error_response,
     no_content_response,
 )
-from pilot.exceptions import TaskConflictError, TaskNotFoundError, TaskNotRunningError
+from pilot.exceptions import (
+    TaskConflictError,
+    TaskNotFoundError,
+    TaskNotRunningError,
+)
 from pilot.managers.task import (
     TaskActivityReader,
     TaskReader,

--- a/admin/backend/api/v1/tasks.py
+++ b/admin/backend/api/v1/tasks.py
@@ -20,6 +20,7 @@ from admin.backend.api.responses import (
 )
 from pilot.exceptions import (
     TaskConflictError,
+    TaskNotCancellableError,
     TaskNotFoundError,
     TaskNotRunningError,
 )
@@ -106,6 +107,8 @@ def cancel_task(task_id: str):
         return error_response("task_not_found", str(error), 404)
     except TaskNotRunningError as error:
         return error_response("task_not_active", str(error), 409)
+    except TaskNotCancellableError as error:
+        return error_response("task_not_cancellable", str(error), 409)
     except Exception:
         return error_response("task_cancellation_failed", "Could not cancel task.", 500)
     return no_content_response()

--- a/admin/frontend/dashboard/src/api/settings.js
+++ b/admin/frontend/dashboard/src/api/settings.js
@@ -5,8 +5,10 @@ export const settingsApi = {
   update: (data) => unwrap(request.patch('settings', { json: data }).json()),
   changeAdminPassword: (data) => unwrap(request.post('auth/password', { json: data }).json()),
   myIp: () => request.get('network/client').json(),
-  llmModels: (provider, apiKey = '') =>
-    request.post('settings/llm/models', { json: { provider, api_key: apiKey } }).json(),
+  llmModels: (provider, apiKey = '', apiBase = '') =>
+    request
+      .post('settings/llm/models', { json: { provider, api_key: apiKey, api_base: apiBase } })
+      .json(),
 }
 
 export const cliUpdatesApi = {

--- a/admin/frontend/dashboard/src/api/tasks.js
+++ b/admin/frontend/dashboard/src/api/tasks.js
@@ -13,7 +13,8 @@ export const tasksApi = {
   },
   outputUrl: (taskId) => apiUrl(`tasks/${taskId}/output/content`),
   streamUrl: (taskId) => apiUrl(`tasks/${taskId}/events`),
-  debugUrl: (taskId) => apiUrl(`tasks/${taskId}/debug`),
+  debugUrl: (taskId, refresh = false) =>
+    apiUrl(`tasks/${taskId}/debug${refresh ? '?refresh=1' : ''}`),
 }
 
 export const taskWorkerApi = {

--- a/admin/frontend/dashboard/src/components/apps/InstallAppDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/InstallAppDialog.vue
@@ -1,93 +1,60 @@
 <template>
-  <Dialog v-model="open" :title="`Install App`" size="md">
-    <template #default>
-      <div class="space-y-4">
-        <div class="flex items-center gap-3">
-          <AppIcon
-            :name="app?.name || ''"
-            :label="appLabel"
-            :logo="app?.logo_url || ''"
-            class="rounded-[10px] size-11"
-            initial-class="text-lg"
-          />
-          <div class="min-w-0">
-            <div class="flex items-center gap-1.5">
-              <p class="font-medium text-ink-gray-8 text-base truncate">{{ appLabel }}</p>
-              <span v-if="app?.label" class="text-ink-gray-5 text-p-xs shrink-0">
-                {{ app.label }}
-              </span>
-            </div>
-            <p v-if="app?.description" class="text-ink-gray-5 text-p-sm line-clamp-2">
-              {{ app.description }}
-            </p>
-          </div>
-        </div>
+  <ActionDialog
+    v-model:open="open"
+    title="Install App"
+    :subject="{ name: app?.name, label: appLabel, badge: app?.label, description: app?.description, logo: app?.logo_url }"
+    :error="error"
+    confirm-label="Install"
+    :loading="installing"
+    :disabled="!selection || presetInstalled"
+    @confirm="confirmInstall"
+  >
+    <div class="space-y-2">
+      <p class="font-medium text-ink-gray-5 text-p-xs uppercase tracking-wide">Install on</p>
 
-        <div class="border-outline-gray-2 border-t" />
+      <SiteRow
+        v-if="presetSite"
+        :label="presetSite.name"
+        :subtitle="presetInstalled ? 'Already installed' : siteVersion(presetSite)"
+        :icon="presetInstalled ? 'lucide-check' : 'lucide-globe'"
+        :checked="presetInstalled"
+        :interactive="false"
+      />
 
-        <div class="space-y-2">
-          <p class="font-medium text-ink-gray-5 text-p-xs uppercase tracking-wide">Install on</p>
+      <div v-else class="gap-2 grid max-h-80 overflow-y-auto">
+        <SiteRow
+          v-if="showAllSitesOption"
+          label="All sites"
+          :subtitle="`Installs on ${installableSites.length} sites`"
+          icon="lucide-layout-grid"
+          :selected="selection === 'all'"
+          @click="selection = 'all'"
+        />
 
-          <SiteRow
-            v-if="presetSite"
-            :label="presetSite.name"
-            :subtitle="presetInstalled ? 'Already installed' : siteVersion(presetSite)"
-            :icon="presetInstalled ? 'lucide-check' : 'lucide-globe'"
-            :checked="presetInstalled"
-            :interactive="false"
-          />
+        <SiteRow
+          v-for="s in sites"
+          :key="s.name"
+          :label="s.name"
+          :subtitle="isInstalled(s) ? 'Already installed' : siteVersion(s)"
+          :icon="isInstalled(s) ? 'lucide-check' : 'lucide-globe'"
+          :checked="isInstalled(s)"
+          :disabled="isInstalled(s)"
+          :selected="selection === s.name"
+          @click="selection = s.name"
+        />
 
-          <div v-else class="gap-2 grid max-h-80 overflow-y-auto">
-            <SiteRow
-              v-if="showAllSitesOption"
-              label="All sites"
-              :subtitle="`Installs on ${installableSites.length} sites`"
-              icon="lucide-layout-grid"
-              :selected="selection === 'all'"
-              @click="selection = 'all'"
-            />
-
-            <SiteRow
-              v-for="s in sites"
-              :key="s.name"
-              :label="s.name"
-              :subtitle="isInstalled(s) ? 'Already installed' : siteVersion(s)"
-              :icon="isInstalled(s) ? 'lucide-check' : 'lucide-globe'"
-              :checked="isInstalled(s)"
-              :disabled="isInstalled(s)"
-              :selected="selection === s.name"
-              @click="selection = s.name"
-            />
-
-            <p v-if="!sites.length" class="py-6 text-ink-gray-5 text-sm text-center">
-              No sites available on this bench.
-            </p>
-          </div>
-        </div>
-
-        <ErrorMessage v-if="error" :message="error" />
-
-        <div class="flex justify-end gap-2">
-          <Button variant="subtle" @click="open = false">Cancel</Button>
-          <Button
-            variant="solid"
-            :disabled="!selection || presetInstalled"
-            :loading="installing"
-            @click="confirmInstall"
-          >
-            Install
-          </Button>
-        </div>
+        <p v-if="!sites.length" class="py-6 text-ink-gray-5 text-sm text-center">
+          No sites available on this bench.
+        </p>
       </div>
-    </template>
-  </Dialog>
+    </div>
+  </ActionDialog>
 </template>
 
 <script setup>
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { Button, Dialog, ErrorMessage } from 'frappe-ui'
-import AppIcon from '@/components/apps/AppIcon.vue'
+import ActionDialog from '@/components/common/ActionDialog.vue'
 import SiteRow from '@/components/sites/SiteRow.vue'
 import { apiErrorMessage } from '@/api/client'
 import { sitesApi } from '@/api/sites'

--- a/admin/frontend/dashboard/src/components/apps/UninstallAppDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/UninstallAppDialog.vue
@@ -1,64 +1,29 @@
 <template>
-  <Dialog v-model="open" title="Uninstall App" size="md">
-    <template #default>
-      <div class="space-y-4">
-        <div class="flex items-center gap-3">
-          <AppIcon
-            :name="app?.name || ''"
-            :label="appLabel"
-            :logo="app?.logo_url || ''"
-            class="rounded-[10px] size-11"
-            initial-class="text-lg"
-          />
-          <div class="min-w-0">
-            <div class="flex items-center gap-1.5">
-              <p class="font-medium text-ink-gray-8 text-base truncate">{{ appLabel }}</p>
-              <span v-if="app?.label" class="text-ink-gray-5 text-p-xs shrink-0">
-                {{ app.label }}
-              </span>
-            </div>
-            <p v-if="app?.description" class="text-ink-gray-5 text-p-sm line-clamp-2">
-              {{ app.description }}
-            </p>
-          </div>
-        </div>
-
-        <div class="border-outline-gray-2 border-t" />
-
-        <div class="space-y-2">
-          <p class="font-medium text-ink-gray-5 text-p-xs uppercase tracking-wide">Uninstall from</p>
-          <SiteRow :label="siteName" icon="lucide-globe" :interactive="false" />
-        </div>
-
-        <div class="flex items-start gap-3 bg-surface-red-1 p-3 border border-outline-red-2 rounded-lg">
-          <span class="mt-0.5 size-4 text-ink-red-6 lucide-alert-triangle shrink-0" />
-          <div class="min-w-0 text-p-sm text-ink-red-8">
-            <p class="font-medium">This can't be undone.</p>
-            <p class="mt-0.5 leading-5">
-              Every doctype {{ appLabel }} owns is dropped from {{ siteName }}, along with the
-              records in it. Back the site up first if you need the data.
-            </p>
-          </div>
-        </div>
-
-        <ErrorMessage v-if="error" :message="error" />
-
-        <div class="flex justify-end gap-2">
-          <Button variant="subtle" @click="open = false">Cancel</Button>
-          <Button variant="solid" theme="red" :loading="uninstalling" @click="confirmUninstall">
-            Uninstall
-          </Button>
-        </div>
-      </div>
-    </template>
-  </Dialog>
+  <ActionDialog
+    v-model:open="open"
+    title="Uninstall App"
+    :subject="{ name: app?.name, label: appLabel, badge: app?.label, description: app?.description, logo: app?.logo_url }"
+    :warning="{
+      title: `This can't be undone.`,
+      message: `Every doctype ${appLabel} owns is dropped from ${siteName}, along with the records in it. Back the site up first if you need the data.`,
+    }"
+    :error="error"
+    confirm-label="Uninstall"
+    confirm-theme="red"
+    :loading="uninstalling"
+    @confirm="confirmUninstall"
+  >
+    <div class="space-y-2">
+      <p class="font-medium text-ink-gray-5 text-p-xs uppercase tracking-wide">Uninstall from</p>
+      <SiteRow :label="siteName" icon="lucide-globe" :interactive="false" />
+    </div>
+  </ActionDialog>
 </template>
 
 <script setup>
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { Button, Dialog, ErrorMessage } from 'frappe-ui'
-import AppIcon from '@/components/apps/AppIcon.vue'
+import ActionDialog from '@/components/common/ActionDialog.vue'
 import SiteRow from '@/components/sites/SiteRow.vue'
 import { apiErrorMessage } from '@/api/client'
 import { sitesApi } from '@/api/sites'

--- a/admin/frontend/dashboard/src/components/common/ActionDialog.vue
+++ b/admin/frontend/dashboard/src/components/common/ActionDialog.vue
@@ -1,0 +1,93 @@
+<template>
+  <Dialog v-model="open" :title="title" :size="size">
+    <template #default>
+      <div class="space-y-4">
+        <slot name="subject">
+          <div v-if="subject" class="flex items-center gap-3">
+            <span
+              v-if="subject.icon"
+              class="place-items-center grid bg-surface-gray-2 rounded-[10px] size-11 shrink-0"
+            >
+              <span class="size-5 text-ink-gray-7" :class="subject.icon" />
+            </span>
+            <AppIcon
+              v-else
+              :name="subject.name || subject.label"
+              :label="subject.label"
+              :logo="subject.logo || ''"
+              class="rounded-[10px] size-11"
+              initial-class="text-lg"
+            />
+            <div class="min-w-0">
+              <div class="flex items-center gap-1.5">
+                <p class="font-medium text-ink-gray-8 text-base truncate">{{ subject.label }}</p>
+                <span v-if="subject.badge" class="text-ink-gray-5 text-p-xs shrink-0">
+                  {{ subject.badge }}
+                </span>
+              </div>
+              <p v-if="subject.description" class="text-ink-gray-5 text-p-sm line-clamp-2">
+                {{ subject.description }}
+              </p>
+            </div>
+          </div>
+        </slot>
+
+        <div v-if="$slots.subject || subject" class="border-outline-gray-2 border-t" />
+
+        <slot />
+
+        <div
+          v-if="warning"
+          class="flex items-start gap-3 bg-surface-red-1 p-3 border border-outline-red-2 rounded-lg"
+        >
+          <span class="mt-0.5 size-4 text-ink-red-6 lucide-alert-triangle shrink-0" />
+          <div class="min-w-0 text-p-sm text-ink-red-8">
+            <p class="font-medium">{{ warning.title }}</p>
+            <p v-if="warning.message" class="mt-0.5 leading-5">{{ warning.message }}</p>
+          </div>
+        </div>
+
+        <slot name="after-warning" />
+
+        <ErrorMessage v-if="error" :message="error" />
+
+        <div class="flex justify-end gap-2">
+          <Button variant="subtle" @click="open = false">{{ cancelLabel }}</Button>
+          <Button
+            variant="solid"
+            :theme="confirmTheme"
+            :loading="loading"
+            :disabled="disabled"
+            @click="emit('confirm')"
+          >
+            {{ confirmLabel }}
+          </Button>
+        </div>
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup>
+import { Button, Dialog, ErrorMessage } from 'frappe-ui'
+import AppIcon from '@/components/apps/AppIcon.vue'
+
+defineProps({
+  title: { type: String, required: true },
+  size: { type: String, default: 'md' },
+  // { label, description, badge, icon } - `icon` picks a lucide tile, otherwise
+  // the app logo is used via { name, logo }.
+  subject: { type: Object, default: null },
+  // { title, message } rendered as the destructive-action callout.
+  warning: { type: Object, default: null },
+  error: { type: String, default: '' },
+  confirmLabel: { type: String, required: true },
+  confirmTheme: { type: String, default: 'gray' },
+  cancelLabel: { type: String, default: 'Cancel' },
+  loading: { type: Boolean, default: false },
+  disabled: { type: Boolean, default: false },
+})
+
+const open = defineModel('open')
+const emit = defineEmits(['confirm'])
+</script>

--- a/admin/frontend/dashboard/src/components/settings/LLM.vue
+++ b/admin/frontend/dashboard/src/components/settings/LLM.vue
@@ -39,6 +39,22 @@
         @update:model-value="onProviderSelect"
       />
 
+      <div v-if="needsApiBase" class="space-y-1.5">
+        <FormControl
+          label="API Base URL"
+          type="text"
+          v-model="apiBase"
+          placeholder="http://your-host:8000/v1"
+        />
+        <p v-if="apiBaseError" class="text-ink-red-6 text-p-sm">{{ apiBaseError }}</p>
+      </div>
+      <FormControl
+        label="API Key"
+        type="password"
+        v-model="apiKey"
+        :placeholder="apiKeySet ? '••••••••' : 'Provider API key'"
+      />
+
       <FormControl
         v-if="freeTextModel"
         label="Model"
@@ -58,20 +74,6 @@
         <p v-if="modelsError" class="text-ink-red-6 text-p-sm">{{ modelsError }}</p>
         <p v-else-if="modelsHint" class="text-ink-gray-5 text-p-sm">{{ modelsHint }}</p>
       </div>
-
-      <FormControl
-        v-if="needsApiBase"
-        label="API Base URL"
-        type="text"
-        v-model="apiBase"
-        placeholder="http://your-host:8000/v1"
-      />
-      <FormControl
-        label="API Key"
-        type="password"
-        v-model="apiKey"
-        :placeholder="apiKeySet ? '••••••••' : 'Provider API key'"
-      />
       <FormControl
         label="System Prompt"
         type="textarea"
@@ -103,7 +105,7 @@
 
       <ErrorMessage v-if="error" :message="error" />
       <div class="flex justify-end">
-        <Button variant="solid" :loading="saving" @click="save">
+        <Button variant="solid" :loading="saving" :disabled="Boolean(apiBaseError)" @click="save">
           {{ connected ? 'Update' : 'Connect' }}
         </Button>
       </div>
@@ -151,8 +153,15 @@ const modelOptions = computed(() => models.value.map((m) => ({ label: m, value: 
 const modelSelection = computed(() =>
   model.value ? { label: model.value, value: model.value } : null,
 )
+const hasApiBase = computed(() => Boolean(apiBase.value.trim()))
+const apiBaseError = computed(() => {
+  if (!provider.value || !needsApiBase.value || hasApiBase.value) return ''
+  return `${providerLabel.value} needs the endpoint of your server, e.g. http://your-host:8000/v1`
+})
+
 const modelPlaceholder = computed(() => {
   if (!provider.value) return 'Select a provider first'
+  if (needsApiBase.value && !hasApiBase.value) return 'Enter the API base URL to load models'
   if (!models.value.length && !hasApiKey.value) return 'Enter the API key to load models'
   return 'Search models…'
 })
@@ -160,8 +169,10 @@ const modelPlaceholder = computed(() => {
 // say so rather than leaving a silently empty dropdown. Self-hosted types the model
 // by hand, so it never reaches here.
 const modelsHint = computed(() => {
-  if (!provider.value || modelsLoading.value || models.value.length || hasApiKey.value) return ''
-  return `Enter the ${providerLabel.value} API key below to load models.`
+  if (!provider.value || modelsLoading.value || models.value.length) return ''
+  if (needsApiBase.value && !hasApiBase.value) return ''
+  if (hasApiKey.value) return ''
+  return `Enter the ${providerLabel.value} API key above to load models.`
 })
 
 async function fetchModels(providerValue) {
@@ -171,9 +182,10 @@ async function fetchModels(providerValue) {
   // Providers without a static catalog list models from their own API, so the key
   // is sent along; the backend falls back to the key already saved in bench.toml.
   if (modelsNeedApiKey.value && !hasApiKey.value) return
+  if (needsApiBase.value && !hasApiBase.value) return
   modelsLoading.value = true
   try {
-    const result = await settingsApi.llmModels(providerValue, apiKey.value.trim())
+    const result = await settingsApi.llmModels(providerValue, apiKey.value.trim(), apiBase.value.trim())
     if (result?.error) modelsError.value = apiErrorMessage(result, 'Could not load models.')
     else models.value = result || []
   } catch (e) {
@@ -191,7 +203,7 @@ function onProviderSelect(option) {
 
 // A key-gated provider can only list models once a key exists, so reload when it settles.
 let apiKeyDebounce = null
-watch(apiKey, () => {
+watch([apiKey, apiBase], () => {
   if (!modelsNeedApiKey.value || !provider.value) return
   clearTimeout(apiKeyDebounce)
   apiKeyDebounce = setTimeout(() => fetchModels(provider.value), 600)

--- a/admin/frontend/dashboard/src/components/sites/settings/Danger.vue
+++ b/admin/frontend/dashboard/src/components/sites/settings/Danger.vue
@@ -106,6 +106,7 @@ import { useRouter } from 'vue-router'
 import { Button, Dialog, ErrorMessage, TextInput } from 'frappe-ui'
 import { apiErrorMessage } from '@/api/client'
 import { sitesApi } from '@/api/sites'
+import { openTaskDetailPage } from '@/utils/taskRoute'
 
 const props = defineProps({ siteName: { type: String, required: true } })
 

--- a/admin/frontend/dashboard/src/components/sites/settings/Danger.vue
+++ b/admin/frontend/dashboard/src/components/sites/settings/Danger.vue
@@ -22,93 +22,86 @@
     </div>
   </div>
 
-  <!-- Migrate dialog -->
-  <Dialog v-model="showMigrate" :options="{ title: 'Migrate this site', size: 'md' }">
-    <template #body-content>
-      <p class="text-ink-gray-7 text-p-sm">
-        This takes a recovery backup of
-        <span class="font-semibold text-ink-gray-8 break-all">{{ siteName }}</span>, then runs
-        <span class="font-mono text-ink-gray-8">bench migrate</span>. If the migration fails, you
-        can retry it or restore the backup from the migration page.
-      </p>
-      <ErrorMessage v-if="migrateError" :message="migrateError" class="mt-2" />
-      <div class="flex justify-end gap-2 mt-4">
-        <Button variant="outline" @click="showMigrate = false">Cancel</Button>
-        <Button variant="solid" theme="red" :loading="migrating" @click="confirmMigrate"
-          >Migrate</Button
-        >
-      </div>
-    </template>
-  </Dialog>
+  <ActionDialog
+    v-model:open="showMigrate"
+    title="Migrate Site"
+    :subject="siteSubject"
+    :warning="{
+      title: 'The site goes down while this runs.',
+      message: `A recovery backup is taken first. If the migration fails you can retry it, or restore that backup from the migration page.`,
+    }"
+    :error="migrateError"
+    confirm-label="Migrate"
+    confirm-theme="red"
+    :loading="migrating"
+    @confirm="confirmMigrate"
+  />
 
-  <!-- Reset dialog -->
-  <Dialog v-model="showReset" :options="{ title: 'Reset this site', size: 'md' }">
-    <template #body-content>
-      <p class="text-ink-gray-7 text-p-sm">
-        This reinstalls
-        <span class="font-semibold text-ink-gray-8 break-all">{{ siteName }}</span> and wipes all
-        its data. Apps stay installed.
-      </p>
-      <TextInput v-model="confirmName" :placeholder="siteName" class="mt-4 w-full">
+  <ActionDialog
+    v-model:open="showReset"
+    title="Reset Site"
+    :subject="siteSubject"
+    :warning="{
+      title: `This can't be undone.`,
+      message: `Every record on ${siteName} is wiped and the database goes back to a fresh install. Installed apps stay.`,
+    }"
+    :error="resetError"
+    confirm-label="Reset site"
+    confirm-theme="red"
+    :loading="resetting"
+    :disabled="confirmName !== siteName"
+    @confirm="confirmReset"
+  >
+    <template #after-warning>
+      <TextInput v-model="confirmName" :placeholder="siteName" class="w-full">
         <template #label>
           <span class="text-sm break-all">Type {{ siteName }} to confirm</span>
         </template>
       </TextInput>
-      <ErrorMessage v-if="resetError" :message="resetError" class="mt-2" />
-      <div class="flex justify-end gap-2 mt-4">
-        <Button variant="outline" @click="showReset = false">Cancel</Button>
-        <Button
-          variant="solid"
-          theme="red"
-          :loading="resetting"
-          :disabled="confirmName !== siteName"
-          @click="confirmReset"
-        >
-          Reset site
-        </Button>
-      </div>
     </template>
-  </Dialog>
+  </ActionDialog>
 
-  <!-- Drop dialog -->
-  <Dialog v-model="showDrop" :options="{ title: 'Delete this site', size: 'md' }">
-    <template #body-content>
-      <p class="text-ink-gray-7 text-p-sm">
-        This permanently deletes
-        <span class="font-semibold text-ink-gray-8 break-all">{{ siteName }}</span>
-        and everything on it. Backups are kept for 30 days.
-      </p>
-      <TextInput v-model="confirmName" :placeholder="siteName" class="mt-4 w-full">
+  <ActionDialog
+    v-model:open="showDrop"
+    title="Drop Site"
+    :subject="siteSubject"
+    :warning="{
+      title: `This can't be undone.`,
+      message: `The database and every file belonging to ${siteName} are deleted. Existing backups are kept for 30 days.`,
+    }"
+    :error="dropError"
+    confirm-label="Drop site"
+    confirm-theme="red"
+    :loading="dropping"
+    :disabled="confirmName !== siteName"
+    @confirm="confirmDrop"
+  >
+    <template #after-warning>
+      <TextInput v-model="confirmName" :placeholder="siteName" class="w-full">
         <template #label>
           <span class="text-sm break-all">Type {{ siteName }} to confirm</span>
         </template>
       </TextInput>
-      <ErrorMessage v-if="dropError" :message="dropError" class="mt-2" />
-      <div class="flex justify-end gap-2 mt-4">
-        <Button variant="outline" @click="showDrop = false">Cancel</Button>
-        <Button
-          variant="solid"
-          theme="red"
-          :loading="dropping"
-          :disabled="confirmName !== siteName"
-          @click="confirmDrop"
-        >
-          Delete site
-        </Button>
-      </div>
     </template>
-  </Dialog>
+  </ActionDialog>
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { Button, Dialog, ErrorMessage, TextInput } from 'frappe-ui'
+import { Button, TextInput } from 'frappe-ui'
+import ActionDialog from '@/components/common/ActionDialog.vue'
 import { apiErrorMessage } from '@/api/client'
 import { sitesApi } from '@/api/sites'
 import { openTaskDetailPage } from '@/utils/taskRoute'
 
 const props = defineProps({ siteName: { type: String, required: true } })
+
+const siteSubject = computed(() => ({
+  label: props.siteName,
+  description: 'Site, database and uploaded files',
+  icon: 'lucide-globe',
+}))
 
 const router = useRouter()
 

--- a/admin/frontend/dashboard/src/components/tasks/TaskDebugDialog.vue
+++ b/admin/frontend/dashboard/src/components/tasks/TaskDebugDialog.vue
@@ -18,6 +18,18 @@
             class="inline-block bg-ink-gray-6 ml-0.5 w-2 h-4 align-text-bottom animate-pulse"
           />
         </div>
+
+        <div v-if="text || error" class="flex justify-end">
+          <Button
+            variant="subtle"
+            size="sm"
+            icon-left="lucide-refresh-cw"
+            :loading="streaming"
+            @click="start({ refresh: true })"
+          >
+            Regenerate
+          </Button>
+        </div>
       </div>
     </template>
   </Dialog>
@@ -25,7 +37,7 @@
 
 <script setup>
 import { ref, computed, watch, onBeforeUnmount } from 'vue'
-import { Alert, Dialog, LoadingText } from 'frappe-ui'
+import { Alert, Button, Dialog, LoadingText } from 'frappe-ui'
 import { markdownToHTML } from 'frappe-ui/markdown'
 import DOMPurify from 'dompurify'
 import { tasksApi } from '@/api/tasks'
@@ -48,12 +60,14 @@ function close() {
   streaming.value = false
 }
 
-function start() {
+// Answers are cached per task, so reopening replays the previous one instantly.
+// `refresh` asks the model again and replaces it.
+function start({ refresh = false } = {}) {
   close()
   text.value = ''
   error.value = ''
   streaming.value = true
-  source = new EventSource(tasksApi.debugUrl(props.taskId))
+  source = new EventSource(tasksApi.debugUrl(props.taskId, refresh))
   source.onmessage = (message) => {
     let event
     try {

--- a/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
+++ b/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
@@ -160,6 +160,7 @@ function updateStatus(event) {
   if (!['queued', 'running'].includes(event.status)) return
   task.value.status = event.status
   task.value.queue_position = event.queue_position
+  task.value.is_cancellable = event.is_cancellable
 }
 
 function handleDone(success) {

--- a/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
+++ b/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
@@ -45,7 +45,7 @@
           Debug with AI
         </Button>
         <Button
-          v-if="isTaskActive(task)"
+          v-if="isTaskCancellable(task)"
           variant="subtle"
           size="sm"
           theme="red"
@@ -108,6 +108,7 @@ import {
   fmtDateTime,
   fmtDuration,
   isTaskActive,
+  isTaskCancellable,
   redirectRouteOnSuccess,
   siteLabel,
   siteRoute,

--- a/admin/frontend/dashboard/src/utils/taskFormat.js
+++ b/admin/frontend/dashboard/src/utils/taskFormat.js
@@ -108,6 +108,7 @@ const REDIRECT_ON_SUCCESS_COMMANDS = [
   'install-app',
   'uninstall-app',
   'get-and-install-app',
+  'drop-site',
 ]
 
 const APP_ARG_KEY = {
@@ -124,6 +125,7 @@ const APP_ACTION_FOR_COMMAND = {
 
 export function redirectRouteOnSuccess(task) {
   if (!REDIRECT_ON_SUCCESS_COMMANDS.includes(task.command)) return null
+  if (task.command === 'drop-site') return { name: 'Sites' }
   const route = siteRoute(task)
   if (!route) return null
   const appKey = APP_ARG_KEY[task.command]

--- a/admin/frontend/dashboard/src/utils/taskFormat.js
+++ b/admin/frontend/dashboard/src/utils/taskFormat.js
@@ -39,6 +39,11 @@ export function isTaskActive(task) {
   return task?.status === 'queued' || task?.status === 'running'
 }
 
+// The backend decides this - some tasks leave partial state behind when killed.
+export function isTaskCancellable(task) {
+  return Boolean(task?.is_cancellable)
+}
+
 export function taskActivityLabel(task) {
   if (task.status === 'queued') {
     return task.queue_position ? `Queued · #${task.queue_position} in queue` : 'Queued'

--- a/admin/frontend/dashboard/src/utils/taskFormat.test.js
+++ b/admin/frontend/dashboard/src/utils/taskFormat.test.js
@@ -75,5 +75,9 @@ test('site-creating and app tasks redirect to the site page on success', () => {
     redirectRouteOnSuccess({ command: 'get-and-install-app', args: { site: 'a.local', repo: 'x' } }),
     { name: 'SiteDetail', params: { name: 'a.local' } },
   )
-  assert.equal(redirectRouteOnSuccess({ command: 'drop-site', args: { site: 'a.local' } }), null)
+  // A dropped site has no detail page left to land on.
+  assert.deepEqual(redirectRouteOnSuccess({ command: 'drop-site', args: { site: 'a.local' } }), {
+    name: 'Sites',
+  })
+  assert.equal(redirectRouteOnSuccess({ command: 'backup-site', args: { site: 'a.local' } }), null)
 })

--- a/admin/frontend/dashboard/src/utils/taskFormat.test.js
+++ b/admin/frontend/dashboard/src/utils/taskFormat.test.js
@@ -3,6 +3,7 @@ import test from 'node:test'
 
 import {
   isTaskActive,
+  isTaskCancellable,
   redirectRouteOnSuccess,
   relativeTime,
   siteRoute,
@@ -80,4 +81,11 @@ test('site-creating and app tasks redirect to the site page on success', () => {
     name: 'Sites',
   })
   assert.equal(redirectRouteOnSuccess({ command: 'backup-site', args: { site: 'a.local' } }), null)
+})
+
+test('cancelling follows the flag the backend sends', () => {
+  assert.equal(isTaskCancellable({ status: 'running', is_cancellable: true }), true)
+  assert.equal(isTaskCancellable({ status: 'running', is_cancellable: false }), false)
+  assert.equal(isTaskCancellable({ status: 'running' }), false)
+  assert.equal(isTaskCancellable(null), false)
 })

--- a/pilot/core/site/__init__.py
+++ b/pilot/core/site/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -78,6 +79,17 @@ class Site:
             config = json.loads(config_path.read_text())
             config.update(settings)
             replace_private_text_locked(config_path, json.dumps(config, indent=1))
+
+    @contextmanager
+    def under_maintenance(self) -> Iterator[None]:
+        """Hold the site in maintenance mode for a schema change, restoring the
+        settings it had before - a site already down stays down afterwards."""
+        original = self.maintenance_settings
+        self.set_maintenance_mode(True)
+        try:
+            yield
+        finally:
+            self.set_maintenance_settings(original)
 
     def _frappe_call(self, *args: str) -> list[str]:
         """Build a frappe bench_helper command."""

--- a/pilot/exceptions.py
+++ b/pilot/exceptions.py
@@ -25,6 +25,10 @@ class TaskNotRunningError(BenchError):
     pass
 
 
+class TaskNotCancellableError(BenchError):
+    pass
+
+
 class TaskConflictError(BenchError):
     pass
 

--- a/pilot/integrations/llm/base.py
+++ b/pilot/integrations/llm/base.py
@@ -8,6 +8,7 @@ only on these class-level APIs, so a new provider is just a new subclass.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from pathlib import Path
 from typing import ClassVar
 
@@ -15,6 +16,9 @@ import litellm
 
 from pilot.exceptions import BenchError
 from pilot.integrations.llm import read_system_prompt
+
+# Answers are small; the cap only stops a long-lived process growing without bound.
+_CACHE_LIMIT = 32
 
 
 class LLMError(BenchError):
@@ -37,6 +41,7 @@ class LLMIntegration:
     # litellm route prefix. Blank => use the config `provider` slug (litellm-native
     # providers); set it when the UI slug differs from the litellm route.
     litellm_provider: ClassVar[str] = ""
+    _cached_responses: ClassVar[dict[str, str]] = {}
 
     def __init__(
         self, api_key: str, *, provider: str, model: str, stream: bool = False, api_base: str = ""
@@ -53,7 +58,7 @@ class LLMIntegration:
         return {}
 
     @classmethod
-    def get_models(cls, provider: str, api_key: str = "") -> list[str]:
+    def get_models(cls, provider: str, api_key: str = "", api_base: str = "") -> list[str]:
         """Selectable models for a provider slug; empty means free-text entry,
         `api_key` is only used by providers with `models_need_api_key`."""
         return []
@@ -63,12 +68,41 @@ class LLMIntegration:
         """The model string handed to litellm.completion (routing lives here)."""
         return f"{self.litellm_provider or self.provider}/{self.model}"
 
-    def prompt(self, prompt: str, *, bench_root: Path, max_tokens: int = 4096, **kwargs):
-        """Send a single-turn prompt and return the litellm response."""
-        messages = [
-            {"role": "system", "content": read_system_prompt(bench_root)},
-            {"role": "user", "content": prompt},
-        ]
+    def _cache_key(self, system_prompt: str, prompt: str) -> str:
+        return f"{system_prompt}-{prompt}-{self._litellm_model}"
+
+    def get_cached_response(self, cache_key: str) -> str | None:
+        """The answer already produced for this exact system prompt, prompt and model."""
+        return self._cached_responses.get(cache_key)
+
+    def _remember_response(self, cache_key: str, text: str) -> None:
+        """Only called once an answer is complete - a half-read stream is not an answer."""
+        if not text:
+            return
+        self._cached_responses[cache_key] = text
+        while len(self._cached_responses) > _CACHE_LIMIT:
+            self._cached_responses.pop(next(iter(self._cached_responses)))
+
+    def prompt(
+        self, prompt: str, *, bench_root: Path, max_tokens: int = 4096, **kwargs
+    ) -> str | Iterator[str]:
+        """The answer to a single-turn prompt: text, or text deltas when streaming.
+        Repeating a prompt replays the cached answer instead of calling the provider."""
+        system_prompt = read_system_prompt(bench_root)
+        cache_key = self._cache_key(system_prompt, prompt)
+
+        cached = self.get_cached_response(cache_key)
+        if cached is not None:
+            return iter([cached]) if self.stream else cached
+
+        raw = self._complete(system_prompt, prompt, max_tokens, **kwargs)
+        if self.stream:
+            return self._iter_answer(raw, cache_key)
+        return self._answer_text(raw, cache_key)
+
+    def _complete(self, system_prompt: str, prompt: str, max_tokens: int, **kwargs):
+        """Call litellm, mapping its errors onto ours."""
+        messages = [{"role": "system", "content": system_prompt}, {"role": "user", "content": prompt}]
         try:
             return litellm.completion(
                 model=self._litellm_model,
@@ -79,9 +113,6 @@ class LLMIntegration:
                 stream=self.stream,
                 **kwargs,
             )
-        # Specific subclasses first — NotFoundError etc. subclass APIError, so a
-        # bare APIError catch above them would shadow them. Messages stay
-        # actionable and never echo the raw provider body (it can be HTML).
         except litellm.AuthenticationError as exc:
             raise LLMAuthError("The API key was rejected. Check the provider key in Settings.") from exc
         except litellm.NotFoundError as exc:
@@ -95,14 +126,17 @@ class LLMIntegration:
         except litellm.APIError as exc:
             raise LLMError("The AI provider returned an error. Check the model and endpoint.") from exc
 
-    def get_response_text(self, response) -> str:
-        """Extract the assistant's text from a `prompt` response."""
+    def _answer_text(self, response, cache_key: str) -> str:
+        """The assistant's text from a non-streamed litellm response, cached."""
         if not response.choices:
             return ""
-        return response.choices[0].message.content or ""
+        text = response.choices[0].message.content or ""
+        self._remember_response(cache_key, text)
+        return text
 
-    def iter_response_text(self, stream):
-        """Yield text deltas from a streamed `prompt` response (stream=True)."""
+    def _iter_answer(self, stream, cache_key: str) -> Iterator[str]:
+        """Yield deltas, caching the answer once the stream has run to completion."""
+        deltas: list[str] = []
         for chunk in stream:
             choices = getattr(chunk, "choices", None)
             if not choices:
@@ -110,4 +144,9 @@ class LLMIntegration:
             delta = getattr(choices[0], "delta", None)
             text = getattr(delta, "content", None) if delta else None
             if text:
+                deltas.append(text)
                 yield text
+
+        # Unreached when the caller abandons the stream or the provider fails, so a
+        # partial answer is never cached.
+        self._remember_response(cache_key, "".join(deltas))

--- a/pilot/integrations/llm/base.py
+++ b/pilot/integrations/llm/base.py
@@ -84,14 +84,21 @@ class LLMIntegration:
             self._cached_responses.pop(next(iter(self._cached_responses)))
 
     def prompt(
-        self, prompt: str, *, bench_root: Path, max_tokens: int = 4096, **kwargs
+        self,
+        prompt: str,
+        *,
+        bench_root: Path,
+        max_tokens: int = 4096,
+        refresh: bool = False,
+        **kwargs,
     ) -> str | Iterator[str]:
         """The answer to a single-turn prompt: text, or text deltas when streaming.
-        Repeating a prompt replays the cached answer instead of calling the provider."""
+        Repeating a prompt replays the cached answer; `refresh` asks the provider
+        again and replaces what was cached."""
         system_prompt = read_system_prompt(bench_root)
         cache_key = self._cache_key(system_prompt, prompt)
 
-        cached = self.get_cached_response(cache_key)
+        cached = None if refresh else self.get_cached_response(cache_key)
         if cached is not None:
             return iter([cached]) if self.stream else cached
 

--- a/pilot/integrations/llm/frappe_llm.py
+++ b/pilot/integrations/llm/frappe_llm.py
@@ -8,14 +8,18 @@ from typing import ClassVar
 from pilot.integrations.llm.self_hosted import SelfHostedIntegration
 
 
-class FrappeLLMIntegration(SelfHostedIntegration):
-    """Frappe-hosted, OpenAI-compatible LLM at a fixed endpoint. Unlike the litellm
-    providers there is no static catalog, so models are listed from the live
-    `/models` endpoint and that call needs the user's API key."""
+def _failure_reason(exc: Exception) -> str:
+    """The OS-level cause (DNS failure, refused connection, timeout), not the wrapper."""
+    reason = getattr(exc, "reason", None) or exc
+    return str(reason) or exc.__class__.__name__
 
-    # Keeping the IP hardcoded for now; will move to a domain once available.
-    base_api: ClassVar[str] = "http://x.x.x.x/v1"
-    requires_api_base: ClassVar[bool] = False
+
+class FrappeLLMIntegration(SelfHostedIntegration):
+    """Frappe-hosted, OpenAI-compatible LLM. The endpoint is supplied per bench like
+    any self-hosted server; unlike them it has no static catalog, so models are listed
+    from the live `/models` endpoint and that call needs the user's API key."""
+
+    requires_api_base: ClassVar[bool] = True
     free_text_model: ClassVar[bool] = False
     models_need_api_key: ClassVar[bool] = True
 
@@ -24,12 +28,17 @@ class FrappeLLMIntegration(SelfHostedIntegration):
         return {"frappe-llm": "Frappe LLM"}
 
     @classmethod
-    def get_models(cls, provider: str, api_key: str = "") -> list[str]:
+    def get_models(cls, provider: str, api_key: str = "", api_base: str = "") -> list[str]:
         if not api_key:
             raise ValueError("Frappe LLM needs an API key to list models.")
 
+        endpoint = api_base.strip().rstrip("/")
+        if not endpoint:
+            raise ValueError("Frappe LLM needs an API base URL to list models.")
+
+        url = f"{endpoint}/models"
         request = urllib.request.Request(
-            url=f"{cls.base_api}/models",
+            url=url,
             headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
         )
         try:
@@ -37,15 +46,15 @@ class FrappeLLMIntegration(SelfHostedIntegration):
                 payload = json.loads(response.read())
         except urllib.error.HTTPError as exc:
             if exc.code in (401, 403):
-                raise ValueError("Frappe LLM rejected the API key.") from exc
-            raise ValueError(f"Frappe LLM could not list models (HTTP {exc.code}).") from exc
+                raise ValueError(f"{url} rejected this API key.") from exc
+            raise ValueError(f"{url} returned HTTP {exc.code} listing models.") from exc
         except (urllib.error.URLError, TimeoutError) as exc:
-            raise ValueError("Could not reach Frappe LLM to list models.") from exc
+            raise ValueError(f"Could not reach {url}: {_failure_reason(exc)}.") from exc
         except json.JSONDecodeError as exc:
-            raise ValueError("Frappe LLM returned an unreadable model list.") from exc
+            raise ValueError(f"{url} returned a model list that is not JSON.") from exc
 
         models = [model.get("id", "") for model in payload.get("data", [])]
         models = [model for model in models if model]
         if not models:
-            raise ValueError("Frappe LLM returned no models for this API key.")
+            raise ValueError(f"Frappe LLM - {url} returned no models for this API key.")
         return sorted(models)

--- a/pilot/integrations/llm/lite.py
+++ b/pilot/integrations/llm/lite.py
@@ -37,5 +37,5 @@ class LiteLLMIntegration(LLMIntegration):
         }
 
     @classmethod
-    def get_models(cls, provider: str, api_key: str = "") -> list[str]:
+    def get_models(cls, provider: str, api_key: str = "", api_base: str = "") -> list[str]:
         return sorted(litellm.models_by_provider.get(provider, set()))

--- a/pilot/integrations/llm/registry.py
+++ b/pilot/integrations/llm/registry.py
@@ -51,10 +51,11 @@ def provider_options() -> list[dict]:
     ]
 
 
-def models_for(provider: str, api_key: str = "") -> list[str]:
+def models_for(provider: str, api_key: str = "", api_base: str = "") -> list[str]:
     """Selectable models for a provider (empty means free-text entry). Providers
-    with `models_need_api_key` list models from their own API, so they need the key."""
-    return _integration_for(provider).get_models(provider, api_key)
+    with `models_need_api_key` list models from their own API, so they need the key,
+    and an `api_base` overrides wherever that provider defaults to."""
+    return _integration_for(provider).get_models(provider, api_key, api_base)
 
 
 def models_need_api_key(provider: str) -> bool:

--- a/pilot/integrations/llm/self_hosted.py
+++ b/pilot/integrations/llm/self_hosted.py
@@ -17,5 +17,5 @@ class SelfHostedIntegration(LLMIntegration):
         return {"self-hosted": "Self-hosted Model"}
 
     @classmethod
-    def get_models(cls, provider: str, api_key: str = "") -> list[str]:
+    def get_models(cls, provider: str, api_key: str = "", api_base: str = "") -> list[str]:
         return []  # the served model name is entered by hand

--- a/pilot/internal/tasks/runner.py
+++ b/pilot/internal/tasks/runner.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-from pilot.exceptions import TaskNotRunningError
+from pilot.exceptions import TaskNotCancellableError, TaskNotRunningError
 from pilot.internal.tasks.authoring import required_task_args
 from pilot.internal.tasks.models import TaskStatus
 from pilot.internal.tasks.payload import TaskPayloadBuilder
@@ -122,6 +122,10 @@ class TaskRunner:
         if not status.is_active:
             raise TaskNotRunningError(f"Task is not active: {task_id} (status={status.value})")
 
+        command = self._store.read_metadata(task_id).get("command", "")
+        if status == TaskStatus.RUNNING and not is_command_cancellable_while_running(command):
+            raise TaskNotCancellableError(f"'{command}' cannot be cancelled once it has started.")
+
         if status == TaskStatus.QUEUED:
             if not self._store.transition(
                 task_id,
@@ -170,11 +174,12 @@ def task_registry() -> tuple[dict[str, type[Task]], dict[str, list[str]]]:
     return _REGISTRY
 
 
-def is_command_cancellable(command: str) -> bool:
-    """Killing some tasks leaves partial state behind, so they opt out."""
+def is_command_cancellable_while_running(command: str) -> bool:
+    """Killing some tasks mid-run leaves partial state behind, so they opt out.
+    Queued tasks are always cancellable - none of their work has started."""
     jobs, _ = task_registry()
     task_class = jobs.get(command)
-    return task_class.is_cancellable if task_class else True
+    return task_class.is_cancellable_while_running if task_class else True
 
 
 def discover_tasks() -> list[type[Task]]:

--- a/pilot/internal/tasks/runner.py
+++ b/pilot/internal/tasks/runner.py
@@ -170,6 +170,13 @@ def task_registry() -> tuple[dict[str, type[Task]], dict[str, list[str]]]:
     return _REGISTRY
 
 
+def is_command_cancellable(command: str) -> bool:
+    """Killing some tasks leaves partial state behind, so they opt out."""
+    jobs, _ = task_registry()
+    task_class = jobs.get(command)
+    return task_class.is_cancellable if task_class else True
+
+
 def discover_tasks() -> list[type[Task]]:
     tasks = []
     for module_info in pkgutil.iter_modules([str(_TASK_PACKAGE_DIR)], prefix="pilot.tasks."):

--- a/pilot/managers/task/debug.py
+++ b/pilot/managers/task/debug.py
@@ -29,15 +29,22 @@ def build_debug_prompt(task: TaskInfo, output: str) -> str:
 
 
 def stream_task_debug(
-    llm_config: LLMConfig, task: TaskInfo, output: str, *, bench_root: Path
+    llm_config: LLMConfig,
+    task: TaskInfo,
+    output: str,
+    *,
+    bench_root: Path,
+    refresh: bool = False,
 ) -> Iterator[str]:
-    """Yield text deltas of the model's explanation; raises LLMError on failure."""
+    """Yield text deltas of the model's explanation; raises LLMError on failure.
+    `refresh` re-asks the model instead of replaying the cached explanation."""
     integration = build_integration(llm_config, stream=True)
     try:
         yield from integration.prompt(
             build_debug_prompt(task, output),
             bench_root=bench_root,
             max_tokens=llm_config.max_tokens,
+            refresh=refresh,
         )
     except LLMError:
         raise

--- a/pilot/managers/task/debug.py
+++ b/pilot/managers/task/debug.py
@@ -33,13 +33,12 @@ def stream_task_debug(
 ) -> Iterator[str]:
     """Yield text deltas of the model's explanation; raises LLMError on failure."""
     integration = build_integration(llm_config, stream=True)
-    response = integration.prompt(
-        build_debug_prompt(task, output),
-        bench_root=bench_root,
-        max_tokens=llm_config.max_tokens,
-    )
     try:
-        yield from integration.iter_response_text(response)
+        yield from integration.prompt(
+            build_debug_prompt(task, output),
+            bench_root=bench_root,
+            max_tokens=llm_config.max_tokens,
+        )
     except LLMError:
         raise
     except Exception as exc:  # a provider hiccup mid-stream

--- a/pilot/managers/task/models.py
+++ b/pilot/managers/task/models.py
@@ -25,6 +25,14 @@ class TaskInfo:
     failure: TaskFailure | None = None
 
     @property
+    def is_cancellable(self) -> bool:
+        """Whether cancelling is safe, decided by the task class - killing some
+        tasks leaves partial state behind."""
+        from pilot.internal.tasks.runner import is_command_cancellable
+
+        return self.status.is_active and is_command_cancellable(self.command)
+
+    @property
     def duration_seconds(self) -> float | None:
         if self.started_at is None or self.finished_at is None:
             return None
@@ -43,6 +51,7 @@ class TaskInfo:
             "exit_code": self.exit_code,
             "duration_seconds": self.duration_seconds,
             "queue_position": self.queue_position,
+            "is_cancellable": self.is_cancellable,
             "failure": (
                 {"code": self.failure.code, "message": self.failure.message} if self.failure else None
             ),

--- a/pilot/managers/task/models.py
+++ b/pilot/managers/task/models.py
@@ -26,11 +26,15 @@ class TaskInfo:
 
     @property
     def is_cancellable(self) -> bool:
-        """Whether cancelling is safe, decided by the task class - killing some
-        tasks leaves partial state behind."""
-        from pilot.internal.tasks.runner import is_command_cancellable
+        """Queued work can always be dropped; killing a running task is only safe
+        when the task says so, since some leave partial state behind."""
+        from pilot.internal.tasks.runner import is_command_cancellable_while_running
 
-        return self.status.is_active and is_command_cancellable(self.command)
+        if not self.status.is_active:
+            return False
+        if self.status == TaskStatus.QUEUED:
+            return True
+        return is_command_cancellable_while_running(self.command)
 
     @property
     def duration_seconds(self) -> float | None:

--- a/pilot/managers/task/reader.py
+++ b/pilot/managers/task/reader.py
@@ -39,6 +39,7 @@ class StatusEvent(TypedDict):
     type: Literal["status"]
     status: str
     queue_position: int | None
+    is_cancellable: bool
 
 
 TaskStreamEvent = OutputEvent | StatusEvent | DoneEvent
@@ -48,11 +49,12 @@ def output_event(line: str, *, overwrite: bool = False) -> OutputEvent:
     return {"type": "overwrite" if overwrite else "line", "line": line}
 
 
-def status_event(status: str, queue_position: int | None) -> StatusEvent:
+def status_event(task: "TaskInfo") -> StatusEvent:
     return {
         "type": "status",
-        "status": status,
-        "queue_position": queue_position,
+        "status": task.status.value,
+        "queue_position": task.queue_position,
+        "is_cancellable": task.is_cancellable,
     }
 
 
@@ -143,7 +145,7 @@ class TaskReader:
         task = self.read_task(task_id)
         output_path = task.output_path
         last_state = (task.status, task.queue_position)
-        yield status_event(task.status.value, task.queue_position)
+        yield status_event(task)
 
         open_private(output_path, "a").close()
         with open(output_path, "r", errors="replace", newline="") as log_file:
@@ -157,7 +159,7 @@ class TaskReader:
                 task = self.read_task(task_id)
                 current_state = (task.status, task.queue_position)
                 if current_state != last_state:
-                    yield status_event(task.status.value, task.queue_position)
+                    yield status_event(task)
                     last_state = current_state
 
                 if not task.status.is_active:

--- a/pilot/tasks/base.py
+++ b/pilot/tasks/base.py
@@ -60,6 +60,8 @@ class Task:
     required_submit_args: ClassVar[tuple[str, ...]] = ()
     # Audit "who queued this" on queue. Turn off for frequent polling/read-only tasks.
     audit_on_queue: ClassVar[bool] = True
+    # Turn off for tasks that leave partial state behind when killed mid-run.
+    is_cancellable: ClassVar[bool] = True
     # Non-sensitive queue args safe to record in the audit entry.
     _AUDIT_ARG_KEYS: ClassVar[tuple[str, ...]] = ("site", "app", "name", "repo", "branch", "marketplace_app")
 

--- a/pilot/tasks/base.py
+++ b/pilot/tasks/base.py
@@ -61,7 +61,8 @@ class Task:
     # Audit "who queued this" on queue. Turn off for frequent polling/read-only tasks.
     audit_on_queue: ClassVar[bool] = True
     # Turn off for tasks that leave partial state behind when killed mid-run.
-    is_cancellable: ClassVar[bool] = True
+    # Queued tasks can always be cancelled - nothing has run yet.
+    is_cancellable_while_running: ClassVar[bool] = True
     # Non-sensitive queue args safe to record in the audit entry.
     _AUDIT_ARG_KEYS: ClassVar[tuple[str, ...]] = ("site", "app", "name", "repo", "branch", "marketplace_app")
 

--- a/pilot/tasks/get_and_install_app.py
+++ b/pilot/tasks/get_and_install_app.py
@@ -13,6 +13,7 @@ class GetAndInstallAppTask(Task):
     """Fetch an app and optionally install it on sites."""
 
     command: ClassVar[str] = "get-and-install-app"
+    is_cancellable_while_running: ClassVar[bool] = False
 
     repo: str = ""
     branch: str = ""

--- a/pilot/tasks/install_app.py
+++ b/pilot/tasks/install_app.py
@@ -2,7 +2,7 @@ import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, ClassVar
 
-from pilot.tasks import Task, on_success, step
+from pilot.tasks import Task, step
 
 if TYPE_CHECKING:
     from pilot.core.app import App
@@ -21,13 +21,8 @@ class InstallAppTask(Task):
         site = self.bench.site(self.site)
         dependencies = self.install(site, app)
         self.build_assets([app, *dependencies])
+        site.clear_cache()
         self.bench.audit_action("app", {"event": "installed", "app": self.app, "site": self.site})
-
-    @on_success
-    def reload_workers(self) -> dict:
-        """Long-lived web and background workers hold the old app list and
-        import map, so they need a restart once this task lands."""
-        return {"web_only": False}
 
     @step("install", lambda self: f"Install {self.app} into {self.site}")
     def install(self, site: "Site", app: "App") -> list["App"]:

--- a/pilot/tasks/install_app.py
+++ b/pilot/tasks/install_app.py
@@ -19,8 +19,9 @@ class InstallAppTask(Task):
     def run(self) -> None:
         app = self.bench.app(self.app)
         site = self.bench.site(self.site)
-        dependencies = self.install(site, app)
-        self.build_assets([app, *dependencies])
+        with site.under_maintenance():
+            dependencies = self.install(site, app)
+            self.build_assets([app, *dependencies])
         site.clear_cache()
         self.bench.audit_action("app", {"event": "installed", "app": self.app, "site": self.site})
 

--- a/pilot/tasks/install_app.py
+++ b/pilot/tasks/install_app.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
 class InstallAppTask(Task):
     command: ClassVar[str] = "install-app"
     # frappe writes module defs and doctypes before recording the app as
-    # installed, so a kill leaves rows behind that fail every retry.
-    is_cancellable: ClassVar[bool] = False
+    # installed, so a kill mid-run leaves rows behind that fail every retry.
+    is_cancellable_while_running: ClassVar[bool] = False
 
     site: str
     app: str

--- a/pilot/tasks/install_app.py
+++ b/pilot/tasks/install_app.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
 @dataclass(kw_only=True)
 class InstallAppTask(Task):
     command: ClassVar[str] = "install-app"
+    # frappe writes module defs and doctypes before recording the app as
+    # installed, so a kill leaves rows behind that fail every retry.
+    is_cancellable: ClassVar[bool] = False
 
     site: str
     app: str

--- a/pilot/tasks/new_site.py
+++ b/pilot/tasks/new_site.py
@@ -19,7 +19,15 @@ class NewSiteTask(Task):
     def run(self) -> None:
         self.require_production_privileges()
         self.fetch_missing_apps()
+        self.reload_for_site_apps()
         self.create()
+
+    @step("reload", "Reload workers for the site's apps")
+    def reload_for_site_apps(self) -> None:
+        """Provisioning runs install-app, which enqueues jobs that import the
+        site's apps. Always reload: an app already on the bench may still predate
+        the running workers, having arrived through `bench get-app`."""
+        self.bench.reload_workers()
 
     @on_failure
     @on_cancel

--- a/pilot/tasks/uninstall_app.py
+++ b/pilot/tasks/uninstall_app.py
@@ -18,7 +18,8 @@ class UninstallAppTask(Task):
     @step("uninstall", lambda self: f"Uninstall {self.app} from {self.site}")
     def uninstall(self) -> None:
         site = self.bench.site(self.site)
-        site.uninstall_apps([self.app], force=self.force, on_progress=self.report)
+        with site.under_maintenance():
+            site.uninstall_apps([self.app], force=self.force, on_progress=self.report)
         site.clear_cache()
 
 

--- a/pilot/tasks/uninstall_app.py
+++ b/pilot/tasks/uninstall_app.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pilot.tasks import Task, on_success, step
+from pilot.tasks import Task, step
 
 
 @dataclass(kw_only=True)
@@ -15,16 +15,11 @@ class UninstallAppTask(Task):
     def run(self) -> None:
         self.uninstall()
 
-    @on_success
-    def reload_workers(self) -> dict:
-        """Long-lived web and background workers hold the old app list and
-        import map, so they need a restart once this task lands."""
-        return {"web_only": False}
-
     @step("uninstall", lambda self: f"Uninstall {self.app} from {self.site}")
     def uninstall(self) -> None:
         site = self.bench.site(self.site)
         site.uninstall_apps([self.app], force=self.force, on_progress=self.report)
+        site.clear_cache()
 
 
 if __name__ == "__main__":

--- a/pilot/tasks/uninstall_app.py
+++ b/pilot/tasks/uninstall_app.py
@@ -8,8 +8,8 @@ from pilot.tasks import Task, step
 class UninstallAppTask(Task):
     command: ClassVar[str] = "uninstall-app"
     # frappe writes module defs and doctypes before recording the app as
-    # installed, so a kill leaves rows behind that fail every retry.
-    is_cancellable: ClassVar[bool] = False
+    # installed, so a kill mid-run leaves rows behind that fail every retry.
+    is_cancellable_while_running: ClassVar[bool] = False
 
     site: str
     app: str

--- a/pilot/tasks/uninstall_app.py
+++ b/pilot/tasks/uninstall_app.py
@@ -7,6 +7,9 @@ from pilot.tasks import Task, step
 @dataclass(kw_only=True)
 class UninstallAppTask(Task):
     command: ClassVar[str] = "uninstall-app"
+    # frappe writes module defs and doctypes before recording the app as
+    # installed, so a kill leaves rows behind that fail every retry.
+    is_cancellable: ClassVar[bool] = False
 
     site: str
     app: str

--- a/tests/admin/backend/api/test_settings_llm.py
+++ b/tests/admin/backend/api/test_settings_llm.py
@@ -165,13 +165,21 @@ def test_llm_models_uses_the_saved_key(tmp_path: Path, monkeypatch: pytest.Monke
     client = _client(bench_root)
     client.patch(
         "/api/v1/settings",
-        json={"llm": {"provider": "frappe-llm", "api_key": "sk-saved", "model": "qwen3.6-27b-fp8"}},
+        json={
+            "llm": {
+                "provider": "frappe-llm",
+                "api_key": "sk-saved",
+                "model": "qwen3.6-27b-fp8",
+                "api_base": "http://frappe-llm.example/v1",
+            }
+        },
     )
     seen = {}
 
-    def fake_get_models(provider: str, api_key: str = "") -> list[str]:
+    def fake_get_models(provider: str, api_key: str = "", api_base: str = "") -> list[str]:
         seen["provider"] = provider
         seen["api_key"] = api_key
+        seen["api_base"] = api_base
         return ["qwen3.6-27b-fp8"]
 
     monkeypatch.setattr(FrappeLLMIntegration, "get_models", fake_get_models)
@@ -180,22 +188,36 @@ def test_llm_models_uses_the_saved_key(tmp_path: Path, monkeypatch: pytest.Monke
 
     assert response.status_code == 200
     assert response.get_json() == ["qwen3.6-27b-fp8"]
-    assert seen == {"provider": "frappe-llm", "api_key": "sk-saved"}
+    # The saved endpoint matters as much as the key - listing must hit the same
+    # server the assistant will.
+    assert seen == {
+        "provider": "frappe-llm",
+        "api_key": "sk-saved",
+        "api_base": "http://frappe-llm.example/v1",
+    }
 
 
 def test_llm_models_prefers_the_posted_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     client = _client(tmp_path / "test-bench")
     seen = {}
 
-    def fake_get_models(provider: str, api_key: str = "") -> list[str]:
+    def fake_get_models(provider: str, api_key: str = "", api_base: str = "") -> list[str]:
         seen["api_key"] = api_key
+        seen["api_base"] = api_base
         return []
 
     monkeypatch.setattr(FrappeLLMIntegration, "get_models", fake_get_models)
 
-    client.post("/api/v1/settings/llm/models", json={"provider": "frappe-llm", "api_key": "sk-typed"})
+    client.post(
+        "/api/v1/settings/llm/models",
+        json={
+            "provider": "frappe-llm",
+            "api_key": "sk-typed",
+            "api_base": "http://typed.example/v1",
+        },
+    )
 
-    assert seen == {"api_key": "sk-typed"}
+    assert seen == {"api_key": "sk-typed", "api_base": "http://typed.example/v1"}
 
 
 def test_llm_models_without_a_provider(tmp_path: Path) -> None:

--- a/tests/admin/backend/api/test_task_debug.py
+++ b/tests/admin/backend/api/test_task_debug.py
@@ -58,11 +58,13 @@ def _make_task(bench_root: Path, status: TaskStatus) -> None:
 
 
 class _FakeIntegration:
-    def prompt(self, *args, **kwargs):
-        self.received = (args, kwargs)
-        return "stream-handle"
+    """`prompt` yields the answer's deltas directly when streaming."""
 
-    def iter_response_text(self, stream):
+    def __init__(self) -> None:
+        self.received: dict = {}
+
+    def prompt(self, *args, **kwargs):
+        self.received = kwargs
         yield "Root "
         yield "cause: bad migration."
 
@@ -104,3 +106,26 @@ def test_debug_missing_task_is_404(tmp_path: Path) -> None:
     _write_bench(tmp_path, connect_ai=True)
     response = _client(tmp_path).get("/api/v1/tasks/nope/debug")
     assert response.status_code == 404
+
+
+def test_debug_passes_refresh_through_to_the_model(tmp_path: Path) -> None:
+    """The Regenerate button sends ?refresh=1; without it the cached answer replays."""
+    _write_bench(tmp_path, connect_ai=True)
+    _make_task(tmp_path, TaskStatus.FAILED)
+    integration = _FakeIntegration()
+
+    with patch("pilot.managers.task.debug.build_integration", return_value=integration):
+        _client(tmp_path).get(f"/api/v1/tasks/{TASK_ID}/debug?refresh=1")
+
+    assert integration.received["refresh"] is True
+
+
+def test_debug_defaults_to_the_cached_answer(tmp_path: Path) -> None:
+    _write_bench(tmp_path, connect_ai=True)
+    _make_task(tmp_path, TaskStatus.FAILED)
+    integration = _FakeIntegration()
+
+    with patch("pilot.managers.task.debug.build_integration", return_value=integration):
+        _client(tmp_path).get(f"/api/v1/tasks/{TASK_ID}/debug")
+
+    assert integration.received["refresh"] is False

--- a/tests/e2e/flows/admin.py
+++ b/tests/e2e/flows/admin.py
@@ -122,7 +122,7 @@ def drop_site(page: Page, base_url: str, site_name: str) -> None:
     task_id = run_task_action(
         page,
         f"/api/v1/sites/{site_name}",
-        lambda: dialog.get_by_role("button", name="Delete site").click(),
+        lambda: dialog.get_by_role("button", name="Drop site", exact=True).click(),
         method="DELETE",
     )
     wait_for_task(page.request, base_url, task_id)

--- a/tests/pilot/core/test_site_apps.py
+++ b/tests/pilot/core/test_site_apps.py
@@ -101,3 +101,40 @@ def test_uninstall_app_clears_cache_after_failure(tmp_path: Path) -> None:
     assert len(commands) == 2
     assert "uninstall-app" in commands[0]
     assert commands[1][-1] == "clear-cache"
+
+
+def test_under_maintenance_restores_the_previous_settings(tmp_path: Path) -> None:
+    """A site that was already down stays down - the guard restores what it read,
+    it does not blindly switch maintenance off."""
+    from unittest.mock import MagicMock
+
+    from pilot.core.site import Site
+
+    site = MagicMock(spec=Site)
+    site.maintenance_settings = {"maintenance_mode": 1, "pause_scheduler": 0}
+
+    with Site.under_maintenance(site):
+        site.set_maintenance_mode.assert_called_once_with(True)
+
+    site.set_maintenance_settings.assert_called_once_with(
+        {"maintenance_mode": 1, "pause_scheduler": 0}
+    )
+
+
+def test_under_maintenance_lifts_maintenance_when_the_body_raises(tmp_path: Path) -> None:
+    """A failed install must not strand the site in maintenance mode."""
+    from unittest.mock import MagicMock
+
+    import pytest
+
+    from pilot.core.site import Site
+
+    site = MagicMock(spec=Site)
+    site.maintenance_settings = {"maintenance_mode": 0, "pause_scheduler": 0}
+
+    with pytest.raises(RuntimeError), Site.under_maintenance(site):
+        raise RuntimeError("install blew up")
+
+    site.set_maintenance_settings.assert_called_once_with(
+        {"maintenance_mode": 0, "pause_scheduler": 0}
+    )

--- a/tests/pilot/integrations/test_llm.py
+++ b/tests/pilot/integrations/test_llm.py
@@ -16,6 +16,9 @@ from pilot.integrations.llm.frappe_llm import FrappeLLMIntegration
 from pilot.integrations.llm.lite import LiteLLMIntegration
 from pilot.integrations.llm.self_hosted import SelfHostedIntegration
 
+_FRAPPE_BASE = "http://frappe-llm.example/v1"
+_BENCH = Path("/tmp/bench")
+
 
 class _FakeAuthError(Exception):
     pass
@@ -94,12 +97,15 @@ def test_self_hosted_routes_through_hosted_vllm(fake_litellm) -> None:
     assert kwargs["api_base"] == "http://h:8000/v1"
 
 
-def test_frappe_llm_uses_fixed_base_api(fake_litellm) -> None:
-    integration = FrappeLLMIntegration("sk-key", provider="frappe-llm", model="qwen3.6-27b-fp8")
+def test_frappe_llm_calls_the_configured_endpoint(fake_litellm) -> None:
+    """Frappe LLM is served per bench, so it routes to the configured api_base."""
+    integration = FrappeLLMIntegration(
+        "sk-key", provider="frappe-llm", model="qwen3.6-27b-fp8", api_base=_FRAPPE_BASE
+    )
     integration.prompt("hi", bench_root=Path("/tmp/bench"))
     kwargs = fake_litellm.completion.call_args.kwargs
     assert kwargs["model"] == "hosted_vllm/qwen3.6-27b-fp8"
-    assert kwargs["api_base"] == FrappeLLMIntegration.base_api
+    assert kwargs["api_base"] == _FRAPPE_BASE
 
 
 # -- responses / errors -----------------------------------------------------
@@ -109,10 +115,10 @@ def _lite():
     return LiteLLMIntegration("sk-key", provider="openai", model="gpt-4o")
 
 
-def test_get_response_text(fake_litellm) -> None:
-    assert _lite().get_response_text(_response("Hello world")) == "Hello world"
-    assert _lite().get_response_text(SimpleNamespace(choices=[])) == ""
-    assert _lite().get_response_text(_response(None)) == ""
+def test_answer_text_handles_an_empty_response(fake_litellm) -> None:
+    assert _lite()._answer_text(_response("Hello world"), "key") == "Hello world"
+    assert _lite()._answer_text(SimpleNamespace(choices=[]), "key") == ""
+    assert _lite()._answer_text(_response(None), "key") == ""
 
 
 def test_auth_error_maps(fake_litellm) -> None:
@@ -143,7 +149,7 @@ def test_provider_options_aggregate_across_integrations(fake_litellm) -> None:
     assert options["openai"]["requires_api_base"] is False
     assert options["openai"]["free_text_model"] is False
     # the two special integrations
-    assert options["frappe-llm"]["requires_api_base"] is False
+    assert options["frappe-llm"]["requires_api_base"] is True
     assert options["frappe-llm"]["free_text_model"] is False
     assert options["frappe-llm"]["models_need_api_key"] is True
     assert options["openai"]["models_need_api_key"] is False
@@ -190,10 +196,12 @@ def test_build_integration_picks_owning_class(fake_litellm) -> None:
     assert isinstance(hosted, SelfHostedIntegration)
 
     frappe = registry.build_integration(
-        SimpleNamespace(provider="frappe-llm", api_key="k", model="qwen3.6-27b-fp8", api_base="")
+        SimpleNamespace(
+            provider="frappe-llm", api_key="k", model="qwen3.6-27b-fp8", api_base=_FRAPPE_BASE
+        )
     )
     assert isinstance(frappe, FrappeLLMIntegration)
-    assert frappe.api_base == FrappeLLMIntegration.base_api
+    assert frappe.api_base == _FRAPPE_BASE
 
 
 def test_unknown_provider_raises(fake_litellm) -> None:
@@ -233,17 +241,24 @@ def _patch_urlopen(monkeypatch: pytest.MonkeyPatch, result):
 
 def test_frappe_models_need_a_key() -> None:
     with pytest.raises(ValueError, match="needs an API key"):
-        FrappeLLMIntegration.get_models("frappe-llm")
+        FrappeLLMIntegration.get_models("frappe-llm", "", _FRAPPE_BASE)
+
+
+def test_frappe_models_need_an_endpoint() -> None:
+    """There is no default server to fall back to, so say that rather than
+    failing later with a connection error against a placeholder host."""
+    with pytest.raises(ValueError, match="needs an API base URL"):
+        FrappeLLMIntegration.get_models("frappe-llm", "sk-key")
 
 
 def test_frappe_models_sorted_and_authorized(monkeypatch: pytest.MonkeyPatch) -> None:
     payload = json.dumps({"data": [{"id": "qwen3.6-27b-fp8"}, {"id": "gpt-oss-120b"}, {}]}).encode()
     calls = _patch_urlopen(monkeypatch, payload)
 
-    models = FrappeLLMIntegration.get_models("frappe-llm", "sk-key")
+    models = FrappeLLMIntegration.get_models("frappe-llm", "sk-key", _FRAPPE_BASE)
 
     assert models == ["gpt-oss-120b", "qwen3.6-27b-fp8"]
-    assert calls[0].full_url == f"{FrappeLLMIntegration.base_api}/models"
+    assert calls[0].full_url == f"{_FRAPPE_BASE}/models"
     assert calls[0].get_header("Authorization") == "Bearer sk-key"
 
 
@@ -251,25 +266,108 @@ def test_frappe_models_reject_bad_key(monkeypatch: pytest.MonkeyPatch) -> None:
     error = urllib.error.HTTPError("url", 401, "Unauthorized", {}, None)
     _patch_urlopen(monkeypatch, error)
 
-    with pytest.raises(ValueError, match="rejected the API key"):
-        FrappeLLMIntegration.get_models("frappe-llm", "sk-bad")
+    with pytest.raises(ValueError, match="rejected this API key"):
+        FrappeLLMIntegration.get_models("frappe-llm", "sk-bad", _FRAPPE_BASE)
 
 
 def test_frappe_models_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_urlopen(monkeypatch, urllib.error.URLError("no route"))
 
-    with pytest.raises(ValueError, match="Could not reach"):
-        FrappeLLMIntegration.get_models("frappe-llm", "sk-key")
+    with pytest.raises(ValueError, match=r"Could not reach .*/models: no route"):
+        FrappeLLMIntegration.get_models("frappe-llm", "sk-key", _FRAPPE_BASE)
 
 
 def test_frappe_models_empty_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
     _patch_urlopen(monkeypatch, json.dumps({"data": []}).encode())
 
     with pytest.raises(ValueError, match="no models"):
-        FrappeLLMIntegration.get_models("frappe-llm", "sk-key")
+        FrappeLLMIntegration.get_models("frappe-llm", "sk-key", _FRAPPE_BASE)
 
 
 def test_registry_passes_key_through(monkeypatch: pytest.MonkeyPatch, fake_litellm) -> None:
     _patch_urlopen(monkeypatch, json.dumps({"data": [{"id": "qwen3.6-27b-fp8"}]}).encode())
 
-    assert registry.models_for("frappe-llm", "sk-key") == ["qwen3.6-27b-fp8"]
+    assert registry.models_for("frappe-llm", "sk-key", _FRAPPE_BASE) == ["qwen3.6-27b-fp8"]
+
+
+# -- response caching --------------------------------------------------------
+
+
+def _delta(text: str):
+    return SimpleNamespace(choices=[SimpleNamespace(delta=SimpleNamespace(content=text))])
+
+
+@pytest.fixture
+def empty_response_cache():
+    base.LLMIntegration._cached_responses.clear()
+    yield base.LLMIntegration._cached_responses
+    base.LLMIntegration._cached_responses.clear()
+
+
+def _streaming_integration(fake_litellm, chunks: list[str]) -> base.LLMIntegration:
+    fake_litellm.completion = MagicMock(return_value=iter([_delta(c) for c in chunks]))
+    return base.LLMIntegration("k", provider="openai", model="gpt-4o", stream=True)
+
+
+def test_streamed_answer_is_replayed_from_cache(fake_litellm, empty_response_cache) -> None:
+    """A stream cannot be rewound, so the assembled text is cached and replayed."""
+    first = _streaming_integration(fake_litellm, ["Hel", "lo ", "world"])
+    assert "".join(first.prompt("why?", bench_root=_BENCH)) == "Hello world"
+
+    # A fresh mock, so a call here would mean the provider was hit again.
+    second = _streaming_integration(fake_litellm, ["should not be used"])
+
+    assert "".join(second.prompt("why?", bench_root=_BENCH)) == "Hello world"
+    assert not fake_litellm.completion.called
+
+
+def test_a_different_prompt_is_not_served_from_cache(fake_litellm, empty_response_cache) -> None:
+    first = _streaming_integration(fake_litellm, ["one"])
+    list(first.prompt("first", bench_root=_BENCH))
+
+    second = _streaming_integration(fake_litellm, ["two"])
+    assert "".join(second.prompt("second", bench_root=_BENCH)) == "two"
+
+
+def test_a_half_read_stream_is_not_cached(fake_litellm, empty_response_cache) -> None:
+    """Closing the dialog mid-answer must not persist a truncated explanation."""
+    integration = _streaming_integration(fake_litellm, ["partial ", "rest"])
+    stream = integration.prompt("why?", bench_root=_BENCH)
+    next(stream)
+    stream.close()
+
+    assert empty_response_cache == {}
+
+
+def test_a_failed_stream_is_not_cached(fake_litellm, empty_response_cache) -> None:
+    def dies_midway():
+        yield _delta("partial ")
+        raise RuntimeError("provider died")
+
+    fake_litellm.completion = MagicMock(return_value=dies_midway())
+    integration = base.LLMIntegration("k", provider="openai", model="gpt-4o", stream=True)
+
+    with pytest.raises(RuntimeError):
+        list(integration.prompt("why?", bench_root=_BENCH))
+
+    assert empty_response_cache == {}
+
+
+def test_non_streamed_answers_are_cached_too(fake_litellm, empty_response_cache) -> None:
+    """Turning streaming off returns the text directly, and caches it the same way."""
+    integration = base.LLMIntegration("k", provider="openai", model="gpt-4o")
+    assert integration.prompt("why?", bench_root=_BENCH) == "hi"
+    assert fake_litellm.completion.call_count == 1
+
+    again = base.LLMIntegration("k", provider="openai", model="gpt-4o")
+
+    assert again.prompt("why?", bench_root=_BENCH) == "hi"
+    assert fake_litellm.completion.call_count == 1
+
+
+def test_cache_does_not_grow_without_bound(fake_litellm, empty_response_cache) -> None:
+    for index in range(base._CACHE_LIMIT + 5):
+        integration = _streaming_integration(fake_litellm, [f"answer {index}"])
+        list(integration.prompt(f"q{index}", bench_root=_BENCH))
+
+    assert len(empty_response_cache) == base._CACHE_LIMIT

--- a/tests/pilot/integrations/test_llm.py
+++ b/tests/pilot/integrations/test_llm.py
@@ -371,3 +371,18 @@ def test_cache_does_not_grow_without_bound(fake_litellm, empty_response_cache) -
         list(integration.prompt(f"q{index}", bench_root=_BENCH))
 
     assert len(empty_response_cache) == base._CACHE_LIMIT
+
+
+def test_refresh_replaces_the_cached_answer(fake_litellm, empty_response_cache) -> None:
+    """The Regenerate button must reach the provider, and what it gets back becomes
+    the new cached answer - otherwise the next open would show the stale one."""
+    first = _streaming_integration(fake_litellm, ["first"])
+    assert "".join(first.prompt("why?", bench_root=_BENCH)) == "first"
+
+    regenerated = _streaming_integration(fake_litellm, ["second"])
+    assert "".join(regenerated.prompt("why?", bench_root=_BENCH, refresh=True)) == "second"
+    assert fake_litellm.completion.called
+
+    reopened = _streaming_integration(fake_litellm, ["should not be used"])
+    assert "".join(reopened.prompt("why?", bench_root=_BENCH)) == "second"
+    assert not fake_litellm.completion.called

--- a/tests/pilot/managers/task/test_task_events.py
+++ b/tests/pilot/managers/task/test_task_events.py
@@ -1,5 +1,8 @@
 import json
+from datetime import UTC, datetime
+from pathlib import Path
 
+from pilot.managers.task.models import TaskInfo, TaskStatus
 from pilot.managers.task.reader import (
     done_event,
     output_event,
@@ -36,9 +39,36 @@ def test_done_event_keeps_terminal_details() -> None:
     }
 
 
+def _task(command: str, status: TaskStatus, queue_position: int | None = None) -> TaskInfo:
+    return TaskInfo(
+        task_id="20260521-143022-aabbcc",
+        command=command,
+        args={},
+        status=status,
+        pid=None,
+        queued_at=datetime.now(UTC),
+        started_at=None,
+        finished_at=None,
+        exit_code=None,
+        output_path=Path("/tmp/output.log"),
+        queue_position=queue_position,
+    )
+
+
 def test_status_event_reports_queue_position() -> None:
-    assert status_event("queued", 2) == {
+    assert status_event(_task("build", TaskStatus.QUEUED, 2)) == {
         "type": "status",
         "status": "queued",
         "queue_position": 2,
+        "is_cancellable": True,
     }
+
+
+def test_status_event_marks_a_running_app_install_uncancellable() -> None:
+    """Killing one mid-run leaves doctypes behind that fail every retry, so the
+    stream has to tell the UI the moment it starts running."""
+    queued = status_event(_task("install-app", TaskStatus.QUEUED))
+    running = status_event(_task("install-app", TaskStatus.RUNNING))
+
+    assert queued["is_cancellable"] is True
+    assert running["is_cancellable"] is False

--- a/tests/pilot/managers/task/test_tasks.py
+++ b/tests/pilot/managers/task/test_tasks.py
@@ -281,7 +281,7 @@ def test_stream_output_yields_structured_events(tmp_path: Path) -> None:
     events = list(TaskReader(tmp_path).stream_output(task_id))
 
     assert events == [
-        {"type": "status", "status": "success", "queue_position": None},
+        {"type": "status", "status": "success", "queue_position": None, "is_cancellable": False},
         {"type": "line", "line": "alpha"},
         {"type": "line", "line": "beta"},
         {

--- a/tests/pilot/managers/test_process_reload.py
+++ b/tests/pilot/managers/test_process_reload.py
@@ -79,22 +79,20 @@ def test_workload_reload_skips_admin_and_redis(tmp_path: Path, monkeypatch) -> N
     assert restarted == ["web", "socketio", "worker_default_1"]
 
 
-def test_app_tasks_declare_a_single_reload_callback() -> None:
+def test_tasks_that_change_bench_apps_declare_a_single_reload_callback() -> None:
     """One reload per task, not one per app - installing an app plus its
     dependencies must not restart the workload several times."""
     from unittest.mock import MagicMock
 
     from pilot.tasks.callbacks import task_callbacks_for
     from pilot.tasks.get_app import GetAppTask
-    from pilot.tasks.install_app import InstallAppTask
     from pilot.tasks.remove_app import RemoveAppTask
-    from pilot.tasks.uninstall_app import UninstallAppTask
+    from pilot.tasks.switch_branch import SwitchBranchTask
 
     tasks = [
         GetAppTask(bench=MagicMock(), bench_root=Path("/tmp/bench"), repo="lms"),
-        InstallAppTask(bench=MagicMock(), bench_root=Path("/tmp/bench"), site="a.local", app="lms"),
-        UninstallAppTask(bench=MagicMock(), bench_root=Path("/tmp/bench"), site="a.local", app="lms"),
         RemoveAppTask(bench=MagicMock(), bench_root=Path("/tmp/bench"), name="lms"),
+        SwitchBranchTask(bench=MagicMock(), bench_root=Path("/tmp/bench"), name="lms", branch="main"),
     ]
 
     for task in tasks:
@@ -102,6 +100,21 @@ def test_app_tasks_declare_a_single_reload_callback() -> None:
             "operation": "reload-workers",
             "args": {"web_only": False},
         }
+
+
+def test_site_app_tasks_clear_the_site_cache_instead_of_reloading() -> None:
+    """The app is already importable, so a restart buys nothing over a cache clear."""
+    from unittest.mock import MagicMock
+
+    from pilot.tasks.callbacks import task_callbacks_for
+    from pilot.tasks.install_app import InstallAppTask
+    from pilot.tasks.uninstall_app import UninstallAppTask
+
+    for task in (
+        InstallAppTask(bench=MagicMock(), bench_root=Path("/tmp/bench"), site="a.local", app="lms"),
+        UninstallAppTask(bench=MagicMock(), bench_root=Path("/tmp/bench"), site="a.local", app="lms"),
+    ):
+        assert "on_success" not in task_callbacks_for(task)
 
 
 def test_reload_workers_callback_is_registered() -> None:

--- a/tests/pilot/tasks/test_install_app_task.py
+++ b/tests/pilot/tasks/test_install_app_task.py
@@ -49,6 +49,7 @@ def test_install_app_task_uses_site_install_app(tmp_path: Path) -> None:
         patch.object(Site, "install_app") as mock_install,
         patch("pilot.managers.environment.PythonEnvManager.build_assets_for_app"),
         patch.object(Site, "clear_cache"),
+        patch.object(Site, "under_maintenance"),
     ):
         task.run()
 
@@ -66,6 +67,7 @@ def test_install_app_task_builds_assets_for_app_and_required_apps(tmp_path: Path
         patch.object(Site, "install_app"),
         patch("pilot.managers.environment.PythonEnvManager.build_assets_for_app") as mock_build,
         patch.object(Site, "clear_cache"),
+        patch.object(Site, "under_maintenance"),
     ):
         task.run()
 
@@ -81,6 +83,7 @@ def test_install_app_task_skips_required_app_missing_from_bench(tmp_path: Path) 
         patch.object(Site, "install_app"),
         patch("pilot.managers.environment.PythonEnvManager.build_assets_for_app") as mock_build,
         patch.object(Site, "clear_cache"),
+        patch.object(Site, "under_maintenance"),
     ):
         task.run()
 
@@ -94,6 +97,7 @@ def test_install_app_task_exits_nonzero_when_site_install_fails(tmp_path: Path) 
 
     with (
         patch.object(Site, "install_app", side_effect=CommandError("boom")),
+        patch.object(Site, "under_maintenance"),
         pytest.raises(SystemExit) as exc,
     ):
         task.run()

--- a/tests/pilot/tasks/test_install_app_task.py
+++ b/tests/pilot/tasks/test_install_app_task.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 
@@ -48,6 +48,7 @@ def test_install_app_task_uses_site_install_app(tmp_path: Path) -> None:
     with (
         patch.object(Site, "install_app") as mock_install,
         patch("pilot.managers.environment.PythonEnvManager.build_assets_for_app"),
+        patch.object(Site, "clear_cache"),
     ):
         task.run()
 
@@ -64,6 +65,7 @@ def test_install_app_task_builds_assets_for_app_and_required_apps(tmp_path: Path
     with (
         patch.object(Site, "install_app"),
         patch("pilot.managers.environment.PythonEnvManager.build_assets_for_app") as mock_build,
+        patch.object(Site, "clear_cache"),
     ):
         task.run()
 
@@ -78,6 +80,7 @@ def test_install_app_task_skips_required_app_missing_from_bench(tmp_path: Path) 
     with (
         patch.object(Site, "install_app"),
         patch("pilot.managers.environment.PythonEnvManager.build_assets_for_app") as mock_build,
+        patch.object(Site, "clear_cache"),
     ):
         task.run()
 
@@ -96,3 +99,23 @@ def test_install_app_task_exits_nonzero_when_site_install_fails(tmp_path: Path) 
         task.run()
 
     assert exc.value.code == 1
+
+
+def test_install_clears_the_site_cache_after_building_assets(tmp_path: Path) -> None:
+    """Running processes keep a cached installed-apps list and asset manifest."""
+    from unittest.mock import MagicMock, call
+
+    from pilot.tasks.install_app import InstallAppTask
+
+    bench = MagicMock()
+    task = InstallAppTask(bench=bench, bench_root=tmp_path, site="a.local", app="lms")
+    order = MagicMock()
+    bench.site.return_value.clear_cache = order.clear_cache
+
+    with (
+        patch.object(InstallAppTask, "install", return_value=[]),
+        patch.object(InstallAppTask, "build_assets", order.build_assets),
+    ):
+        task.run()
+
+    assert order.mock_calls == [call.build_assets(ANY), call.clear_cache()]

--- a/tests/pilot/tasks/test_new_site_task.py
+++ b/tests/pilot/tasks/test_new_site_task.py
@@ -104,3 +104,40 @@ def test_fetch_missing_apps_raises_when_not_in_marketplace(tmp_path: Path) -> No
             assert "not found in marketplace" in str(error)
         else:
             raise AssertionError("expected BenchError")
+
+
+def test_run_reloads_workers_after_fetching_apps_and_before_provisioning(tmp_path: Path) -> None:
+    """Provisioning runs install-app, which enqueues jobs importing the site's
+    apps - workers must restart in between or those jobs fail to import."""
+    from unittest.mock import MagicMock, call
+
+    task = make_task(tmp_path, ["helpdesk"])
+    order = MagicMock()
+    task.bench.reload_workers = order.reload
+
+    with (
+        patch.object(task, "require_production_privileges"),
+        patch.object(task, "fetch_missing_apps", order.fetch),
+        patch.object(task, "create", order.create),
+    ):
+        task.run()
+
+    assert order.mock_calls == [call.fetch(), call.reload(), call.create()]
+
+
+def test_run_reloads_workers_even_when_no_app_was_fetched(tmp_path: Path) -> None:
+    """An app already on the bench can still postdate the running workers - it
+    may have arrived through `bench get-app` after they started."""
+    from unittest.mock import MagicMock
+
+    task = make_task(tmp_path, ["frappe"])
+    (task.bench.sites_path / "apps.txt").write_text("frappe\n")
+    task.bench.reload_workers = MagicMock()
+
+    with (
+        patch.object(task, "require_production_privileges"),
+        patch.object(task, "create"),
+    ):
+        task.run()
+
+    task.bench.reload_workers.assert_called_once()


### PR DESCRIPTION
### Install / uninstall app
- Removed the `reload-workers` callback from both
- Both call `site.clear_cache()` instead; in install it runs after the asset build
- Added `Site.under_maintenance()`
  - Install (including asset build) and uninstall run inside it

### Site drop
- Added the missing `openTaskDetailPage`, Drop and Reset never redirected
- `drop-site` added to the redirect-on-success list, pointing at the Sites list rather than the deleted site's detail page

### Cancellable Jobs
- Some jobs should not be cancellable like install app & uninstall app leaves dirt behind; sometimes also leaves site in a broken state.