### PR TITLE
chore(rename): use pilot as the CLI command

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,7 +5,7 @@ on:
     branches: [develop]
   pull_request:
     branches: [develop]
-  # Heavy (bench init clones the framework); allow manual runs too.
+  # Heavy (pilot init clones the framework); allow manual runs too.
   workflow_dispatch:
 
 jobs:
@@ -80,7 +80,7 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install yarn, bench and e2e deps
+      - name: Install yarn, Pilot and e2e deps
         run: |
           npm install -g yarn
           pip install -e ".[test,admin,e2e]"
@@ -108,8 +108,8 @@ jobs:
 
       - name: Run e2e tests
         working-directory: tests/e2e
-        # BENCH_BIN is intentionally unset so the harness uses the repo launcher
-        # (<repo>/bench), which writes to <repo>/benches where the harness reads.
+        # PILOT_BIN is intentionally unset so the harness uses the repo launcher
+        # (<repo>/bin/pilot), which writes to <repo>/benches where the harness reads.
         run: pytest -v -s --durations=10
         env:
           E2E_MARIADB_PASSWORD: admin

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Install yarn and bench
+      - name: Install yarn and Pilot
         run: |
           npm install -g yarn
           pip install -e ".[test,admin]"
@@ -55,14 +55,14 @@ jobs:
           cp tests/fixtures/ci_bench.toml benches/ci-bench/bench.toml
           cp tests/fixtures/ci_common_config.toml benches/common_config.toml
 
-      - name: bench init
-        run: bench init -b ci-bench
+      - name: Pilot init
+        run: pilot init -b ci-bench
         timeout-minutes: 45
 
       - name: Create sites
         run: |
-          bench new-site site1.localhost --admin-password admin
-          bench new-site site2.localhost --admin-password admin
+          pilot new-site site1.localhost --admin-password admin
+          pilot new-site site2.localhost --admin-password admin
 
       - name: Verify sites exist
         run: |
@@ -89,8 +89,8 @@ jobs:
           $PYTHON -m frappe.utils.bench_helper frappe --site site1.localhost clear-cache
           $PYTHON -m frappe.utils.bench_helper frappe --site site2.localhost clear-cache
 
-      - name: bench build
-        run: bench build
+      - name: Pilot build
+        run: pilot build
 
       # Non-production tests rely on the redis started above. Production tests
       # manage their own redis, so they run separately after that redis is

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-# Benches (created by `bench new`)
+# Benches (created by `pilot new`)
 /benches/
 
-# Rootless per-host database servers (created by `bench init`)
+# Rootless per-host database servers (created by `pilot init`)
 /databases/
 
 # Local ad-hoc screenshots

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ curl -fsSL https://raw.githubusercontent.com/frappe/pilot/develop/install.sh | b
 Create a bench and launch the setup wizard:
 
 ```bash
-bench new dev-bench
-bench -b dev-bench start
+pilot new dev-bench
+pilot -b dev-bench start
 ```
 
 The first `start` will print the url to access the admin wizard. The wizard asks for the Admin password, database settings, and Frappe source settings, then initializes the bench with live task progress.
@@ -65,17 +65,17 @@ Common commands:
 
 | Command | Purpose |
 |---|---|
-| `bench new <name>` | Create a bench and `bench.toml` |
-| `bench ls` | List benches, status, production state, and Admin URL |
-| `bench -b <name> init` | Initialize a bench from `bench.toml` |
-| `bench -b <name> start` | Start development processes |
-| `bench -b <name> stop` | Stop development processes |
-| `bench -b <name> get-app <repo>` | Clone and install an app |
-| `bench -b <name> new-site <site>` | Create a site |
-| `bench -b <name> update` | Pull apps, install deps, build assets, and migrate sites |
-| `bench -b <name> setup production` | Configure process manager, nginx, Admin domain, and optional TLS |
-| `bench -b <name> restart` | Restart production processes |
-| `bench -b <name> remove production` | Remove production deployment files and services |
+| `pilot new <name>` | Create a bench and `bench.toml` |
+| `pilot ls` | List benches, status, production state, and Admin URL |
+| `pilot -b <name> init` | Initialize a bench from `bench.toml` |
+| `pilot -b <name> start` | Start development processes |
+| `pilot -b <name> stop` | Stop development processes |
+| `pilot -b <name> get-app <repo>` | Clone and install an app |
+| `pilot -b <name> new-site <site>` | Create a site |
+| `pilot -b <name> update` | Pull apps, install deps, build assets, and migrate sites |
+| `pilot -b <name> setup production` | Configure process manager, nginx, Admin domain, and optional TLS |
+| `pilot -b <name> restart` | Restart production processes |
+| `pilot -b <name> remove production` | Remove production deployment files and services |
 
 For the full command list, see [Commands](docs/commands.md).
 
