### PR TITLE
refactor: Process reader and UI polling intervals

### DIFF
--- a/admin/backend/providers/processes.py
+++ b/admin/backend/providers/processes.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import psutil
 
 if TYPE_CHECKING:
     from pilot.managers.processes.supervisor import SupervisorProcessManager
@@ -172,82 +175,41 @@ class ProcessProvider:
 
     @classmethod
     def _get_process_stats(cls, pid: int) -> tuple[float | None, float | None, float | None]:
-        """CPU%, RSS and PSS (MB) summed across the process subtree, via `ps`."""
-        pids = cls._get_subtree_pids(pid)
+        """CPU%, RSS and PSS (MB) summed across the process subtree."""
         try:
-            result = subprocess.run(
-                ["ps", "-o", "%cpu=,rss=", "-p", ",".join(map(str, pids))],
-                capture_output=True,
-                text=True,
-                timeout=5,
-            )
-        except (OSError, subprocess.SubprocessError):
-            return None, None, None
-        if result.returncode != 0:
+            root = psutil.Process(pid)
+            subtree = [root, *root.children(recursive=True)]
+        except psutil.Error:
             return None, None, None
 
-        cpu_total, rss_kb = 0.0, 0
-        for line in result.stdout.splitlines():
-            parts = line.split()
-            if len(parts) >= 2:
-                cpu_total += float(parts[0])
-                rss_kb += int(parts[1])
+        cpu_total, rss_kb, pss_kb = 0.0, 0, []
+        for process in subtree:
+            try:
+                cpu_total += cls._lifetime_cpu_percent(process)
+                rss_kb += process.memory_info().rss // 1024
+                if (pss := getattr(process.memory_full_info(), "pss", None)) is not None:
+                    pss_kb.append(pss // 1024)
+            except psutil.Error:
+                continue
 
-        pss_vals = [v for p in pids if (v := cls._get_pss_kb(p)) is not None]
-        pss_mb = round(sum(pss_vals) / 1024.0, 1) if pss_vals else None
+        pss_mb = round(sum(pss_kb) / 1024.0, 1) if pss_kb else None
         return round(cpu_total, 1), round(rss_kb / 1024.0, 1), pss_mb
 
     @staticmethod
-    def _get_subtree_pids(pid: int) -> list[int]:
-        """Return pid plus descendants for a service's real footprint."""
-        children: dict[int, list[int]] = {}
-        try:
-            proc_entries = os.listdir("/proc")
-        except OSError:
-            return [pid]
-        for entry in proc_entries:
-            if not entry.isdigit():
-                continue
-            try:
-                with open(f"/proc/{entry}/stat") as f:
-                    data = f.read()
-                # ppid is 2 fields after comm's closing ')' (comm may contain "( )").
-                ppid = int(data[data.rindex(")") + 2 :].split()[1])
-            except (OSError, ValueError, IndexError):
-                continue
-            children.setdefault(ppid, []).append(int(entry))
-
-        tree, stack = [], [pid]
-        while stack:
-            cur = stack.pop()
-            tree.append(cur)
-            stack.extend(children.get(cur, []))
-        return tree
-
-    @staticmethod
-    def _get_pss_kb(pid: int) -> int | None:
-        """Return PSS in KB from /proc/<pid>/smaps_rollup, if readable."""
-        try:
-            with open(f"/proc/{pid}/smaps_rollup") as f:
-                for line in f:
-                    if line.startswith("Pss:"):
-                        return int(line.split()[1])
-        except (OSError, ValueError, IndexError):
-            pass
-        return None
+    def _lifetime_cpu_percent(process: psutil.Process) -> float:
+        """CPU averaged over the process's whole life, matching what `ps %cpu`
+        reports. psutil's own cpu_percent() needs two samples and would read 0
+        on a one-shot request."""
+        cpu_times = process.cpu_times()
+        elapsed = time.time() - process.create_time()
+        if elapsed <= 0:
+            return 0.0
+        return (cpu_times.user + cpu_times.system) / elapsed * 100
 
     @staticmethod
     def _get_proc_uptime(pid: int) -> str | None:
-        """Return wall-clock uptime from /proc/<pid>/stat, if readable."""
         try:
-            with open("/proc/uptime") as f:
-                system_uptime = float(f.read().split()[0])
-            with open(f"/proc/{pid}/stat") as f:
-                data = f.read()
-            # Start time is field 22 (clock ticks since boot); fields after comm
-            # ')' start at field 3, so it's index 19 in the post-comm split.
-            starttime_ticks = int(data[data.rindex(")") + 2 :].split()[19])
-            elapsed = system_uptime - starttime_ticks / os.sysconf("SC_CLK_TCK")
-            return _format_duration(elapsed) if elapsed >= 0 else None
-        except (OSError, ValueError, IndexError):
+            elapsed = time.time() - psutil.Process(pid).create_time()
+        except psutil.Error:
             return None
+        return _format_duration(elapsed) if elapsed >= 0 else None

--- a/admin/frontend/dashboard/src/pages/dashboard/Analytics.vue
+++ b/admin/frontend/dashboard/src/pages/dashboard/Analytics.vue
@@ -140,6 +140,11 @@
         </ChartCard>
       </div>
 
+      <!-- Live mode collecting its first points, with the stat bar already up -->
+      <div v-else-if="!isHistorical" class="gap-4 grid grid-cols-1 sm:grid-cols-2 mb-6">
+        <Skeleton v-for="i in 6" :key="i" class="rounded-lg h-[340px]" />
+      </div>
+
       <!-- WAF analytics (only renders when the WAF has logged activity) -->
       <WafAnalytics :window="activeWindow" />
     </template>
@@ -156,6 +161,7 @@ import DatabaseInsights from '@/components/dashboard/DatabaseInsights.vue'
 import SiteInsights from '@/components/dashboard/SiteInsights.vue'
 import { apiErrorMessage } from '@/api/client'
 import { monitorApi } from '@/api/monitor'
+import { livePollDelayMs } from '@/utils/livePolling'
 import { useSites } from '@/composables/sites/useSites'
 
 const WINDOWS = [
@@ -326,13 +332,14 @@ function humanizeSince(earliest) {
 
 // Data loading
 
-function setWindow(key) {
+async function setWindow(key) {
   activeWindow.value = key
   if (key === 'live') {
     liveHistory.value = []
     application.value = { earliest: null, services: [], cpu: [], memory: [] }
-    seedLiveHistory()
-    loadStats()
+    await seedLiveHistory()
+    await loadStats()
+    scheduleStats()
   } else {
     loadHistory(key)
   }
@@ -442,9 +449,8 @@ const allEmpty = computed(
     systemEmpty.value &&
     appEmpty.value,
 )
-const pageLoading = computed(() =>
-  isHistorical.value ? historyLoading.value : !stats.value || liveHistory.value.length < 2,
-)
+// Live mode only waits on the stat bar's own data; the charts wait on showCharts.
+const pageLoading = computed(() => (isHistorical.value ? historyLoading.value : !stats.value))
 const showCharts = computed(() =>
   isHistorical.value
     ? !historyLoading.value && !historyError.value && !systemEmpty.value
@@ -665,15 +671,29 @@ function formatBytes(bytes) {
 // Lifecycle
 
 let statsTimer
-onMounted(() => {
+function scheduleStats() {
+  clearTimeout(statsTimer)
+  const delay = livePollDelayMs({
+    isLive: view.value === 'system' && !isHistorical.value,
+    pointCount: liveHistory.value.length,
+  })
+  statsTimer = setTimeout(async () => {
+    await loadStats()
+    scheduleStats()
+  }, delay)
+}
+
+onMounted(async () => {
   if (view.value === 'system') {
     if (isHistorical.value) loadHistory(activeWindow.value)
     else {
-      seedLiveHistory()
-      loadStats()
+      // Seed first: a bench with monitor history reaches a drawable chart in one
+      // shot and never enters the warm-up cadence.
+      await seedLiveHistory()
+      await loadStats()
     }
   }
-  statsTimer = setInterval(loadStats, 10000)
+  scheduleStats()
 })
-onUnmounted(() => clearInterval(statsTimer))
+onUnmounted(() => clearTimeout(statsTimer))
 </script>

--- a/admin/frontend/dashboard/src/utils/livePolling.js
+++ b/admin/frontend/dashboard/src/utils/livePolling.js
@@ -1,0 +1,11 @@
+/** Live-metrics poll pacing. A line needs two points, and benches without a monitor
+ * daemon (macOS, local dev) seed zero, so the chart has to accumulate them one poll
+ * at a time - poll fast until it can draw, then settle to the steady cadence. */
+
+export const LIVE_POLL_MS = 10000
+export const LIVE_WARMUP_POLL_MS = 1000
+export const MIN_CHART_POINTS = 2
+
+export function livePollDelayMs({ isLive, pointCount }) {
+  return isLive && pointCount < MIN_CHART_POINTS ? LIVE_WARMUP_POLL_MS : LIVE_POLL_MS
+}

--- a/admin/frontend/dashboard/src/utils/livePolling.test.js
+++ b/admin/frontend/dashboard/src/utils/livePolling.test.js
@@ -1,0 +1,24 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { livePollDelayMs, LIVE_POLL_MS, LIVE_WARMUP_POLL_MS } from './livePolling.js'
+
+test('warms up while the chart cannot draw a line yet', () => {
+  assert.equal(livePollDelayMs({ isLive: true, pointCount: 0 }), LIVE_WARMUP_POLL_MS)
+  assert.equal(livePollDelayMs({ isLive: true, pointCount: 1 }), LIVE_WARMUP_POLL_MS)
+})
+
+test('settles to the steady cadence once two points exist', () => {
+  assert.equal(livePollDelayMs({ isLive: true, pointCount: 2 }), LIVE_POLL_MS)
+  assert.equal(livePollDelayMs({ isLive: true, pointCount: 240 }), LIVE_POLL_MS)
+})
+
+test('a seeded bench never warms up', () => {
+  // Production seeds a full window from the monitor log before the first schedule.
+  assert.equal(livePollDelayMs({ isLive: true, pointCount: 360 }), LIVE_POLL_MS)
+})
+
+test('non-live views keep the steady cadence regardless of point count', () => {
+  assert.equal(livePollDelayMs({ isLive: false, pointCount: 0 }), LIVE_POLL_MS)
+  assert.equal(livePollDelayMs({ isLive: false, pointCount: 1 }), LIVE_POLL_MS)
+})

--- a/pilot/core/server/monitoring.py
+++ b/pilot/core/server/monitoring.py
@@ -49,7 +49,7 @@ class Monitor:
         self._network: dict[str, float] = {}
         self._disk_io: dict[str, float] = {}
         self._targets: dict[str, int] | None = None
-        self._cpu_before: tuple[dict[str, int], dict[int, int]] | None = None
+        self._cpu_before: tuple[dict[str, float], dict[int, float]] | None = None
         self._io_before: tuple[dict[str, int], dict[str, int]] | None = None
 
     def monitored_targets(self) -> dict[str, int]:

--- a/pilot/core/server/monitoring.py
+++ b/pilot/core/server/monitoring.py
@@ -8,6 +8,8 @@ import typing
 from datetime import UTC, datetime
 from pathlib import Path
 
+import psutil
+
 from pilot.core.server.monitoring_config import MonitorConfigurator
 from pilot.core.server.monitoring_proc import ProcMetricsReader
 from pilot.core.server.monitoring_processes import ProcessResolver
@@ -16,7 +18,7 @@ from pilot.utils import cli_root, iter_sibling_benches
 if typing.TYPE_CHECKING:
     from pilot.core.bench import Bench
 
-# Gap between the two /proc samples used to turn cumulative counters into a rate.
+# Gap between the two samples used to turn cumulative counters into a rate.
 CPU_SAMPLE_INTERVAL = 1.0
 
 # Raw MariaDB status counters/gauges + variables logged per cycle; the provider
@@ -56,8 +58,8 @@ class Monitor:
         return self._targets
 
     def sample_cpu(self) -> None:
-        pids = [pid for pid in self.monitored_targets().values() if Path(f"/proc/{pid}").exists()]
-        self._cpu_before = (self._cpu_fields(), {pid: self._proc_ticks(pid) for pid in pids})
+        pids = [pid for pid in self.monitored_targets().values() if psutil.pid_exists(pid)]
+        self._cpu_before = (self._cpu_fields(), {pid: self._proc_cpu_seconds(pid) for pid in pids})
 
     def compute_cpu(self) -> None:
         assert self._cpu_before is not None, "sample_cpu() must run before compute_cpu()"
@@ -191,10 +193,11 @@ class Monitor:
     def collect_application_metrics(self) -> None:
         processes = []
         for service, pid in self.monitored_targets().items():
-            if not Path(f"/proc/{pid}").exists():
+            try:
+                processes.append(self._process_metrics(service, pid))
+            except psutil.NoSuchProcess:
+                # Either never started, or exited between resolving the pid and reading it.
                 processes.append({"service": service, "pid": pid, "missing": True})
-                continue
-            processes.append(self._process_metrics(service, pid))
 
         self._append(
             self.log_path,
@@ -205,23 +208,22 @@ class Monitor:
             },
         )
 
-    def _proc_usage(self, ticks_before: int, pid: int, delta_total: int) -> float:
+    def _proc_usage(self, seconds_before: float, pid: int, delta_total: float) -> float:
         try:
-            delta = self._proc_ticks(pid) - ticks_before
-        except FileNotFoundError:
+            delta = self._proc_cpu_seconds(pid) - seconds_before
+        except psutil.NoSuchProcess:
             return 0.0
         return round(delta / delta_total * 100, 2) if delta_total > 0 else 0.0
 
     def _process_metrics(self, service: str, pid: int) -> dict:
-        status = self._read_status(pid)
-        pss_memory = self._read_pss(pid)
+        memory_kb = self._proc_memory_kb(pid)
         read_bytes, write_bytes = self._io_bytes(pid)
         return {
             "service": service,
             "pid": pid,
-            "state": status.get("State", "?").split()[0],
+            "state": self._process_state(pid),
             "cpu_percent": self._cpu_percent(pid),
-            "memory_rss_mb": round(pss_memory / 1024, 2),
+            "memory_rss_mb": round(memory_kb / 1024, 2),
             "read_bytes": read_bytes,
             "write_bytes": write_bytes,
             "open_fds": self._open_fds(pid),
@@ -230,11 +232,11 @@ class Monitor:
     def _cpu_percent(self, pid: int) -> float:
         return self._proc_cpu.get(pid, 0.0)
 
-    def _cpu_fields(self) -> dict[str, int]:
+    def _cpu_fields(self) -> dict[str, float]:
         return self._proc_reader.cpu_fields()
 
-    def _proc_ticks(self, pid: int) -> int:
-        return self._proc_reader.proc_ticks(pid)
+    def _proc_cpu_seconds(self, pid: int) -> float:
+        return self._proc_reader.proc_cpu_seconds(pid)
 
     def _net_fields(self) -> dict[str, int]:
         return self._proc_reader.net_fields()
@@ -242,11 +244,11 @@ class Monitor:
     def _disk_io_fields(self) -> dict[str, int]:
         return self._proc_reader.disk_io_fields()
 
-    def _read_status(self, pid: int) -> dict[str, str]:
-        return self._proc_reader.read_status(pid)
+    def _process_state(self, pid: int) -> str:
+        return self._proc_reader.process_state(pid)
 
-    def _read_pss(self, pid: int) -> int:
-        return self._proc_reader.read_pss(pid)
+    def _proc_memory_kb(self, pid: int) -> int:
+        return self._proc_reader.proc_memory_kb(pid)
 
     def _io_bytes(self, pid: int) -> tuple[int, int]:
         return self._proc_reader.io_bytes(pid)

--- a/pilot/core/server/monitoring_proc.py
+++ b/pilot/core/server/monitoring_proc.py
@@ -4,106 +4,117 @@ import os
 import re
 from pathlib import Path
 
+import psutil
+
 CPU_STAT_FIELDS = ("user", "nice", "system", "idle", "iowait", "irq", "softirq", "steal")
-NET_IFACE_EXCLUDE = {"lo"}
-DISK_DEVICE_PATTERN = re.compile(r"^(sd[a-z]+|vd[a-z]+|xvd[a-z]+|nvme\d+n\d+)$")
-SECTOR_BYTES = 512
+NET_IFACE_EXCLUDE = {"lo", "lo0"}
+DISK_DEVICE_PATTERN = re.compile(r"^(sd[a-z]+|vd[a-z]+|xvd[a-z]+|nvme\d+n\d+|disk\d+)$")
 
 
 class ProcMetricsReader:
+    """Host and per-process metric reads. Counters a platform cannot report -
+    PSS, per-process IO, and the iowait/irq/steal CPU slices outside Linux -
+    read as zero rather than failing the sample."""
+
     def __init__(self, bench_path: Path):
         self.bench_path = bench_path
 
-    def cpu_fields(self) -> dict[str, int]:
-        values = [int(value) for value in Path("/proc/stat").read_text().splitlines()[0].split()[1:]]
-        return dict(zip(CPU_STAT_FIELDS, values, strict=False))
+    def cpu_fields(self) -> dict[str, float]:
+        """Cumulative CPU seconds per state. Only deltas are used, so seconds
+        replace the raw jiffies the kernel exposes without changing any result."""
+        times = psutil.cpu_times()
+        return {field: float(getattr(times, field, 0.0)) for field in CPU_STAT_FIELDS}
 
-    def proc_ticks(self, pid: int) -> int:
-        fields = Path(f"/proc/{pid}/stat").read_text().split()
-        return int(fields[13]) + int(fields[14])
+    def proc_cpu_seconds(self, pid: int) -> float:
+        times = psutil.Process(pid).cpu_times()
+        return times.user + times.system
 
     def net_fields(self) -> dict[str, int]:
-        rx_bytes = tx_bytes = 0
-        for line in Path("/proc/net/dev").read_text().splitlines()[2:]:
-            iface, rest = line.split(":", 1)
-            if iface.strip() in NET_IFACE_EXCLUDE:
-                continue
-            values = rest.split()
-            rx_bytes += int(values[0])
-            tx_bytes += int(values[8])
-        return {"rx_bytes": rx_bytes, "tx_bytes": tx_bytes}
-
-    def disk_io_fields(self) -> dict[str, int]:
-        read_sectors = write_sectors = 0
-        for line in Path("/proc/diskstats").read_text().splitlines():
-            fields = line.split()
-            if len(fields) >= 10 and DISK_DEVICE_PATTERN.match(fields[2]):
-                read_sectors += int(fields[5])
-                write_sectors += int(fields[9])
+        counters = psutil.net_io_counters(pernic=True)
+        interfaces = [
+            counter for name, counter in counters.items() if name not in NET_IFACE_EXCLUDE
+        ]
         return {
-            "read_bytes": read_sectors * SECTOR_BYTES,
-            "write_bytes": write_sectors * SECTOR_BYTES,
+            "rx_bytes": sum(counter.bytes_recv for counter in interfaces),
+            "tx_bytes": sum(counter.bytes_sent for counter in interfaces),
         }
 
-    def read_status(self, pid: int) -> dict[str, str]:
-        lines = Path(f"/proc/{pid}/status").read_text().splitlines()
-        return {key: value.strip() for key, value in (line.split(":", 1) for line in lines if ":" in line)}
+    def disk_io_fields(self) -> dict[str, int]:
+        """Whole disks only: partitions double-count their parent device, and
+        dm-/loop devices double-count whatever they sit on."""
+        counters = psutil.disk_io_counters(perdisk=True) or {}
+        devices = [counter for name, counter in counters.items() if DISK_DEVICE_PATTERN.match(name)]
+        return {
+            "read_bytes": sum(counter.read_bytes for counter in devices),
+            "write_bytes": sum(counter.write_bytes for counter in devices),
+        }
 
-    def read_pss(self, pid: int) -> int:
-        lines = Path(f"/proc/{pid}/smaps_rollup").read_text().splitlines()
-        for line in lines:
-            if line.casefold().startswith("pss:"):
-                parts = line.split(":", 1)[1].split()
-                if parts:
-                    return int(parts[0])
-        return 0
+    def process_state(self, pid: int) -> str:
+        return psutil.Process(pid).status()
+
+    def proc_memory_kb(self, pid: int) -> int:
+        """Proportional set size where the platform reports it, unique set size
+        otherwise - both charge shared pages more honestly than RSS."""
+        info = psutil.Process(pid).memory_full_info()
+        shared_aware = getattr(info, "pss", None)
+        if shared_aware is None:
+            shared_aware = getattr(info, "uss", 0)
+        return int(shared_aware / 1024)
 
     def io_bytes(self, pid: int) -> tuple[int, int]:
-        lines = Path(f"/proc/{pid}/io").read_text().splitlines()
-        data = {key: int(value) for key, value in (line.split(": ", 1) for line in lines if ": " in line)}
-        return data.get("read_bytes", 0), data.get("write_bytes", 0)
+        process = psutil.Process(pid)
+        if not hasattr(process, "io_counters"):
+            return 0, 0
+        try:
+            counters = process.io_counters()
+        except psutil.AccessDenied:
+            return 0, 0
+        return counters.read_bytes, counters.write_bytes
 
     def open_fds(self, pid: int) -> int:
         try:
-            return len(list(Path(f"/proc/{pid}/fd").iterdir()))
-        except PermissionError:
+            return psutil.Process(pid).num_fds()
+        except psutil.AccessDenied:
             return -1
 
     def load_average(self) -> tuple[float, float, float]:
-        parts = Path("/proc/loadavg").read_text().split()
-        return float(parts[0]), float(parts[1]), float(parts[2])
+        one, five, fifteen = psutil.getloadavg()
+        return one, five, fifteen
 
     def memory_usage(self) -> dict:
-        data = {}
-        for line in Path("/proc/meminfo").read_text().splitlines():
-            if ":" in line:
-                key, value = line.split(":", 1)
-                data[key.strip()] = int(value.strip().split()[0])
-        total_mb = round(data.get("MemTotal", 0) / 1024, 2)
-        free_mb = round(data.get("MemFree", 0) / 1024, 2)
-        cached_mb = round((data.get("Cached", 0) + data.get("Buffers", 0)) / 1024, 2)
+        memory = psutil.virtual_memory()
+        swap = psutil.swap_memory()
+        total_mb = _to_mb(memory.total)
+        free_mb = _to_mb(memory.free)
+        cached_mb = _to_mb(getattr(memory, "cached", 0) + getattr(memory, "buffers", 0))
         used_mb = round(max(total_mb - free_mb - cached_mb, 0), 2)
-        swap_used_mb = round(max(data.get("SwapTotal", 0) - data.get("SwapFree", 0), 0) / 1024, 2)
         return {
             "total_mb": total_mb,
             "used_mb": used_mb,
             "cached_mb": cached_mb,
             "free_mb": free_mb,
-            "swap_used_mb": swap_used_mb,
+            "swap_used_mb": _to_mb(swap.used),
             "percent": round(used_mb / total_mb * 100, 2) if total_mb else 0.0,
         }
 
     def disk_usage(self, path: Path) -> dict:
+        """statvfs, not psutil.disk_usage: psutil reports free space as the
+        user-available blocks, which would drop the filesystem's reserved
+        blocks out of total = used + free and move every recorded disk figure."""
         stats = os.statvfs(path)
         total_bytes = stats.f_blocks * stats.f_frsize
         free_bytes = stats.f_bfree * stats.f_frsize
         used_bytes = total_bytes - free_bytes
         return {
-            "total_mb": round(total_bytes / 1024**2, 2),
-            "used_mb": round(used_bytes / 1024**2, 2),
-            "free_mb": round(free_bytes / 1024**2, 2),
+            "total_mb": _to_mb(total_bytes),
+            "used_mb": _to_mb(used_bytes),
+            "free_mb": _to_mb(free_bytes),
             "percent": round(used_bytes / total_bytes * 100, 2) if total_bytes else 0.0,
         }
 
     def storage_usage(self) -> dict:
         return {"disk": self.disk_usage(self.bench_path)}
+
+
+def _to_mb(value_bytes: float) -> float:
+    return round(value_bytes / 1024**2, 2)

--- a/pilot/core/server/monitoring_proc.py
+++ b/pilot/core/server/monitoring_proc.py
@@ -56,10 +56,10 @@ class ProcMetricsReader:
         """Proportional set size where the platform reports it, unique set size
         otherwise - both charge shared pages more honestly than RSS."""
         info = psutil.Process(pid).memory_full_info()
-        shared_aware = getattr(info, "pss", None)
+        shared_aware: int | None = getattr(info, "pss", None)
         if shared_aware is None:
-            shared_aware = getattr(info, "uss", 0)
-        return int(shared_aware / 1024)
+            shared_aware = int(getattr(info, "uss", 0))
+        return shared_aware // 1024
 
     def io_bytes(self, pid: int) -> tuple[int, int]:
         process = psutil.Process(pid)

--- a/tests/pilot/core/test_monitor.py
+++ b/tests/pilot/core/test_monitor.py
@@ -1,12 +1,15 @@
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import PropertyMock, patch
 
+import psutil
 import pytest
 
 from pilot.config import BenchConfig, MariaDBConfig, RedisConfig, WorkerConfig
 from pilot.core.bench import Bench
 from pilot.core.server.monitoring import Monitor, MonitorConfigurator
+from pilot.core.server.monitoring_proc import CPU_STAT_FIELDS
 
 
 @pytest.fixture(autouse=True)
@@ -187,18 +190,93 @@ def test_compute_io_reports_bytes_per_sec(tmp_path: Path) -> None:
     assert monitor._disk_io == {"read_bytes_per_sec": 1000.0, "write_bytes_per_sec": 500.0}
 
 
+def _disk_counter(read_bytes: int, write_bytes: int) -> SimpleNamespace:
+    return SimpleNamespace(read_bytes=read_bytes, write_bytes=write_bytes)
+
+
+def _net_counter(bytes_recv: int, bytes_sent: int) -> SimpleNamespace:
+    return SimpleNamespace(bytes_recv=bytes_recv, bytes_sent=bytes_sent)
+
+
 def test_disk_io_fields_ignores_partitions(tmp_path: Path) -> None:
+    """Partitions and dm-/loop devices double-count the disk underneath them."""
     monitor = _make_monitor(_make_bench(tmp_path))
-    diskstats = tmp_path / "diskstats"
-    diskstats.write_text(
-        "   8       0 sda 100 0 2000 0 50 0 1000 0 0 0 0\n"
-        "   8       1 sda1 40 0 800 0 20 0 400 0 0 0 0\n"
-        "  259       0 nvme0n1 10 0 200 0 5 0 100 0 0 0 0\n"
-    )
-    with patch(
-        "pilot.core.server.monitoring_proc.Path",
-        side_effect=lambda p: diskstats if p == "/proc/diskstats" else Path(p),
-    ):
+    counters = {
+        "sda": _disk_counter(2000, 1000),
+        "sda1": _disk_counter(800, 400),
+        "nvme0n1": _disk_counter(200, 100),
+        "dm-0": _disk_counter(9999, 9999),
+        "loop0": _disk_counter(5555, 5555),
+    }
+    with patch("psutil.disk_io_counters", return_value=counters):
         result = monitor._disk_io_fields()
 
-    assert result == {"read_bytes": (2000 + 200) * 512, "write_bytes": (1000 + 100) * 512}
+    assert result == {"read_bytes": 2000 + 200, "write_bytes": 1000 + 100}
+
+
+def test_net_fields_excludes_loopback(tmp_path: Path) -> None:
+    monitor = _make_monitor(_make_bench(tmp_path))
+    counters = {
+        "eth0": _net_counter(1000, 200),
+        "lo": _net_counter(9999, 9999),
+        "lo0": _net_counter(8888, 8888),
+    }
+    with patch("psutil.net_io_counters", return_value=counters):
+        result = monitor._net_fields()
+
+    assert result == {"rx_bytes": 1000, "tx_bytes": 200}
+
+
+def test_cpu_fields_defaults_absent_states_to_zero(tmp_path: Path) -> None:
+    """macOS reports no iowait/irq/softirq/steal; the sample must still complete."""
+    monitor = _make_monitor(_make_bench(tmp_path))
+    times = SimpleNamespace(user=100.0, nice=1.0, system=50.0, idle=800.0)
+    with patch("psutil.cpu_times", return_value=times):
+        fields = monitor._cpu_fields()
+
+    assert set(fields) == set(CPU_STAT_FIELDS)
+    assert fields["user"] == 100.0
+    assert fields["iowait"] == 0.0
+    assert fields["steal"] == 0.0
+
+
+def test_proc_memory_falls_back_to_uss_without_pss(tmp_path: Path) -> None:
+    """Linux reports PSS; platforms without it fall back to USS, not to zero."""
+    monitor = _make_monitor(_make_bench(tmp_path))
+    process = SimpleNamespace(memory_full_info=lambda: SimpleNamespace(uss=4 * 1024 * 1024))
+    with patch("psutil.Process", return_value=process):
+        assert monitor._proc_memory_kb(1234) == 4096
+
+    process = SimpleNamespace(
+        memory_full_info=lambda: SimpleNamespace(pss=2 * 1024 * 1024, uss=4 * 1024 * 1024)
+    )
+    with patch("psutil.Process", return_value=process):
+        assert monitor._proc_memory_kb(1234) == 2048
+
+
+def test_io_bytes_is_zero_where_the_platform_has_no_counters(tmp_path: Path) -> None:
+    monitor = _make_monitor(_make_bench(tmp_path))
+    with patch("psutil.Process", return_value=SimpleNamespace()):
+        assert monitor._io_bytes(1234) == (0, 0)
+
+    process = SimpleNamespace(
+        io_counters=lambda: SimpleNamespace(read_bytes=500, write_bytes=250)
+    )
+    with patch("psutil.Process", return_value=process):
+        assert monitor._io_bytes(1234) == (500, 250)
+
+
+def test_collect_application_metrics_marks_a_vanished_process_missing(tmp_path: Path) -> None:
+    """A pid that exits between resolution and reading must not kill the tick."""
+    monitor = _make_monitor(_make_bench(tmp_path / "my-bench"))
+    monitor._targets = {"web": 4242}
+    app_log = tmp_path / "app.log"
+
+    with (
+        patch.object(type(monitor), "log_path", new_callable=PropertyMock, return_value=app_log),
+        patch("psutil.Process", side_effect=psutil.NoSuchProcess(4242)),
+    ):
+        monitor.collect_application_metrics()
+
+    entry = json.loads(app_log.read_text().splitlines()[-1])
+    assert entry["processes"] == [{"service": "web", "pid": 4242, "missing": True}]


### PR DESCRIPTION
- Better monitoring polling instead of hard 10s bound, we poll immediately after in case we don't have two points.
- Replace monitoring with psutils instead of /proc reads. (more reliable)