### PR TITLE
fix: keep branch name attached after pinned-commit/tag checkout

### DIFF
--- a/pilot/core/app/repository.py
+++ b/pilot/core/app/repository.py
@@ -213,16 +213,16 @@ class AppRepository:
         if pin.kind == "tag":
             self._sync_remote_url()
             run_command(["git", "-C", str(self.app.path), "fetch", "--depth", "1", "origin", pin.ref])
-            run_command(["git", "-C", str(self.app.path), "checkout", "FETCH_HEAD"])
+            self._checkout_pinned_ref("FETCH_HEAD")
         else:
             self.checkout_pinned_commit(pin.ref)
 
     def checkout_pinned_commit(self, sha: str) -> None:
-        """Check out a specific commit SHA."""
+        """Check out a specific commit SHA, staying on the app's configured branch."""
         self._sync_remote_url()
         try:
             run_command(["git", "-C", str(self.app.path), "fetch", "--depth", "1", "origin", sha])
-            run_command(["git", "-C", str(self.app.path), "checkout", "FETCH_HEAD"])
+            self._checkout_pinned_ref("FETCH_HEAD")
             return
         except CommandError:
             pass
@@ -238,4 +238,11 @@ class AppRepository:
                 self.app.config.branch,
             ]
         )
-        run_command(["git", "-C", str(self.app.path), "checkout", sha])
+        self._checkout_pinned_ref(sha)
+
+    def _checkout_pinned_ref(self, ref: str) -> None:
+        """Land on `ref`, keeping the configured branch name attached instead of a detached HEAD."""
+        branch = self.app.config.branch
+        if branch and not self.is_commit_hash(branch) and self.repo.checkout_new_branch(branch, ref):
+            return
+        run_command(["git", "-C", str(self.app.path), "checkout", ref])

--- a/tests/pilot/core/test_core.py
+++ b/tests/pilot/core/test_core.py
@@ -18,6 +18,7 @@ from pilot.core.bench import Bench
 from pilot.core.server import Server
 from pilot.core.site import Site
 from pilot.exceptions import BenchError
+from pilot.internal.git import GitRepo
 from pilot.managers.processes.local import ProcessDefinition, ProcessManager
 
 FIXTURES_DIR = Path(__file__).parent.parent.parent / "fixtures"
@@ -296,6 +297,33 @@ def test_app_update_with_commit_target_checks_out_advertised_commit(tmp_path: Pa
     ).stdout.strip()
 
     app.update(pin=RevisionPin(kind="commit", ref=target_sha))
+
+    assert app.installed_hash == target_sha
+
+
+def test_app_update_with_commit_target_stays_on_configured_branch(tmp_path: Path) -> None:
+    """A pinned-commit update should land at that commit without detaching HEAD."""
+    remote = tmp_path / "remote"
+    remote.mkdir()
+    _init_git_repo(remote)
+    _commit(remote, "c1")
+    _commit(remote, "c2")
+
+    import subprocess
+
+    target_sha = subprocess.run(
+        ["git", "-C", str(remote), "rev-parse", "HEAD^"], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+    bench = make_bench(tmp_path)
+    app = App(AppConfig(name="myapp", repo="r", branch="develop"), bench)
+    subprocess.run(["git", "clone", "-q", str(remote), str(app.path)], check=True)
+    subprocess.run(["git", "-C", str(app.path), "checkout", "-q", "-B", "develop"], check=True)
+
+    app.update(pin=RevisionPin(kind="commit", ref=target_sha))
+
+    assert app.installed_hash == target_sha
+    assert GitRepo(app.path).branch == "develop"
 
     assert app.installed_hash == target_sha
 


### PR DESCRIPTION
- During `bench update`, apps are updated via a pinned `RevisionPin` (commit or tag), which previously always ended in `git checkout <sha>`/`git checkout FETCH_HEAD` — detaching HEAD. This left apps on a random-looking detached commit instead of their configured branch.
- `AppRepository.checkout_pinned_commit`/`checkout_pinned_target` now land the pin via `GitRepo.checkout_new_branch` (the same primitive already used by `switch_branch`), which resets the app's configured local branch onto the pinned commit/tag and checks it out — so HEAD stays attached to the branch name while pointing at the exact pinned commit.
- Falls back to a plain detached checkout only when there's no real branch name configured (e.g. `branch` itself is a commit hash).
