### PR TITLE
fix(packages): fail loudly without sudo

### DIFF
--- a/pilot/managers/packages.py
+++ b/pilot/managers/packages.py
@@ -5,12 +5,21 @@ import subprocess
 from abc import ABC, abstractmethod
 from typing import ClassVar
 
-from pilot.managers.platform import Distro, _privileged, detect_distro, is_macos
+from pilot.exceptions import BenchError
+from pilot.managers.platform import (
+    Distro,
+    _privileged,
+    detect_distro,
+    has_passwordless_sudo,
+    is_macos,
+    is_root,
+)
 
 
 class SystemPackageManager(ABC):
     # Canonical (Debian/apt) name -> native name(s). Unmapped names pass through.
     package_aliases: ClassVar[dict[str, str | tuple[str, ...]]] = {}
+    requires_privilege: ClassVar[bool] = True
 
     def _resolve(self, *packages: str) -> list[str]:
         resolved: list[str] = []
@@ -20,8 +29,17 @@ class SystemPackageManager(ABC):
             resolved.extend(name for name in names if name not in resolved)
         return resolved
 
-    @abstractmethod
     def install(self, *packages: str) -> None:
+        if self.requires_privilege and not is_root() and not has_passwordless_sudo():
+            names = ", ".join(self._resolve(*packages))
+            raise BenchError(
+                f"Required: {names}. No passwordless sudo available; install "
+                "manually with your system package manager, then re-run this command."
+            )
+        self._install(*packages)
+
+    @abstractmethod
+    def _install(self, *packages: str) -> None:
         """Install one or more system packages."""
 
     @abstractmethod
@@ -34,7 +52,7 @@ class AptPackageManager(SystemPackageManager):
         "modsecurity-nginx": "libnginx-mod-http-modsecurity",
     }
 
-    def install(self, *packages: str) -> None:
+    def _install(self, *packages: str) -> None:
         subprocess.run(
             _privileged(["apt-get", "install", "-y", *self._resolve(*packages)]),
             env={**os.environ, "DEBIAN_FRONTEND": "noninteractive"},
@@ -65,7 +83,7 @@ class DnfPackageManager(SystemPackageManager):
         "modsecurity-nginx": "nginx-mod-modsecurity",
     }
 
-    def install(self, *packages: str) -> None:
+    def _install(self, *packages: str) -> None:
         subprocess.run(
             _privileged(["dnf", "install", "-y", *self._resolve(*packages)]),
             check=True,
@@ -97,7 +115,7 @@ class PacmanPackageManager(SystemPackageManager):
         "modsecurity-nginx": "nginx-mod-modsecurity",
     }
 
-    def install(self, *packages: str) -> None:
+    def _install(self, *packages: str) -> None:
         subprocess.run(
             _privileged(["pacman", "-S", "--noconfirm", "--needed", *self._resolve(*packages)]),
             check=True,
@@ -113,7 +131,9 @@ class PacmanPackageManager(SystemPackageManager):
 
 
 class BrewPackageManager(SystemPackageManager):
-    def install(self, *packages: str) -> None:
+    requires_privilege: ClassVar[bool] = False
+
+    def _install(self, *packages: str) -> None:
         subprocess.run(
             ["brew", "install", *packages],
             check=True,

--- a/pilot/managers/packages.py
+++ b/pilot/managers/packages.py
@@ -1,5 +1,3 @@
-"""System package installation with per-distro package aliases."""
-
 import os
 import subprocess
 from abc import ABC, abstractmethod
@@ -79,7 +77,6 @@ class DnfPackageManager(SystemPackageManager):
         "redis-server": "valkey",
         "postgresql": "postgresql-server",
         "postgresql-client": "postgresql",
-        "zfsutils-linux": "zfs",
         "modsecurity-nginx": "nginx-mod-modsecurity",
     }
 
@@ -110,8 +107,6 @@ class PacmanPackageManager(SystemPackageManager):
         # Arch moved redis to the AUR in favour of valkey.
         "redis-server": "valkey",
         "postgresql-client": "postgresql",
-        # Only available via the third-party archzfs repository.
-        "zfsutils-linux": "zfs-utils",
         "modsecurity-nginx": "nginx-mod-modsecurity",
     }
 

--- a/tests/pilot/managers/test_package_managers.py
+++ b/tests/pilot/managers/test_package_managers.py
@@ -142,9 +142,27 @@ def test_is_installed_argv(monkeypatch, manager, expected) -> None:
 
 def test_install_uses_sudo_when_not_root(monkeypatch) -> None:
     monkeypatch.setattr(platform, "is_root", lambda: False)
+    monkeypatch.setattr(package_managers, "has_passwordless_sudo", lambda: True)
     with patch.object(package_managers.subprocess, "run") as run:
         DnfPackageManager().install("git")
     assert run.call_args[0][0] == ["sudo", "dnf", "install", "-y", "git"]
+
+
+def test_install_raises_without_passwordless_sudo(monkeypatch) -> None:
+    from pilot.exceptions import BenchError
+
+    monkeypatch.setattr(package_managers, "is_root", lambda: False)
+    monkeypatch.setattr(package_managers, "has_passwordless_sudo", lambda: False)
+    with pytest.raises(BenchError, match="Required: git"):
+        DnfPackageManager().install("git")
+
+
+def test_install_skips_permission_check_on_macos(monkeypatch) -> None:
+    monkeypatch.setattr(package_managers, "is_root", lambda: False)
+    monkeypatch.setattr(package_managers, "has_passwordless_sudo", lambda: False)
+    with patch.object(package_managers.subprocess, "run") as run:
+        BrewPackageManager().install("git")
+    assert run.call_args[0][0] == ["brew", "install", "git"]
 
 
 # Node.js is installed once by install.sh's root bootstrap now, not per bench


### PR DESCRIPTION
- Raise a clear error instead of hanging when sudo/root is unavailable
- Brew installs skip the check since it never needs sudo
- Drop unused zfsutils-linux aliases from dnf/pacman