@@ -122,8 +122,8 @@ Apps and sites also exist on disk under the bench. See [Configuration](docs/conf
 Production setup writes process-manager config, nginx integration, Admin routing, monitoring config, and optional Let's Encrypt certificates.
 
 ```bash
-bench -b main setup production --admin-domain admin.example.com
-bench -b main setup production --admin-domain admin.example.com --tls --letsencrypt-email ops@example.com
+pilot -b main setup production --admin-domain admin.example.com
+pilot -b main setup production --admin-domain admin.example.com --tls --letsencrypt-email ops@example.com
 ```
 
 The Admin domain is required in production. Set `admin.tls = false` when HTTPS terminates at an upstream proxy.
@@ -165,14 +165,14 @@ Use a source checkout when working on Pilot:
 ```bash
 git clone https://github.com/frappe/pilot ~/pilot
 cd ~/pilot
-export PATH="$PWD:$PATH"
+export PATH="$PWD/bin:$PATH"
 ```
 
 Create a development bench:
 
 ```bash
-bench new dev
-bench -b dev start
+pilot new dev
+pilot -b dev start
 ```
 
 Useful development toggles in `bench.toml`:

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
-# Bench CLI Spec
+# Pilot CLI Spec
 
-Bench CLI manages local and production Frappe benches with a small object model: `Server`, `Bench`, `Site`, `App`, and the database engines behind a bench.
+Pilot manages local and production Frappe benches with a small object model: `Server`, `Bench`, `Site`, `App`, and the database engines behind a bench.
 
 The command line and Admin API should stay thin. They parse input, authorize the request, start tasks when needed, and delegate work to `pilot.core`.
 

--- a/admin/backend/frontend.py
+++ b/admin/backend/frontend.py
@@ -25,7 +25,7 @@ def ensure_admin_frontend(on_progress: Callable[[str], None] = lambda message: N
     if _has_admin_dist(root):
         return
     raise BenchError(
-        "Admin UI is missing from this release. Reinstall bench-cli, or run it from a source checkout."
+        "Admin UI is missing from this release. Reinstall Pilot, or run it from a source checkout."
     )
 
 
@@ -92,7 +92,7 @@ def _find_frontend() -> Path:
     if (candidate / "package.json").exists():
         return candidate
     raise BenchError(
-        "admin/frontend/dashboard not found. This command requires the bench-cli source directory "
+        "admin/frontend/dashboard not found. This command requires the Pilot source directory "
         "with admin/frontend/dashboard/."
     )
 
@@ -104,7 +104,7 @@ def _find_editor() -> Path:
     if (candidate / "package.json").exists():
         return candidate
     raise BenchError(
-        "admin/frontend/editor not found. This command requires the bench-cli source directory "
+        "admin/frontend/editor not found. This command requires the Pilot source directory "
         "with admin/frontend/editor/."
     )
 
@@ -116,7 +116,7 @@ def _find_in_app_embed() -> Path:
     if (candidate / "package.json").exists():
         return candidate
     raise BenchError(
-        "admin/frontend/in-app-embed not found. This command requires the bench-cli source directory "
+        "admin/frontend/in-app-embed not found. This command requires the Pilot source directory "
         "with admin/frontend/in-app-embed/."
     )
 

--- a/admin/frontend/dashboard/src/components/benches/NewBenchDialog.vue
+++ b/admin/frontend/dashboard/src/components/benches/NewBenchDialog.vue
@@ -56,7 +56,7 @@ function stopElapsed() {
 }
 
 // Whether the *current* bench is running in production. A dev bench (started
-// with `bench start`) most likely has no systemd/supervisor configured, so
+// with `pilot start`) most likely has no systemd/supervisor configured, so
 // auto-provisioning a managed bench from the UI would silently fail or confuse.
 // In that case we point the user at the CLI instead.
 const isProduction = ref(null)
@@ -270,7 +270,7 @@ async function createBench() {
           </p>
           <pre
             class="bg-surface-gray-2 px-3 py-2.5 rounded-lg text-ink-gray-8 text-sm select-all"
-          >bench new my-bench</pre>
+          >pilot new my-bench</pre>
         </div>
 
         <!-- Production bench: a process manager is configured, so we create the

--- a/admin/frontend/dashboard/src/components/settings/Firewall.vue
+++ b/admin/frontend/dashboard/src/components/settings/Firewall.vue
@@ -8,7 +8,7 @@
         <span class="text-ink-gray-6 text-p-sm"
           >These rules take effect only in production (they're applied by nginx). This bench isn't
           deployed, so nothing is enforced until you run
-          <span class="font-mono text-xs">bench setup production</span>.</span
+          <span class="font-mono text-xs">pilot setup production</span>.</span
         >
       </template>
     </Alert>

--- a/admin/frontend/dashboard/src/components/settings/Version.vue
+++ b/admin/frontend/dashboard/src/components/settings/Version.vue
@@ -10,8 +10,8 @@
         This is a development install. Update it from a terminal:
       </p>
       <pre class="p-3 bg-surface-gray-2 rounded overflow-x-auto text-ink-gray-8 text-xs">git pull
-bench admin build
-bench admin upgrade</pre>
+pilot admin build
+pilot admin upgrade</pre>
       <p class="text-ink-gray-5 text-p-sm">The last step restarts the admin service.</p>
     </div>
 

--- a/admin/frontend/dashboard/src/components/settings/Waf.vue
+++ b/admin/frontend/dashboard/src/components/settings/Waf.vue
@@ -16,7 +16,7 @@
           <span class="text-ink-gray-6 text-p-sm"
             >The WAF takes effect only in production (it's applied by nginx). This bench isn't
             deployed, so nothing is enforced until you run
-            <span class="font-mono text-xs">bench setup production</span>.</span
+            <span class="font-mono text-xs">pilot setup production</span>.</span
           >
         </template>
       </Alert>
@@ -31,7 +31,7 @@
           <span class="text-ink-gray-6 text-p-sm"
             >The ModSecurity module isn't installed on this host, so the WAF stays inactive even
             when enabled. Redeploy production (<span class="font-mono text-xs"
-              >bench setup production</span
+              >pilot setup production</span
             >) to install it, then it takes effect.</span
           >
         </template>

--- a/admin/frontend/dashboard/src/composables/setup/useSetup.js
+++ b/admin/frontend/dashboard/src/composables/setup/useSetup.js
@@ -102,7 +102,7 @@ export function useSetup() {
     isInstalling.value && showStreamDetails.value ? 'max-w-2xl' : 'max-w-lg',
   )
   const isDone = computed(() => currentStep.value === 'done')
-  const benchCommand = computed(() => (benchName.value ? `bench -b ${benchName.value}` : 'bench'))
+  const pilotCommand = computed(() => (benchName.value ? `pilot -b ${benchName.value}` : 'pilot'))
   const stepTitle = computed(() => {
     if (isDone.value && isProductionHandoff.value) return 'Finishing setup'
     return STEP_TITLES[currentStep.value] || benchName.value
@@ -120,7 +120,7 @@ export function useSetup() {
       postgresPasswordConfigured.value = config.postgres_password_configured === true
       // Bench arrived with production already chosen (the admin UI's "New Bench"
       // flow) - the wizard's task will bring up production itself, so the 'done'
-      // step shouldn't tell the user to run `bench setup production` by hand.
+      // step shouldn't tell the user to run `pilot setup production` by hand.
       // The flattened config renders an unset manager as the literal string
       // "none" (see BenchTomlBuilder._flatten), not an empty value.
       const processManager = config.production_process_manager
@@ -345,7 +345,7 @@ export function useSetup() {
     isLinux,
     isProductionHandoff,
     isDone,
-    benchCommand,
+    pilotCommand,
     terminal,
     streamUrl,
     streamStatus,

--- a/admin/frontend/dashboard/src/pages/auth/Login.vue
+++ b/admin/frontend/dashboard/src/pages/auth/Login.vue
@@ -85,7 +85,7 @@
           <li>
             Run
             <code class="bg-surface-gray-2 px-1 py-0.5 rounded font-mono text-ink-gray-8"
-              >bench -b {{ session.benchName }} set-admin-password</code
+              >pilot -b {{ session.benchName }} set-admin-password</code
             >
           </li>
         </ol>

--- a/admin/frontend/dashboard/src/pages/setup/Setup.vue
+++ b/admin/frontend/dashboard/src/pages/setup/Setup.vue
@@ -122,7 +122,7 @@
             <p class="font-medium text-ink-gray-6 text-xs">Develop locally</p>
             <code
               class="block bg-surface-gray-2 mt-1 px-2 py-1.5 rounded font-mono text-ink-gray-8 text-sm select-all"
-              >{{ benchCommand }}
+              >{{ pilotCommand }}
               start</code
             >
           </div>
@@ -130,13 +130,13 @@
             <p class="font-medium text-ink-gray-6 text-xs">Deploy to production</p>
             <code
               class="block bg-surface-gray-2 mt-1 px-2 py-1.5 rounded font-mono text-ink-gray-8 text-sm select-all"
-              >{{ benchCommand }}
+              >{{ pilotCommand }}
               setup production --admin-domain &lt;your-domain&gt; --tls --letsencrypt-email
               &lt;you@example.com&gt;</code
             >
           </div>
           <p class="text-ink-gray-5 text-xs">
-            <code class="font-mono">{{ benchCommand }} start</code>
+            <code class="font-mono">{{ pilotCommand }} start</code>
             reloads this page automatically once the bench is back.
           </p>
         </div>
@@ -230,7 +230,7 @@ const {
   isLinux,
   isProductionHandoff,
   isDone,
-  benchCommand,
+  pilotCommand,
   terminal,
   streamUrl,
   streamStatus,

--- a/bin/pilot
+++ b/bin/pilot
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 """
-Bench CLI entry point.
+Pilot CLI entry point.
 
 Requires Python 3.11+. No installation, no venv activation needed.
 All dependencies are stdlib only. Admin UI uses its own isolated venv
-(created automatically on first 'bench build-admin' or 'bench start').
+(created automatically on first 'pilot admin build' or 'pilot start').
 """
 
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.realpath(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.realpath(os.path.abspath(__file__)))))
 
 from pilot.cli import main
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Bench CLI is organized around a few domain objects. External surfaces should delegate to those objects instead of doing orchestration directly.
+Pilot is organized around a few domain objects. External surfaces should delegate to those objects instead of doing orchestration directly.
 
 ## Directory Map
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,74 +2,74 @@
 
 Commands are a user interface over the core object model. Keep command classes small: parse arguments, resolve a bench, and call a core object or task.
 
-Use `bench --help` and `bench <command> --help` for exact flags.
+Use `pilot --help` and `pilot <command> --help` for exact flags.
 
 ## Bench Commands
 
-- `bench new NAME`: create a new bench.
-- `bench init`: initialize a bench from `bench.toml`.
-- `bench ls`: list benches in the fixed benches directory.
-- `bench drop --bench NAME`: remove a bench.
+- `pilot new NAME`: create a new bench.
+- `pilot init`: initialize a bench from `bench.toml`.
+- `pilot ls`: list benches in the fixed benches directory.
+- `pilot drop --bench NAME`: remove a bench.
 
 Bench commands with `--bench NAME` can run from outside the bench directory. `Bench("name")` resolves the same fixed benches directory in Python code.
 
 ## Runtime Commands
 
-- `bench start`: start bench processes.
-- `bench stop`: stop bench processes.
-- `bench restart`: restart the production workload.
-- `bench build`: build assets or download prebuilt assets when available.
-- `bench frappe -- ...`: pass through to Frappe's bench helper.
+- `pilot start`: start bench processes.
+- `pilot stop`: stop bench processes.
+- `pilot restart`: restart the production workload.
+- `pilot build`: build assets or download prebuilt assets when available.
+- `pilot frappe -- ...`: pass through to Frappe's bench helper.
 
 Some runtime commands support all benches when invoked with the CLI option for all-bench execution.
 
 ## App Commands
 
-- `bench new-app APP`: scaffold a new Frappe app under `apps/` and install it. Prompts for title, description, publisher, email, license, GitHub workflow, and branch; pass any of `--title/--description/--publisher/--email/--license/--branch/--github-workflow` to skip prompts (branch defaults to `develop`).
-- `bench get-app REPO_OR_NAME`: clone and install an app into the bench.
-- `bench list-apps`: list apps present in the bench.
-- `bench install-app APP --site SITE`: install apps on a site.
-- `bench uninstall-app APP --site SITE`: uninstall apps from a site.
-- `bench remove-app APP`: remove an app from the bench when no site needs it.
+- `pilot new-app APP`: scaffold a new Frappe app under `apps/` and install it. Prompts for title, description, publisher, email, license, GitHub workflow, and branch; pass any of `--title/--description/--publisher/--email/--license/--branch/--github-workflow` to skip prompts (branch defaults to `develop`).
+- `pilot get-app REPO_OR_NAME`: clone and install an app into the bench.
+- `pilot list-apps`: list apps present in the bench.
+- `pilot install-app APP --site SITE`: install apps on a site.
+- `pilot uninstall-app APP --site SITE`: uninstall apps from a site.
+- `pilot remove-app APP`: remove an app from the bench when no site needs it.
 
 Long app operations should use task classes from `pilot.tasks`.
 
 ## Site Commands
 
-- `bench new-site SITE`: create a site and add it to bench config.
-- `bench rename-site OLD NEW`: rename a site.
-- `bench list-site-apps SITE`: list apps installed on a site.
-- `bench set-admin-password SITE`: update the site Administrator password.
+- `pilot new-site SITE`: create a site and add it to bench config.
+- `pilot rename-site OLD NEW`: rename a site.
+- `pilot list-site-apps SITE`: list apps installed on a site.
+- `pilot set-admin-password SITE`: update the site Administrator password.
 
 Site behavior belongs on `Site` or a module under `pilot/core/site`.
 
 ## Setup Commands
 
-- `bench setup requirements`: install Python and JS requirements.
-- `bench setup config`: regenerate config files from `bench.toml`.
-- `bench setup nginx`: render nginx config.
-- `bench setup letsencrypt`: issue or refresh TLS certificates.
-- `bench setup production`: deploy process manager and nginx integration.
-- `bench remove production`: remove production deployment files and services.
+- `pilot setup requirements`: install Python and JS requirements.
+- `pilot setup config`: regenerate config files from `bench.toml`.
+- `pilot setup nginx`: render nginx config.
+- `pilot setup letsencrypt`: issue or refresh TLS certificates.
+- `pilot setup production`: deploy process manager and nginx integration.
+- `pilot remove production`: remove production deployment files and services.
 
 Production setup uses the bench config and system managers. The command should not duplicate nginx, process manager, or certificate logic.
 
 ## Task Worker Commands
 
-- `bench tasks status`: show Admin task worker state.
-- `bench tasks start`: allow queued Admin tasks to run.
-- `bench tasks stop`: drain the worker and leave queued tasks waiting.
+- `pilot tasks status`: show Admin task worker state.
+- `pilot tasks start`: allow queued Admin tasks to run.
+- `pilot tasks stop`: drain the worker and leave queued tasks waiting.
 
 These commands control the task worker, not individual Frappe workers.
 
 ## Admin Commands
 
-- `bench admin build`: rebuild Admin frontend assets from source.
-- `bench admin upgrade`: update bench-cli to the latest version, run pending upgrade patches (pre_update before, post_update after), and restart the admin service.
-- `bench admin enroll`: exchange the bootstrap token for this bench's Central credential.
-- `bench admin set-central-config`: store Central endpoint and Pilot auth token.
-- `bench admin issue-site-token`: issue a scoped site-to-bench API token.
-- `bench admin run-patches [--phase pre_update|post_update|all]`: run pending bench-cli upgrade patches by hand (see [Configuration](configuration.md#common-config)); `bench admin upgrade` already runs both phases automatically.
+- `pilot admin build`: rebuild Admin frontend assets from source.
+- `pilot admin upgrade`: update Pilot to the latest version, run pending upgrade patches (pre_update before, post_update after), and restart the admin service.
+- `pilot admin enroll`: exchange the bootstrap token for this bench's Central credential.
+- `pilot admin set-central-config`: store Central endpoint and Pilot auth token.
+- `pilot admin issue-site-token`: issue a scoped site-to-bench API token.
+- `pilot admin run-patches [--phase pre_update|post_update|all]`: run pending Pilot upgrade patches by hand (see [Configuration](configuration.md#common-config)); `pilot admin upgrade` already runs both phases automatically.
 
 Admin commands live in `pilot/commands/admin`. Backend route behavior lives under `admin/backend/api/v1`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,4 +144,4 @@ jwks_audience = "bench-fleet"
 
 The host-wide system/DB/slow-query monitor log paths (`system_log_path`/`db_log_path`/`slow_query_log_path`) are not configurable at all, in `bench.toml` or `common_config.toml` - they're fixed at `cli_root()/system/logs/{system-stats.log,db-stats.log,slow-queries.json}` (see `pilot/config/monitor.py`).
 
-A pre-upgrade bench whose `bench.toml` still carries these fields directly is migrated by the `merge_common_config` patch - see [pilot/patches](../pilot/patches) and `bench admin run-patches`.
+A pre-upgrade bench whose `bench.toml` still carries these fields directly is migrated by the `merge_common_config` patch - see [pilot/patches](../pilot/patches) and `pilot admin run-patches`.

--- a/docs/domain-provider.md
+++ b/docs/domain-provider.md
@@ -11,7 +11,7 @@ The implementation contract lives in `pilot/core/adapters/domain_provider.py`.
 
 ## Install
 
-Build one executable named exactly `bench-domain-provider`, make it executable, and put it on `PATH` for the user running bench and the Admin service.
+Build one executable named exactly `bench-domain-provider`, make it executable, and put it on `PATH` for the user running Pilot and the Admin service.
 
 ```sh
 install -m 0755 ./my-domain-provider /usr/local/bin/bench-domain-provider
@@ -154,4 +154,4 @@ if __name__ == "__main__":
 ./bench-domain-provider register taken.example.com
 ```
 
-Install it on `PATH`, then test `bench new-site` with a wildcard-matching name and Add/Remove Domain in the Admin UI.
+Install it on `PATH`, then test `pilot new-site` with a wildcard-matching name and Add/Remove Domain in the Admin UI.

--- a/docs/production.md
+++ b/docs/production.md
@@ -21,14 +21,14 @@ tls = true
 ## Setup Flow
 
 ```bash
-bench setup requirements
-bench setup config
-bench setup nginx
-bench setup production --admin-domain admin.example.com
-bench setup letsencrypt
+pilot setup requirements
+pilot setup config
+pilot setup nginx
+pilot setup production --admin-domain admin.example.com
+pilot setup letsencrypt
 ```
 
-`bench setup production` writes process manager config and nginx integration. `bench remove production` removes production deployment files and services while keeping logs, certificates, and admin domain config.
+`pilot setup production` writes process manager config and nginx integration. `pilot remove production` removes production deployment files and services while keeping logs, certificates, and admin domain config.
 
 ## Process Managers
 
@@ -36,15 +36,15 @@ Supported managers are `systemd` and `supervisor`.
 
 Runtime commands:
 
-- `bench start`
-- `bench stop`
-- `bench restart`
+- `pilot start`
+- `pilot stop`
+- `pilot restart`
 
-`bench restart` targets the production workload. Local development start/stop uses bench runtime managers.
+`pilot restart` targets the production workload. Local development start/stop uses bench runtime managers.
 
 ## Nginx And TLS
 
-Nginx config is rendered from bench and site state. Regenerate it with `bench setup nginx` or `bench setup config`.
+Nginx config is rendered from bench and site state. Regenerate it with `pilot setup nginx` or `pilot setup config`.
 
 Let's Encrypt setup uses configured domains and should run after nginx is rendered. Site domain changes should reload nginx through site/domain code.
 

--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ set -e
 # their derivatives via ID_LIKE. Unknown distros fall back to apt.
 #
 # Two passes. As root it prepares the host and the bench user, then stops.
-# As that user it installs bench itself, needing no privileges at all.
+# As that user it installs Pilot itself, needing no privileges at all.
 
 # ── configuration ─────────────────────────────────────────────────────────────
 # All three point at the same GitHub repo; override PILOT_GITHUB_SLUG to install
@@ -175,11 +175,11 @@ ensure_homebrew() {
 }
 
 # ── system packages ───────────────────────────────────────────────────────────
-# Everything bench needs at runtime is installed here, as root, once. The bench
+# Everything Pilot needs at runtime is installed here, as root, once. The bench
 # user has no passwordless sudo, so anything missing from this list becomes a
-# password prompt in the middle of `bench init` or a deploy.
+# password prompt in the middle of `pilot init` or a deploy.
 
-# Bare images ship almost nothing: the tools this script and bench both need
+# Bare images ship almost nothing: the tools this script and Pilot both need
 # before first use, plus the build deps for the admin venv and frappe wheels.
 bootstrap_packages() {
     case "$DISTRO" in
@@ -206,7 +206,7 @@ add_distro_repos() {
 
 # One MariaDB, PostgreSQL and Redis per bench user (rootless, systemctl --user),
 # shared across that user's benches. The dev headers are for the Python client
-# libraries frappe's virtualenv compiles during `bench init`.
+# libraries frappe's virtualenv compiles during `pilot init`.
 install_database_engines() {
     case "$DISTRO" in
         macos)
@@ -221,7 +221,7 @@ install_database_engines() {
     esac
 }
 
-# What `bench setup production` needs. Installing the WAF module up front keeps
+# What `pilot setup production` needs. Installing the WAF module up front keeps
 # enabling the WAF later a non-root operation too.
 install_production_packages() {
     case "$DISTRO" in
@@ -255,7 +255,7 @@ install_node() {
 
 # The distro packages auto-start services on their default ports. Benches run
 # their own instances, so free the ports and the memory right away. nginx is
-# started by `bench setup production`, which a sudoers grant already allows.
+# started by `pilot setup production`, which a sudoers grant already allows.
 disable_system_services() {
     case "$DISTRO" in
         macos|unknown) return 0 ;;
@@ -467,10 +467,10 @@ prepare_host() {
     echo ""
     echo "========================================================================"
     echo " User '$BENCH_USER' is ready — base tools, database engines and the"
-    echo " production stack are installed system-wide, so day-to-day bench"
+    echo " production stack are installed system-wide, so day-to-day Pilot"
     echo " commands never need root."
     echo ""
-    echo " bench must NOT be installed as root. Switch to '$BENCH_USER' and run"
+    echo " Pilot must NOT be installed as root. Switch to '$BENCH_USER' and run"
     echo " the installer again:"
     echo ""
     echo "   su - $BENCH_USER"
@@ -482,7 +482,7 @@ prepare_host() {
 # Nothing below here needs privileges: prepare_host granted them all already.
 
 # Only root can turn lingering on. Fail now rather than midway through
-# `bench init`, where systemctl --user finds no bus to talk to.
+# `pilot init`, where systemctl --user finds no bus to talk to.
 require_linger() {
     systemd_booted || return 0
     linger_enabled "$(id -un)" && return 0
@@ -550,19 +550,31 @@ ensure_tzdata() {
 add_path_line() {
     file="$1"; line="$2"
     mkdir -p "$(dirname "$file")"
-    grep -qF 'pilot' "$file" 2>/dev/null && return 0
+    case "$line" in
+        fish_add_path*) legacy_line="fish_add_path \$HOME/pilot" ;;
+        *) legacy_line="export PATH=\"\$HOME/pilot:\$PATH\"" ;;
+    esac
+    if grep -qFx "$legacy_line" "$file" 2>/dev/null; then
+        tmp="$(mktemp)"
+        awk -v old="$legacy_line" -v new="$line" '$0 == old { print new; next } { print }' "$file" > "$tmp"
+        cat "$tmp" > "$file"
+        rm -f "$tmp"
+        echo "Updated Pilot PATH in $file"
+        return 0
+    fi
+    grep -qFx "$line" "$file" 2>/dev/null && return 0
     echo "$line" >> "$file"
-    echo "Added bench to PATH in $file"
+    echo "Added Pilot to PATH in $file"
 }
 
 # Sets RC_FILE to the rc it touched, for the closing hint.
-add_bench_to_path() {
+add_pilot_to_path() {
     # Escaped so $HOME lands literally in the rc file and expands at shell start.
-    export_line="export PATH=\"\$HOME/pilot:\$PATH\""
+    export_line="export PATH=\"\$HOME/pilot/bin:\$PATH\""
     case "$SHELL" in
         */fish)
             RC_FILE="$HOME/.config/fish/config.fish"
-            add_path_line "$RC_FILE" "fish_add_path \$HOME/pilot" ;;
+            add_path_line "$RC_FILE" "fish_add_path \$HOME/pilot/bin" ;;
         */zsh)
             RC_FILE="$HOME/.zshrc"
             add_path_line "$RC_FILE" "$export_line" ;;
@@ -578,7 +590,7 @@ add_bench_to_path() {
             add_path_line "$HOME/.profile" "$export_line" ;;
     esac
 
-    export PATH="$PILOT_DIR:$PATH"
+    export PATH="$PILOT_DIR/bin:$PATH"
     # fish rc syntax is not sh, so never source it back into this shell.
     case "$SHELL" in */fish) RC_FILE=""; return ;; esac
     # Best-effort: shell-specific rc syntax may not parse here, which is fine —
@@ -614,20 +626,21 @@ install_for_user() {
     echo "Setting up your environment..."
     require_linger
     fetch_pilot
-    chmod +x "$PILOT_DIR/bench"
+    rm -f "$PILOT_DIR/bench"
+    chmod +x "$PILOT_DIR/bin/pilot"
     ensure_uv
     ensure_tzdata
-    add_bench_to_path
+    add_pilot_to_path
     ensure_admin_venv
 
     echo ""
-    echo "bench installed to $PILOT_DIR"
+    echo "Pilot installed to $PILOT_DIR"
     echo ""
     echo "Quick start:"
-    echo "  bench new my-bench"
-    echo "  bench start"
+    echo "  pilot new my-bench"
+    echo "  pilot start"
     echo ""
-    echo "If 'bench' is not found, open a new terminal or run: . ${RC_FILE:-$HOME/.bashrc}"
+    echo "If 'pilot' is not found, open a new terminal or run: . ${RC_FILE:-$HOME/.bashrc}"
 }
 
 # ── run ───────────────────────────────────────────────────────────────────────

--- a/pilot/commands/admin/run_patches.py
+++ b/pilot/commands/admin/run_patches.py
@@ -10,7 +10,7 @@ from pilot.commands import Arg, BenchMode, Command
 class RunPatchesCommand(Command):
     name: ClassVar[str] = "run-patches"
     group: ClassVar[str] = "admin"
-    help: ClassVar[str] = "Run pending bench-cli upgrade patches (see pilot/patches/patches.txt)."
+    help: ClassVar[str] = "Run pending Pilot upgrade patches (see pilot/patches/patches.txt)."
     bench_mode: ClassVar[BenchMode] = BenchMode.NONE
 
     phase: Annotated[

--- a/pilot/commands/admin/upgrade.py
+++ b/pilot/commands/admin/upgrade.py
@@ -11,7 +11,7 @@ from pilot.commands import BenchMode, Command
 class UpgradeCommand(Command):
     name: ClassVar[str] = "upgrade"
     group: ClassVar[str] = "admin"
-    help: ClassVar[str] = "Update bench-cli to the latest version and restart the admin service."
+    help: ClassVar[str] = "Update Pilot to the latest version and restart the admin service."
     # OPTIONAL: used only to restart the admin service in production, if one is active.
     bench_mode: ClassVar[BenchMode] = BenchMode.OPTIONAL
 

--- a/pilot/commands/bench/create.py
+++ b/pilot/commands/bench/create.py
@@ -18,7 +18,7 @@ class NewCommand(Command):
         str,
         Arg(
             help="Admin domain for this bench. Optional for development; "
-            "required by 'bench setup production' (pass it there if omitted here)."
+            "required by 'pilot setup production' (pass it there if omitted here)."
         ),
     ] = ""
     # None -> inherit the server-wide value from a sibling bench (default False).

--- a/pilot/commands/bench/list.py
+++ b/pilot/commands/bench/list.py
@@ -20,7 +20,7 @@ class ListCommand(Command):
         benches_dir = cli_root() / "benches"
         rows = self._collect(benches_dir)
         if not rows:
-            self.report("No benches yet. Create one with: bench new <name>")
+            self.report("No benches yet. Create one with: pilot new <name>")
             return
 
         # Column widths sized to content (with sensible minimums).

--- a/pilot/commands/runtime/frappe.py
+++ b/pilot/commands/runtime/frappe.py
@@ -19,7 +19,7 @@ class FrappeCommand(Command):
     def run(self) -> None:
         python = self.bench.env_path / "bin" / "python"
         if not python.exists():
-            raise BenchError("Frappe environment not found. Run 'bench init' first.")
+            raise BenchError("Frappe environment not found. Run 'pilot init' first.")
         result = subprocess.run(
             [*self.bench.frappe_call, "frappe", *self.args],
             cwd=self.bench.sites_path,

--- a/pilot/commands/setup/config.py
+++ b/pilot/commands/setup/config.py
@@ -18,4 +18,4 @@ class UpdateConfigCommand(Command):
         self.report("Updating common_site_config.json...")
         self.bench.rebuild_runtime_config()
         if self.bench.config.production.enabled:
-            self.report("  Note: run 'bench setup nginx' to reload nginx with the new config.")
+            self.report("  Note: run 'pilot setup nginx' to reload nginx with the new config.")

--- a/pilot/config/admin.py
+++ b/pilot/config/admin.py
@@ -53,7 +53,7 @@ class AdminConfig:
                 raise ConfigError(
                     f"admin.domain is required in production but is missing for bench '{bench_name}'. "
                     f"Set it in bench.toml (e.g. admin.example.com) or pass "
-                    f"'bench setup production --admin-domain <domain>'."
+                    f"'pilot setup production --admin-domain <domain>'."
                 )
             return
         if not _HOSTNAME_PATTERN.match(self.domain):

--- a/pilot/config/bench.py
+++ b/pilot/config/bench.py
@@ -214,7 +214,7 @@ class BenchConfig:
     @staticmethod
     def _known_fields(dataclass_type: type, data: dict) -> dict:
         """Drop keys a bench.toml table has that the dataclass no longer
-        declares, so a config written by an older bench-cli still loads."""
+        declares, so a config written by an older Pilot version still loads."""
         known = {f.name for f in fields(dataclass_type)}
         return {k: v for k, v in data.items() if k in known}
 
@@ -624,7 +624,7 @@ class BenchConfig:
             self.workers.groups = _workers_to_groups(value)
         elif key == "production_process_manager":
             # Store the manager preference only. Production is enabled (and the
-            # deployment built) by `bench setup production`, never by editing config.
+            # deployment built) by `pilot setup production`, never by editing config.
             self.production.process_manager = "" if str(value) in ("", "none") else str(value)
         # unknown keys (wizard extras like is_linux) are ignored
 
@@ -827,7 +827,7 @@ _BENCH_KEYS = {
     "default_branch",
     "allow_developer_mode",
 }
-# Keys older bench-cli versions wrote that the parser still tolerates.
+# Keys older Pilot versions wrote that the parser still tolerates.
 _PRODUCTION_LEGACY = {"lightweight", "nginx"}
 _WORKER_LEGACY = {"queue"}
 

--- a/pilot/core/app/dependency_installer.py
+++ b/pilot/core/app/dependency_installer.py
@@ -37,7 +37,7 @@ class AppDependencyInstaller:
                 raise BenchError(
                     f"'{self.app.config.name}' isn't in the marketplace registry, so its "
                     f"dependencies can't be installed automatically. It requires {missing} "
-                    "- run 'bench get-app <repo>' for each of them first, then retry."
+                    "- run 'pilot get-app <repo>' for each of them first, then retry."
                 ) from exc
             return None
 

--- a/pilot/core/bench/creator.py
+++ b/pilot/core/bench/creator.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 class BenchCreator:
     """Creates a bench. Host-shared settings (MariaDB/Postgres server, ACME
     email, admin JWKS trust) live in common_config.toml. Database credentials
-    are generated at `bench init`, not here - see BenchInitializer."""
+    are generated at `pilot init`, not here - see BenchInitializer."""
 
     def __init__(
         self,
@@ -58,7 +58,7 @@ class BenchCreator:
         admin_port = BenchConfig.default_ports()["admin.port"] + offset
         on_progress(f"\nBench '{self.name}' created at {self.target_directory}")
         on_progress("\nNext step:")
-        on_progress("  bench start")
+        on_progress("  pilot start")
         on_progress(f"  Then open http://localhost:{admin_port} - the setup wizard takes it from there.")
 
         return Bench(self.target_directory)

--- a/pilot/core/bench/initializer.py
+++ b/pilot/core/bench/initializer.py
@@ -31,7 +31,7 @@ class BenchInitializer:
         python_env_manager = PythonEnvManager(self.bench)
 
         # Production deployment (process manager, nginx, TLS) is intentionally
-        # NOT done here - it's a separate `bench setup production` step. bench
+        # NOT done here - it's a separate `pilot setup production` step. Pilot
         # init never needs root: system packages/services are installed once
         # by install.sh, and MariaDB/PostgreSQL run as a rootless per-user
         # server (see MariaDBManager/PostgresManager).
@@ -59,8 +59,8 @@ class BenchInitializer:
             action()
 
         on_progress("\nBench initialised. Next steps:")
-        on_progress("  bench new-site site1.example.com   # create your first site")
-        on_progress("  bench start                        # start all processes")
+        on_progress("  pilot new-site site1.example.com   # create your first site")
+        on_progress("  pilot start                        # start all processes")
 
     def _rollback(self, on_progress: Callable[[str], None]) -> None:
         if not self._rollback_actions:
@@ -175,7 +175,7 @@ class BenchInitializer:
         # frappe imports mysqlclient in its __init__.py for every engine, so the
         # MariaDB client headers are always required; postgres benches additionally
         # need libpq headers for psycopg. install.sh provisions them once for the
-        # whole host, so bench init only ever verifies them.
+        # whole host, so pilot init only ever verifies them.
         from pilot.exceptions import BenchError
         from pilot.managers.platform import is_linux
 

--- a/pilot/core/bench/production.py
+++ b/pilot/core/bench/production.py
@@ -142,7 +142,7 @@ class BenchProduction:
         self.bench.config.production.process_manager = ""
         on_progress(f"\nProduction deployment removed for {name}.")
         on_progress("\nRun it locally with:")
-        on_progress(f"  bench -b {name} start")
+        on_progress(f"  pilot -b {name} start")
         on_progress("\nDevelopment admin:")
         on_progress(f"  {admin_url(self.bench.config)}")
 

--- a/pilot/core/bench/runtime.py
+++ b/pilot/core/bench/runtime.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 _DEV_RESTART_MESSAGE = (
     "Restart is available only for production benches managed by\n"
     "systemd or Supervisor.\n\n"
-    "For development, stop the runner and execute `bench start` again."
+    "For development, stop the runner and execute `pilot start` again."
 )
 
 
@@ -154,7 +154,7 @@ class BenchRuntime:
 
         if not (dist / "assets").exists() and not can_build:
             raise BenchError(
-                "Admin UI is missing from this release. Reinstall bench-cli, "
+                "Admin UI is missing from this release. Reinstall Pilot, "
                 "or run it from a source checkout."
             )
         if can_build:
@@ -203,7 +203,7 @@ class BenchRuntime:
         )
 
         if self._is_initialized():
-            on_progress("\nSetup complete. Run 'bench start' to start your bench.\n")
+            on_progress("\nSetup complete. Run 'pilot start' to start your bench.\n")
 
     def _admin_port(self) -> int:
         import tomllib
@@ -251,5 +251,5 @@ def incomplete_production_message(bench: "Bench") -> str:
         f"Bench {bench.config.name} is configured for production, but its {pm}\n"
         f"deployment is incomplete.\n\n"
         f"Repair it with:\n"
-        f"  bench -b {bench.config.name} setup production"
+        f"  pilot -b {bench.config.name} setup production"
     )

--- a/pilot/core/bench/setup.py
+++ b/pilot/core/bench/setup.py
@@ -169,7 +169,7 @@ class ProductionSetup:
 
         if not is_linux():
             print(
-                "Error: bench setup production only runs on Linux servers.\nOn macOS, use 'bench start' for local development.",
+                "Error: pilot setup production only runs on Linux servers.\nOn macOS, use 'pilot start' for local development.",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -250,7 +250,7 @@ class ProductionSetup:
 
     def _start_workload(self) -> None:
         """Start the workload (and admin) so the bench is actually serving once
-        setup completes - otherwise sites 502 until a separate `bench start`."""
+        setup completes - otherwise sites 502 until a separate `pilot start`."""
         from pilot.managers.processes.local import ProcessManager
 
         ProcessManager.for_bench(self.bench).start()

--- a/pilot/core/site/provisioning.py
+++ b/pilot/core/site/provisioning.py
@@ -143,7 +143,7 @@ def validate_new_site(bench: "Bench", name: str, apps: list[str]) -> bool:
     installed = set(apps_txt.read_text().splitlines()) if apps_txt.exists() else set()
     for app in apps:
         if app not in installed:
-            raise BenchError(f"App '{app}' is not installed. Run 'bench get-app <repo>' first.")
+            raise BenchError(f"App '{app}' is not installed. Run 'pilot get-app <repo>' first.")
     return bool(patterns)
 
 

--- a/pilot/core/site/rename.py
+++ b/pilot/core/site/rename.py
@@ -64,14 +64,14 @@ class SiteRename:
             self._run_or_advise(
                 "production setup",
                 lambda: self.bench.setup_production(on_progress=on_progress),
-                f"bench setup production -b {name}",
+                f"pilot setup production -b {name}",
                 on_progress,
             )
         elif ssl_enabled:
             self._run_or_advise(
                 "Let's Encrypt setup",
                 self.bench.setup_letsencrypt,
-                f"bench setup letsencrypt -b {name}",
+                f"pilot setup letsencrypt -b {name}",
                 on_progress,
             )
 

--- a/pilot/integrations/git/base.py
+++ b/pilot/integrations/git/base.py
@@ -12,7 +12,7 @@ from pilot.exceptions import BenchError
 
 # Provider token-generation links surfaced in the UI.
 TOKEN_HELP_URLS = {
-    "github": "https://github.com/settings/tokens/new?scopes=repo&description=Bench+CLI",
+    "github": "https://github.com/settings/tokens/new?scopes=repo&description=Pilot",
 }
 
 

--- a/pilot/integrations/git/github.py
+++ b/pilot/integrations/git/github.py
@@ -31,7 +31,7 @@ class GitHubProvider(GitProvider):
         headers = {
             "Accept": "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
-            "User-Agent": "bench-cli",
+            "User-Agent": "pilot",
         }
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
@@ -84,7 +84,7 @@ class GitHubProvider(GitProvider):
     def fetch_raw_file(self, repo_url: str, path: str, ref: str = "HEAD") -> str:
         owner, repo = parse_github_owner_repo(repo_url)
         url = f"https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}"
-        headers = {"User-Agent": "bench"}
+        headers = {"User-Agent": "pilot"}
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
         req = urllib.request.Request(url, headers=headers)

--- a/pilot/internal/cli/dispatch.py
+++ b/pilot/internal/cli/dispatch.py
@@ -71,9 +71,9 @@ def _implicit_bench_root(benches_dir: Path) -> Path:
             return candidates[0]
         if len(candidates) > 1:
             names = ", ".join(d.name for d in sorted(candidates))
-            raise BenchError(f"Multiple benches found: {names}\nSpecify one with: bench -b <name> <command>")
+            raise BenchError(f"Multiple benches found: {names}\nSpecify one with: pilot -b <name> <command>")
 
-    raise BenchError("No bench found. Create one with: bench new <name>")
+    raise BenchError("No bench found. Create one with: pilot new <name>")
 
 
 def load_bench(context: CliContext, require_explicit: bool = False) -> "Bench":
@@ -213,8 +213,8 @@ def report_elapsed(elapsed: float) -> None:
 
 def available_hint(benches_dir: Path, sort: bool = False) -> str:
     if not benches_dir.is_dir():
-        return "  No benches found. Run: bench new <name>"
+        return "  No benches found. Run: pilot new <name>"
     names = [d.name for d in benches_dir.iterdir() if d.is_dir() and (d / "bench.toml").exists()]
     if not names:
-        return "  No benches found. Run: bench new <name>"
+        return "  No benches found. Run: pilot new <name>"
     return f"  Available: {', '.join(sorted(names) if sort else names)}"

--- a/pilot/internal/cli/registry.py
+++ b/pilot/internal/cli/registry.py
@@ -11,7 +11,7 @@ from pilot.exceptions import BenchError
 from pilot.internal.cli.command import add_command_arguments, command_from_args
 from pilot.internal.cli.dispatch import CliContext, load_bench
 
-# Help text for command groups (e.g. `bench setup ...`).
+# Help text for command groups (e.g. `pilot setup ...`).
 GROUP_HELP = {
     "admin": "Admin control-plane commands.",
     "setup": "Production setup commands.",
@@ -49,7 +49,7 @@ def command_names() -> frozenset[str]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="bench", description="Frappe bench manager")
+    parser = argparse.ArgumentParser(prog="pilot", description="Frappe bench manager")
     parser.add_argument("--verbose", action="store_true", help="Show full tracebacks on error.")
     parser.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompts.")
     parser.add_argument(

--- a/pilot/internal/patch_runner.py
+++ b/pilot/internal/patch_runner.py
@@ -46,7 +46,7 @@ def _run_one(name: str, on_progress: Progress) -> None:
         on_progress(f"Skipping '{name}': no such patch file ({patch_file}).")
         return
     on_progress(f"Running patch '{name}'...")
-    # bench is a plain script, not a pip install, so "pilot" is only on
+    # Pilot is a plain script, not a pip install, so "pilot" is only on
     # sys.path inside this already-running process - a fresh subprocess needs
     # it via PYTHONPATH to import anything from the runtime.
     env = {**os.environ, "PYTHONPATH": str(_CLI_ROOT)}

--- a/pilot/managers/environment.py
+++ b/pilot/managers/environment.py
@@ -38,7 +38,7 @@ class AdminEnvManager:
     def uv(self) -> str:
         uv = shutil.which("uv")
         if not uv:
-            raise RuntimeError("uv not found - run the bench-cli install script to set it up")
+            raise RuntimeError("uv not found - run the Pilot install script to set it up")
         return uv
 
     def ensure(self) -> None:

--- a/pilot/managers/processes/base.py
+++ b/pilot/managers/processes/base.py
@@ -15,8 +15,8 @@ from pilot.managers.processes.local import ProcessDefinition, ProcessManager
 
 
 class UnitGroup(Enum):
-    WORKLOAD = auto()  # web, socketio, workers, redis - what `bench stop` stops
-    ADMIN = auto()  # the control plane - survives `bench stop`
+    WORKLOAD = auto()  # web, socketio, workers, redis - what `pilot stop` stops
+    ADMIN = auto()  # the control plane - survives `pilot stop`
     WEB = auto()  # just web, for reload_workers(web_only=True)
 
 

--- a/pilot/managers/processes/local.py
+++ b/pilot/managers/processes/local.py
@@ -137,7 +137,7 @@ class ProcessManager:
 
     def start(self) -> None:
         if not self.is_configured():
-            raise BenchError(f"Procfile not found at {self.procfile_path}. Run 'bench init' first.")
+            raise BenchError(f"Procfile not found at {self.procfile_path}. Run 'pilot init' first.")
         self.write_config()
         self.pid_file.write_text(str(os.getpid()))
         try:

--- a/pilot/tasks/new_site.py
+++ b/pilot/tasks/new_site.py
@@ -26,7 +26,7 @@ class NewSiteTask(Task):
     def reload_for_site_apps(self) -> None:
         """Provisioning runs install-app, which enqueues jobs that import the
         site's apps. Always reload: an app already on the bench may still predate
-        the running workers, having arrived through `bench get-app`."""
+        the running workers, having arrived through `pilot get-app`."""
         self.bench.reload_workers()
 
     @on_failure

--- a/pilot/tasks/update_cli.py
+++ b/pilot/tasks/update_cli.py
@@ -15,7 +15,7 @@ class UpdateCliTask(Task):
         self.update()
         self.restart_admin()
 
-    @step("update", lambda self: f"Update bench-cli at {cli_root()}")
+    @step("update", lambda self: f"Update Pilot at {cli_root()}")
     def update(self) -> None:
         from pilot.updater import perform_upgrade
 

--- a/pilot/updater.py
+++ b/pilot/updater.py
@@ -15,6 +15,7 @@ from pilot.utils import cli_root, extract_tar_archive
 RELEASE_REPO = "frappe/pilot"
 _RELEASES_API = f"https://api.github.com/repos/{RELEASE_REPO}/releases?per_page=1"
 _TARBALL_ASSET = "pilot.tar.gz"
+_OBSOLETE_TOP_LEVEL_ENTRIES = ("bench",)
 
 Progress = Callable[[str], None]
 
@@ -107,13 +108,18 @@ def _swap_in(root: Path, staging: Path, on_progress: Progress) -> None:
 
     Directories in the release (pilot/, admin/) are swapped whole, so files dropped between
     versions are pruned. Data dirs (benches/, .admin-venv, .git) are absent from the tarball
-    and never touched. A stale top-level entry removed entirely between versions is left in
-    place - rare, and harmless. (ponytail: prune those too only if it ever matters.)
+    and never touched. Top-level entries are otherwise preserved unless explicitly listed
+    as obsolete.
     """
     backup = root.with_name(root.name + ".backup")
     _reset_dir(backup)
     swapped: list[tuple[str, bool]] = []
     try:
+        for name in _OBSOLETE_TOP_LEVEL_ENTRIES:
+            target = root / name
+            if target.exists() or target.is_symlink():
+                os.rename(target, backup / name)
+                swapped.append((name, True))
         for entry in sorted(staging.iterdir()):
             target = root / entry.name
             had_original = target.exists()

--- a/pilot/updater.py
+++ b/pilot/updater.py
@@ -23,7 +23,7 @@ def latest_release() -> dict | None:
     """Newest release as {tag, asset_url, body}, or None. Uses the releases list (prereleases included)."""
     request = urllib.request.Request(
         _RELEASES_API,
-        headers={"Accept": "application/vnd.github+json", "User-Agent": "bench-cli"},
+        headers={"Accept": "application/vnd.github+json", "User-Agent": "pilot"},
     )
     with urllib.request.urlopen(request, timeout=30) as response:
         releases = json.load(response)
@@ -46,7 +46,7 @@ def update_available() -> tuple[bool, str | None]:
 
 
 def perform_upgrade(on_progress: Progress = lambda message: None) -> None:
-    """Update the bench-cli code in place. Restarting the admin service is the caller's job."""
+    """Update the Pilot code in place. Restarting the admin service is the caller's job."""
     from pilot.internal.patch_runner import run_patches
 
     run_patches("pre_update", on_progress=on_progress)
@@ -63,7 +63,7 @@ def _upgrade_dev(on_progress: Progress) -> None:
     from pilot.utils import run_command
 
     root = cli_root()
-    on_progress("Pulling latest bench-cli (dev install)...")
+    on_progress("Pulling latest Pilot (dev install)...")
     run_command(["git", "-C", str(root), "pull"], stream_output=True)
     on_progress("Installing admin Python dependencies...")
     AdminEnvManager(root).install_python_deps()

--- a/pilot/utils.py
+++ b/pilot/utils.py
@@ -367,7 +367,7 @@ def get_yarn_bin() -> str:
     local_yarn = Path.home() / ".local" / "bin" / "yarn"
     if local_yarn.exists():
         return str(local_yarn)
-    raise BenchError("yarn not found - run bench init to install it.")
+    raise BenchError("yarn not found - run pilot init to install it.")
 
 
 def redact_text(text: str, secrets: list[str] | None) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.11"
 dependencies = []
 
 [project.scripts]
-bench = "pilot.cli:main"
+pilot = "pilot.cli:main"
 
 [project.optional-dependencies]
 admin = ["flask>=3.0", "psutil>=5.9", "pymysql>=1.1", "gunicorn>=21.2", "boto3==1.43.39", "psycopg2-binary>=2.9", "pyjwt[crypto]>=2.8", "litellm==1.93.0", "PyOTP==2.10.0"]

--- a/scripts/smoke_install.sh
+++ b/scripts/smoke_install.sh
@@ -51,7 +51,8 @@ echo "--- path B: bench user run installs everything ---"
 su - frappe -c "PILOT_REPO_URL=$PILOT_REPO_URL PILOT_BRANCH=$PILOT_BRANCH sh /pilot-src/install.sh --dev"
 
 echo "--- assertions ---"
-su - frappe -c 'test -x "$HOME/pilot/bench"'
+su - frappe -c 'test -x "$HOME/pilot/bin/pilot"'
+su - frappe -c 'test ! -e "$HOME/pilot/bench"'
 su - frappe -c 'test -f "$HOME/pilot/.admin-venv/bin/python"'
 su - frappe -c 'command -v node'
 su - frappe -c 'command -v git'

--- a/scripts/smoke_install_macos.sh
+++ b/scripts/smoke_install_macos.sh
@@ -36,7 +36,8 @@ echo "=== macOS smoke test ==="
 sh "$REPO_ROOT/install.sh" --dev
 
 echo "--- assertions ---"
-test -x "$HOME/pilot/bench"
+test -x "$HOME/pilot/bin/pilot"
+test ! -e "$HOME/pilot/bench"
 test -f "$HOME/pilot/.admin-venv/bin/python"
 command -v brew
 command -v node

--- a/tests/admin/backend/api/test_settings_apply.py
+++ b/tests/admin/backend/api/test_settings_apply.py
@@ -78,7 +78,7 @@ def test_settings_report_nginx_failure_without_exception_text(tmp_path: Path) ->
         config.production.process_manager = "systemd"
 
     # nginx is only regenerated on a production bench; production is set up out
-    # of band (`bench setup production`), not via the settings patcher.
+    # of band (`pilot setup production`), not via the settings patcher.
     client = _client(tmp_path / "bench", enable_production)
     update = {
         "firewall": {

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -4,7 +4,7 @@ Browser-driven tests that exercise the real bench lifecycle through the **admin
 UI** - the same path a user takes:
 
 ```
-bench new  →  setup wizard  →  login  →  create site
+pilot new  →  setup wizard  →  login  →  create site
             →  install app  →  uninstall app  →  drop site
 ```
 
@@ -16,7 +16,7 @@ completion. Built on **pytest + pytest-playwright** (sync API).
 
 | Path | Purpose |
 |------|---------|
-| `harness/bench.py`  | `Bench` class: wraps `bench new` / `bench start` (wizard + full), stop, destroy (via `bench drop`). Reads the admin port from `bench.toml`; the admin password is harness-chosen (the wizard sets it). |
+| `harness/bench.py`  | `Bench` class: wraps `pilot new` / `pilot start` (wizard + full), stop, destroy (via `pilot drop`). Reads the admin port from `bench.toml`; the admin password is harness-chosen (the wizard sets it). |
 | `harness/tasks.py`  | Capture a UI action's `task_id` and poll `/api/v1/tasks/:id` to success. |
 | `flows/wizard.py`   | `complete_dev_wizard()` - drives `Setup.vue` for the chosen engine (`db_type="mariadb"`/`"postgres"`), dev mode. |
 | `flows/admin.py`    | `login`, `create_site`, `install_custom_app`, `uninstall_app`, `drop_site` + API-based assertions. |
@@ -32,7 +32,7 @@ the remaining steps once one fails.
 Prerequisites: MariaDB and/or PostgreSQL packages installed (bench provisions
 its own rootless, per-user server from them - see `MariaDBManager`/
 `PostgresManager` - so no running system service or pre-set password is
-needed), Redis, and `bench` on `PATH` (or set `BENCH_BIN`).
+needed), Redis, and `pilot` on `PATH` (or set `PILOT_BIN`).
 
 ```bash
 pip install -e ".[admin,e2e]"      # from the repo root
@@ -53,8 +53,8 @@ full trace (DOM snapshots, screenshots, network) with:
 playwright show-trace test-results/<module>/trace.zip
 ```
 
-By default the harness does **not** build the admin UI - `bench start` serves the
-prebuilt bundle (downloaded for the wizard, fetched by `bench init` for the full
+By default the harness does **not** build the admin UI - `pilot start` serves the
+prebuilt bundle (downloaded for the wizard, fetched by `pilot init` for the full
 bench). Set `E2E_BUILD_ADMIN=1` to build the admin UI from source instead, so the
 run exercises *this branch's* frontend (slower, but required to catch frontend
 changes - this is what CI does).
@@ -63,17 +63,17 @@ Useful env vars:
 
 | Variable | Default | Meaning |
 |----------|---------|---------|
-| `BENCH_BIN` | `<repo>/bench` | CLI entry point. |
+| `PILOT_BIN` | `<repo>/bin/pilot` | CLI entry point. |
 | `E2E_DB_TYPE` | `mariadb` | Bench database engine: `mariadb` or `postgres`. |
 | `E2E_MARIADB_PASSWORD` | `admin` | Root password the wizard sets on bench's own rootless MariaDB server. |
 | `E2E_POSTGRES_PASSWORD` | `admin` | Superuser password the wizard sets on bench's own rootless PostgreSQL server (used when `E2E_DB_TYPE=postgres`). |
 | `E2E_EXTRA_APP` | `1` | `0` skips the install/uninstall app steps (keeps a run quick). |
 | `E2E_EXTRA_APP_NAME` / `_REPO` / `_BRANCH` | `blog` / `frappe/blog` / `develop` | The extra app installed/uninstalled. Point at `erpnext`, `india-compliance`, etc. to widen coverage. |
 | `E2E_KEEP_ON_FAILURE` | (set) | On failure the bench is kept for inspection; set to `0` to always clean up. |
-| `E2E_BUILD_ADMIN` | off | `1` builds the admin UI from source (wizard + full bench) so the run exercises *this branch's* frontend. Off (default) = the harness never builds and `bench start` serves the prebuilt bundle (faster). |
+| `E2E_BUILD_ADMIN` | off | `1` builds the admin UI from source (wizard + full bench) so the run exercises *this branch's* frontend. Off (default) = the harness never builds and `pilot start` serves the prebuilt bundle (faster). |
 
 The suite creates a bench named `e2e-<db_type>` (e.g. `e2e-mariadb`,
-`e2e-postgres`) under `benches/` and tears it down with `bench drop` on
+`e2e-postgres`) under `benches/` and tears it down with `pilot drop` on
 teardown. Bench names must start with `e2e-` (the harness refuses to delete
 anything else).
 

--- a/tests/e2e/flows/wizard.py
+++ b/tests/e2e/flows/wizard.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from playwright.sync_api import Page, expect
 
-# Long pole: bench init clones the framework and builds the venv.
+# Long pole: pilot init clones the framework and builds the venv.
 SETUP_TIMEOUT_MS = 20 * 60_000
 
 
@@ -32,14 +32,14 @@ def complete_dev_wizard(
     # "Connect to external database" shows host/user/password fields.
     page.get_by_role("button", name="Next").click()
     # The wizard always provisions a development bench (no production/process-manager
-    # choice - that's a separate `bench setup production` step run from the terminal
+    # choice - that's a separate `pilot setup production` step run from the terminal
     # afterwards). We keep the repo default.
     expect(page.get_by_text("Customize your bench")).to_be_visible(timeout=30_000)
     if framework_branch:
         _choose_select(page, "Frappe branch", framework_branch)
 
     page.get_by_role("button", name="Set up bench").click()
-    # bench init clones the framework and builds the venv; this is the long pole.
+    # pilot init clones the framework and builds the venv; this is the long pole.
     expect(page.get_by_text("Setting up your bench")).to_be_visible(timeout=60_000)
 
     # The wizard resolves to exactly one terminal state: success ("Your bench is

--- a/tests/e2e/harness/bench.py
+++ b/tests/e2e/harness/bench.py
@@ -18,10 +18,10 @@ from urllib.request import urlopen
 REPO_ROOT = Path(__file__).resolve().parents[3]
 BENCHES_DIR = REPO_ROOT / "benches"
 
-# The CLI entry point. CI installs the `bench` console script (pip install -e),
+# The CLI entry point. CI installs the `pilot` console script (pip install -e),
 # but the in-repo launcher works everywhere (stdlib-only, python3 shebang), so
-# default to it and let BENCH_BIN override.
-BENCH_BIN = os.environ.get("BENCH_BIN") or str(REPO_ROOT / "bench")
+# default to it and let PILOT_BIN override.
+PILOT_BIN = os.environ.get("PILOT_BIN") or str(REPO_ROOT / "bin" / "pilot")
 
 # Only ever destroy benches we created, so a misconfigured run can't delete a
 # developer's real bench.
@@ -43,7 +43,7 @@ class Bench:
             raise ValueError(f'Bench name must start with "{E2E_PREFIX}" (got "{name}")')
         self.name = name
         self._extra_env = env or {}
-        # `bench new` no longer pre-generates an admin password (it's set in the
+        # `pilot new` no longer pre-generates an admin password (it's set in the
         # wizard's first step and persisted by PUT /api/v1/setup/configuration).
         # So the harness chooses it, the wizard enters it, and login reuses it.
         # A bare token_urlsafe() isn't guaranteed to satisfy the wizard's password
@@ -72,28 +72,28 @@ class Bench:
         return f"http://127.0.0.1:{self.admin_port}"
 
     def create(self) -> None:
-        """`bench new <name>` then read the generated admin port."""
+        """`pilot new <name>` then read the generated admin port."""
         if self.dir.exists():
             raise RuntimeError(f'Bench "{self.name}" already exists at {self.dir} - clean it up first')
         self._run(["new", self.name])
         if not (self.dir / "bench.toml").exists():
-            # `bench` resolves its benches dir as <dir containing pilot>/benches.
-            # The repo launcher (<repo>/bench, the default) puts it at <repo>/benches,
-            # which is what this harness reads. A `bench` from a non-editable
+            # `pilot` resolves its benches dir as <dir containing pilot>/benches.
+            # The repo launcher (<repo>/bin/pilot, the default) puts it at <repo>/benches,
+            # which is what this harness reads. A `pilot` from a non-editable
             # `pip install` lives in site-packages and writes benches there instead,
-            # so `bench new` "succeeds" yet nothing appears where we look.
+            # so `pilot new` "succeeds" yet nothing appears where we look.
             raise RuntimeError(
-                f"`bench new {self.name}` reported success but {self.dir / 'bench.toml'} "
-                f"was not created.\nBENCH_BIN={BENCH_BIN} writes benches under a different "
+                f"`pilot new {self.name}` reported success but {self.dir / 'bench.toml'} "
+                f"was not created.\nPILOT_BIN={PILOT_BIN} writes benches under a different "
                 f"root than this harness reads ({BENCHES_DIR}).\nUse the repo launcher "
-                f"(unset BENCH_BIN, or point it at {REPO_ROOT / 'bench'}); an installed "
-                f"`bench` from a non-editable pip install writes next to its site-packages."
+                f"(unset PILOT_BIN, or point it at {REPO_ROOT / 'bin' / 'pilot'}); an installed "
+                f"`pilot` from a non-editable pip install writes next to its site-packages."
             )
         self._info = self._read_config()
 
     def start_wizard(self) -> None:
         """Start the standalone setup-wizard server."""
-        # No-op unless E2E_BUILD_ADMIN is set; otherwise `bench start` downloads
+        # No-op unless E2E_BUILD_ADMIN is set; otherwise `pilot start` downloads
         # the prebuilt wizard UI itself.
         self._build_admin_ui()
         self._spawn_start()
@@ -118,8 +118,8 @@ class Bench:
         self._proc = None
 
     def start_full(self) -> None:
-        """`bench -b <name> start` on the initialized bench: full admin + workload."""
-        # `bench init` (run by the wizard) re-downloads the prebuilt admin dist,
+        """`pilot -b <name> start` on the initialized bench: full admin + workload."""
+        # `pilot init` (run by the wizard) re-downloads the prebuilt admin dist,
         # clobbering any local build. Rebuild from source only when E2E_BUILD_ADMIN
         # is set (no-op otherwise) - e.g. to exercise *this* branch's admin UI
         # rather than the released bundle.
@@ -130,7 +130,7 @@ class Bench:
     def stop(self) -> None:
         """Best-effort: stop the bench and kill the spawned process tree."""
         subprocess.run(
-            [BENCH_BIN, "-b", self.name, "stop"],
+            [PILOT_BIN, "-b", self.name, "stop"],
             cwd=REPO_ROOT,
             env=self._process_env(),
             stdout=subprocess.DEVNULL,
@@ -147,12 +147,12 @@ class Bench:
             self.remove_dir()
 
     def _drop_bench(self) -> None:
-        """`bench -b <name> drop --yes` - best-effort. No-op if the bench has no
+        """`pilot -b <name> drop --yes` - best-effort. No-op if the bench has no
         config yet (nothing to drop)."""
         if not (self.dir / "bench.toml").exists():
             return
         subprocess.run(
-            [BENCH_BIN, "-b", self.name, "drop", "--yes"],
+            [PILOT_BIN, "-b", self.name, "drop", "--yes"],
             cwd=REPO_ROOT,
             env=self._process_env(),
             stdout=subprocess.DEVNULL,
@@ -277,7 +277,7 @@ class Bench:
     def _run(self, args: list[str]) -> None:
         BENCHES_DIR.mkdir(parents=True, exist_ok=True)
         res = subprocess.run(
-            [BENCH_BIN, *args],
+            [PILOT_BIN, *args],
             cwd=REPO_ROOT,
             env=self._process_env(),
             capture_output=True,
@@ -285,7 +285,7 @@ class Bench:
         )
         if res.returncode != 0:
             raise RuntimeError(
-                f"bench {' '.join(args)} failed (exit {res.returncode}):\n{res.stdout}\n{res.stderr}"
+                f"pilot {' '.join(args)} failed (exit {res.returncode}):\n{res.stdout}\n{res.stderr}"
             )
 
     def _spawn_start(self) -> None:
@@ -294,7 +294,7 @@ class Bench:
         # start_new_session=True -> own process group so stop() can signal the
         # whole tree. stdout/stderr inherit so logs stream to the console.
         self._proc = subprocess.Popen(
-            [BENCH_BIN, "-b", self.name, "start"],
+            [PILOT_BIN, "-b", self.name, "start"],
             cwd=REPO_ROOT,
             env=self._process_env(),
             start_new_session=True,
@@ -322,7 +322,7 @@ class Bench:
         while time.time() < deadline:
             if self._proc and self._proc.poll() is not None:
                 raise RuntimeError(
-                    f"bench start exited early (code {self._proc.returncode}) before the admin came up"
+                    f"pilot start exited early (code {self._proc.returncode}) before the admin came up"
                 )
             try:
                 with urlopen(f"{self.admin_url}/api/v1/bootstrap", timeout=5) as res:

--- a/tests/fixtures/testapp/pyproject.toml
+++ b/tests/fixtures/testapp/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "testapp"
 version = "0.0.1"
-description = "Minimal app used in bench-cli integration tests"
+description = "Minimal app used in Pilot integration tests"
 dependencies = []
 
 [build-system]

--- a/tests/fixtures/testapp/testapp/hooks.py
+++ b/tests/fixtures/testapp/testapp/hooks.py
@@ -1,7 +1,7 @@
 app_name = "testapp"
 app_title = "Test App"
 app_publisher = "Frappe Technologies Pvt. Ltd."
-app_description = "Minimal app used in bench-cli integration tests"
+app_description = "Minimal app used in Pilot integration tests"
 app_email = "hello@frappe.io"
 app_license = "MIT"
 app_version = "0.0.1"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,7 +15,7 @@ BENCH_TEST_ROOT = Path(os.environ.get("BENCH_TEST_ROOT", _DEFAULT_BENCH_ROOT))
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
-        "integration: requires a fully initialised Frappe bench (run bench init first)",
+        "integration: requires a fully initialised Frappe bench (run pilot init first)",
     )
     config.addinivalue_line(
         "markers",
@@ -29,21 +29,21 @@ def bench_root() -> Path:
     if not (BENCH_TEST_ROOT / "bench.toml").exists():
         pytest.skip(
             f"No bench.toml at {BENCH_TEST_ROOT}. "
-            "Run 'bench init' inside that directory first, or set BENCH_TEST_ROOT."
+            "Run 'pilot init' inside that directory first, or set BENCH_TEST_ROOT."
         )
-    # bench-cli installs no `bench` into the bench venv; probe the interpreter.
+    # Pilot installs no `pilot` into the bench venv; probe the interpreter.
     if not (BENCH_TEST_ROOT / "env" / "bin" / "python").exists():
         pytest.skip(
-            f"Bench env not initialised at {BENCH_TEST_ROOT}. Run 'bench init' inside that directory first."
+            f"Bench env not initialised at {BENCH_TEST_ROOT}. Run 'pilot init' inside that directory first."
         )
     return BENCH_TEST_ROOT
 
 
 @pytest.fixture(scope="session")
 def bench_bin() -> str:
-    b = shutil.which("bench")
+    b = shutil.which("pilot")
     if b is None:
-        pytest.skip("'bench' binary not found in PATH - install bench-cli first")
+        pytest.skip("'pilot' binary not found in PATH - install Pilot first")
     return b
 
 

--- a/tests/integration/test_install_app_cascade.py
+++ b/tests/integration/test_install_app_cascade.py
@@ -36,7 +36,7 @@ def test_install_app_cascades_telephony_for_helpdesk(
     if not (bench_root / "apps" / HELPDESK).is_dir() or not (bench_root / "apps" / TELEPHONY).is_dir():
         pytest.skip(
             f"{HELPDESK}/{TELEPHONY} not cloned on this bench - run "
-            f"'bench get-app {HELPDESK}' first to exercise this cascade check."
+            f"'pilot get-app {HELPDESK}' first to exercise this cascade check."
         )
 
     # Both start uninstalled on the site - telephony must come back purely

--- a/tests/integration/test_production_ssl.py
+++ b/tests/integration/test_production_ssl.py
@@ -20,7 +20,7 @@ ADMIN_DOMAIN_2 = "bench-admin2.localhost"
 ADMIN_PASSWORD = "admin"
 HTTP_PORT = 80
 HTTPS_PORT = 443
-CERT_ORG = "bench-cli-e2e"  # baked into our certs to prove nginx served ours
+CERT_ORG = "pilot-e2e"  # baked into our certs to prove nginx served ours
 LETSENCRYPT_LIVE = Path("/etc/letsencrypt/live")
 ALL_DOMAINS = (SITE, RENAMED_SITE, ADMIN_DOMAIN, ADMIN_DOMAIN_2)
 

--- a/tests/integration/test_setup_wizard.py
+++ b/tests/integration/test_setup_wizard.py
@@ -79,7 +79,7 @@ class TestSetupWizard:
         # Frappe routes the request to the correct site via the Host header.
         session.headers["Host"] = SITE
 
-        # Authenticate as Administrator (created by bench new-site --admin-password).
+        # Authenticate as Administrator (created by pilot new-site --admin-password).
         login = session.post(
             f"{BASE_URL}/api/method/login",
             data={"usr": "Administrator", "pwd": ADMIN_PASSWORD},

--- a/tests/pilot/commands/test_commands.py
+++ b/tests/pilot/commands/test_commands.py
@@ -1,4 +1,4 @@
-"""Unit tests for bench-cli command classes."""
+"""Unit tests for Pilot command classes."""
 
 from __future__ import annotations
 
@@ -41,8 +41,8 @@ def make_bench(tmp_path: Path) -> Bench:
 
 
 def _ensure_database_credentials(bench_dir: Path) -> None:
-    """The DB-credential step of `bench init` (see BenchInitializer) - database
-    ports/passwords are generated there, not by `bench new`."""
+    """The DB-credential step of `pilot init` (see BenchInitializer) - database
+    ports/passwords are generated there, not by `pilot new`."""
     from pilot.core.bench import Bench
     from pilot.core.bench.initializer import BenchInitializer
 
@@ -156,7 +156,7 @@ def test_new_command_first_bench_has_no_jwks_url(tmp_path: Path, monkeypatch: py
 def test_new_command_postgres_bench_has_no_password_yet(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """`bench new` alone must not provision the shared DB server - only `bench
+    """`pilot new` alone must not provision the shared DB server - only `pilot
     init` does (BenchInitializer._ensure_database_credentials)."""
     from pilot.commands.bench.create import NewCommand
 

--- a/tests/pilot/commands/test_rename_site.py
+++ b/tests/pilot/commands/test_rename_site.py
@@ -118,4 +118,4 @@ def test_rename_followup_advises_on_failure(
     )
     out = capsys.readouterr().out
     assert "did not complete" in out
-    assert "bench setup production -b b1" in out
+    assert "pilot setup production -b b1" in out

--- a/tests/pilot/config/test_common_config.py
+++ b/tests/pilot/config/test_common_config.py
@@ -29,7 +29,7 @@ def test_write_then_read_round_trips(tmp_path: Path) -> None:
 
 
 def test_read_ignores_stale_mariadb_instance_keys(tmp_path: Path) -> None:
-    """Legacy MariaDB instance keys (from an older bench-cli schema) are
+    """Legacy MariaDB instance keys (from an older Pilot schema) are
     ignored, not rejected, when read back."""
     (tmp_path / "common_config.toml").write_text(
         '[mariadb]\nroot_password = "root"\ninstance = "old-bench"\n'

--- a/tests/pilot/core/test_core.py
+++ b/tests/pilot/core/test_core.py
@@ -548,7 +548,7 @@ def test_bench_sites_scans_filesystem(tmp_path: Path) -> None:
 
 
 def test_bench_init_apps_comes_from_config(tmp_path: Path) -> None:
-    """bench.init_apps() returns apps from bench.toml (used during bench init)."""
+    """bench.init_apps() returns apps from bench.toml (used during pilot init)."""
     bench = make_bench(tmp_path)
     init_apps = bench.init_apps()
     assert len(init_apps) == 1

--- a/tests/pilot/managers/test_managers_extra.py
+++ b/tests/pilot/managers/test_managers_extra.py
@@ -393,7 +393,7 @@ def test_systemd_admin_socket_listens_on_internal_port(tmp_path: Path) -> None:
     socket_unit = SystemdRenderer("test-bench").render_admin_socket(7001)
     assert "[Socket]" in socket_unit
     assert "ListenStream=127.0.0.1:7001" in socket_unit
-    # Independent of the workload target so the admin survives `bench stop`.
+    # Independent of the workload target so the admin survives `pilot stop`.
     assert "WantedBy=default.target" in socket_unit
     assert "PartOf=" not in socket_unit
 

--- a/tests/pilot/tasks/test_new_site_task.py
+++ b/tests/pilot/tasks/test_new_site_task.py
@@ -127,7 +127,7 @@ def test_run_reloads_workers_after_fetching_apps_and_before_provisioning(tmp_pat
 
 def test_run_reloads_workers_even_when_no_app_was_fetched(tmp_path: Path) -> None:
     """An app already on the bench can still postdate the running workers - it
-    may have arrived through `bench get-app` after they started."""
+    may have arrived through `pilot get-app` after they started."""
     from unittest.mock import MagicMock
 
     task = make_task(tmp_path, ["frappe"])

--- a/tests/pilot/test_cli.py
+++ b/tests/pilot/test_cli.py
@@ -122,7 +122,7 @@ print('\\n'.join(_leaks))
 
 def test_main_dispatches_native_command(monkeypatch: pytest.MonkeyPatch) -> None:
     dispatched = []
-    monkeypatch.setattr(sys, "argv", ["bench", "--bench", "demo", "restart"])
+    monkeypatch.setattr(sys, "argv", ["pilot", "--bench", "demo", "restart"])
     monkeypatch.setattr(
         registry,
         "dispatch",
@@ -144,7 +144,7 @@ def test_main_forwards_unknown_command_to_frappe(monkeypatch: pytest.MonkeyPatch
     monkeypatch.setattr(
         sys,
         "argv",
-        ["bench", "--bench", "demo", "--site", "site.localhost", "migrate"],
+        ["pilot", "--bench", "demo", "--site", "site.localhost", "migrate"],
     )
 
     cli.main()
@@ -162,7 +162,7 @@ def test_main_forwards_explicit_frappe_command(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(
         sys,
         "argv",
-        ["bench", "-b", "demo", "frappe", "--site", "site.localhost", "migrate", "--verbose"],
+        ["pilot", "-b", "demo", "frappe", "--site", "site.localhost", "migrate", "--verbose"],
     )
 
     cli.main()
@@ -174,7 +174,7 @@ def test_main_dispatches_all_benches_without_selecting_one(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     dispatched = []
-    monkeypatch.setattr(sys, "argv", ["bench", "-b", "all", "restart"])
+    monkeypatch.setattr(sys, "argv", ["pilot", "-b", "all", "restart"])
     monkeypatch.setattr(
         registry,
         "dispatch_all",

--- a/tests/pilot/test_cli_dispatch.py
+++ b/tests/pilot/test_cli_dispatch.py
@@ -9,6 +9,7 @@ import pytest
 from pilot.exceptions import BenchError
 from pilot.internal.cli import CliContext
 from pilot.internal.cli import dispatch as cli_dispatch
+from pilot.internal.cli.registry import build_parser
 
 
 def _context(root: Path, bench_name: str | None = None) -> CliContext:
@@ -20,6 +21,10 @@ def _make_bench(root: Path, name: str) -> Path:
     bench_dir.mkdir(parents=True)
     (bench_dir / "bench.toml").write_text(f'[bench]\nname = "{name}"\n')
     return bench_dir
+
+
+def test_parser_uses_pilot_program_name() -> None:
+    assert build_parser().prog == "pilot"
 
 
 def test_single_bench_auto_picked_without_explicit(tmp_path: Path, monkeypatch) -> None:

--- a/tests/pilot/test_updater.py
+++ b/tests/pilot/test_updater.py
@@ -96,12 +96,15 @@ def _make_install(tmp_path: Path) -> tuple[Path, Path]:
     root = tmp_path / "pilot"
     (root / "pilot").mkdir(parents=True)
     (root / "pilot" / "old.py").write_text("old")
+    (root / "bench").write_text("old launcher")
     (root / "benches").mkdir()
     (root / "benches" / "data.txt").write_text("keep me")
 
     staging = root.with_name("pilot.update")
     (staging / "pilot").mkdir(parents=True)
     (staging / "pilot" / "new.py").write_text("new")
+    (staging / "bin").mkdir()
+    (staging / "bin" / "pilot").write_text("new launcher")
     (staging / "VERSION").write_text("v0.0.2-pre-alpha")
     return root, staging
 
@@ -113,6 +116,8 @@ def test_swap_in_prunes_stale_files_and_keeps_data(tmp_path: Path) -> None:
 
     assert (root / "pilot" / "new.py").read_text() == "new"
     assert not (root / "pilot" / "old.py").exists()  # stale file pruned via whole-dir swap
+    assert (root / "bin" / "pilot").read_text() == "new launcher"
+    assert not (root / "bench").exists()
     assert (root / "VERSION").read_text() == "v0.0.2-pre-alpha"
     assert (root / "benches" / "data.txt").read_text() == "keep me"  # data untouched
     assert not root.with_name("pilot.backup").exists()  # backup cleaned up
@@ -133,6 +138,7 @@ def test_swap_in_rolls_back_on_failure(tmp_path: Path) -> None:
 
     assert (root / "pilot" / "old.py").read_text() == "old"
     assert not (root / "pilot" / "new.py").exists()
+    assert (root / "bench").read_text() == "old launcher"
     assert not root.with_name("pilot.backup").exists()
     assert (root / "benches" / "data.txt").read_text() == "keep me"
 


### PR DESCRIPTION
## Why

Pilot currently installs a command named `bench` which can conflict with the existing bench cli tool.

## What changed

- Rename Pilot's command from `bench` to `pilot` with no old alias.
- Move the source launcher to `bin/pilot` and add `~/pilot/bin` to `PATH`.
- Remove the old `~/pilot/bench` launcher during installs and self-updates.
- Restore the old launcher if a self-update rolls back.
- Update command hints, Admin UI guidance, docs, tests, and CI workflows.

Frappe's own separate `env/bin/bench` command is unchanged.

## Checks

- 134 focused CLI and upgrade tests pass.
- Type checking passes for 325 source files.
- Installer shell checks pass.
- Admin UI tests and production build pass.
- A built wheel installs `pilot` and does not install `bench`.
- The release archive contains `bin/pilot` and no root `bench` launcher.

The full local suite has 2,008 passing tests and 11 unrelated macOS failures in existing storage, process, and database-manager tests. The full lint check also reports five existing issues outside this change.
