### PR TITLE
fix: install JS deps before building app frontend/roster assets

### DIFF
--- a/pilot/managers/python_assets.py
+++ b/pilot/managers/python_assets.py
@@ -48,6 +48,8 @@ class PythonAssetBuilder:
         if (app.path / "package.json").exists():
             self.ensure_yarn_install(app.path)
 
+        self.ensure_frontend_dependencies(app)
+
         print(f"  Building assets for {app.config.name}...")
         sys.stdout.flush()
         run_command(
@@ -66,6 +68,15 @@ class PythonAssetBuilder:
                     cwd=app.path / frontend_dir,
                     stream_output=True,
                 )
+
+    def ensure_frontend_dependencies(self, app: "App") -> None:
+        """frappe's own `bench build` shells into `frontend`/`roster`, so node_modules must
+        be synced there before that step runs, not just in the standalone build loop after it."""
+        for frontend_dir in ["frontend", "roster"]:
+            if (app.path / frontend_dir / "package.json").exists():
+                print(f"  Installing JS dependencies for {frontend_dir} of {app.config.name}...")
+                sys.stdout.flush()
+                self.ensure_yarn_install(app.path / frontend_dir)
 
     def ensure_yarn_install(self, path: Path) -> None:
         """Run yarn install when node_modules is missing or yarn.lock changed."""

--- a/tests/pilot/managers/test_python_assets.py
+++ b/tests/pilot/managers/test_python_assets.py
@@ -1,0 +1,47 @@
+"""Tests for PythonAssetBuilder."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pilot.managers.python_assets import PythonAssetBuilder
+
+
+def make_app(app_path: Path, name: str = "gameplan") -> MagicMock:
+    app = MagicMock()
+    app.path = app_path
+    app.config.name = name
+    return app
+
+
+def test_build_assets_for_app_installs_js_deps_before_frappe_build_runs(tmp_path: Path) -> None:
+    """frappe's own `bench build` step shells into `frontend` and runs `yarn build` there,
+    so node_modules must be synced before that step, not only in the standalone loop after it."""
+    app_path = tmp_path / "gameplan"
+    frontend_dir = app_path / "frontend"
+    frontend_dir.mkdir(parents=True)
+    (frontend_dir / "package.json").write_text("{}")
+
+    manager = MagicMock()
+    manager.bench.frappe_call = ["python"]
+    manager.bench.sites_path = tmp_path / "sites"
+    builder = PythonAssetBuilder(manager)
+
+    events: list[str] = []
+
+    with (
+        patch("pilot.managers.python_assets.git_has_local_changes", return_value=True),
+        patch(
+            "pilot.managers.python_assets.run_command",
+            side_effect=lambda *a, **k: events.append("run_command"),
+        ),
+        patch.object(
+            builder,
+            "ensure_yarn_install",
+            side_effect=lambda path: events.append(f"ensure_yarn_install:{path.name}"),
+        ),
+    ):
+        builder.build_assets_for_app(make_app(app_path))
+
+    assert events.index("ensure_yarn_install:frontend") < events.index("run_command")


### PR DESCRIPTION
## Problem
When updating or reverting an app, we reinstall its Python packages but never reinstall its frontend JS packages (`node_modules` under `frontend`/`roster`). After checking out a different commit, the build runs against old JS dependencies that no longer match the new code.

The actual break happens earlier than it looks: frappe's own `bench build --app <name>` step shells into the app's `frontend`/`roster` folder and runs `yarn build` there directly, before pilot's own frontend build step ever runs. It only checks that `node_modules` exists at the app root, not inside `frontend`/`roster`, so a stale `frontend/node_modules` from a previous commit breaks the build right there.

This is what happened on `bench1`: updating `gameplan` failed because a new dependency wasn't installed, and the automatic revert failed too because the old frontend code no longer matched the newer JS packages still sitting in `node_modules`.

## Solution
Sync JS dependencies (`yarn install`) in each `frontend`/`roster` folder before calling `bench build`, not just afterward. Since both update and revert use the same build function, this one fix covers both.