### PR TITLE
feat: reject DocType and Page records in app fixtures

### DIFF
--- a/pilot/core/app/validator/fixtures.py
+++ b/pilot/core/app/validator/fixtures.py
@@ -10,20 +10,41 @@ if typing.TYPE_CHECKING:
     from pilot.core.app import App
 
 
+# Their controllers write module files on insert, which fixture import has no module path for.
+UNIMPORTABLE_DOCTYPES = ("DocType", "Page")
+
+
 class FixturesCheck:
     """Parse every fixture file, since frappe imports them during migrate."""
 
     def run(self, app: "App") -> None:
         broken = []
+        unimportable = []
         for path in sorted((module_path(app) / "fixtures").glob("*.json")):
+            name = path.relative_to(app.path)
             try:
-                json.loads(path.read_text())
+                records = json.loads(path.read_text())
             except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-                broken.append(f"{path.relative_to(app.path)}: {exc}")
+                broken.append(f"{name}: {exc}")
+                continue
+
+            if not isinstance(records, list):
+                continue
+            for doctype in UNIMPORTABLE_DOCTYPES:
+                if any(isinstance(r, dict) and r.get("doctype") == doctype for r in records):
+                    unimportable.append(f"{name}: contains '{doctype}' records")
 
         if broken:
             raise AppValidationError(
                 f"'{app.config.name}' has fixtures that aren't valid JSON:\n"
                 + "\n".join(f"  {problem}" for problem in broken)
                 + "\nFix the JSON or drop the file - frappe imports these during migrate."
+            )
+
+        if unimportable:
+            names = " and ".join(UNIMPORTABLE_DOCTYPES)
+            raise AppValidationError(
+                f"'{app.config.name}' has fixtures frappe cannot import:\n"
+                + "\n".join(f"  {problem}" for problem in unimportable)
+                + f"\n{names} records must ship in the app's modules, not as fixtures."
             )

--- a/tests/pilot/core/test_app_validator.py
+++ b/tests/pilot/core/test_app_validator.py
@@ -512,6 +512,21 @@ def test_fixtures_fail_on_unparsable_json(tmp_path: Path) -> None:
         FixturesCheck().run(app)
 
 
+@pytest.mark.parametrize("doctype", ["DocType", "Page"])
+def test_fixtures_fail_on_unimportable_doctypes(tmp_path: Path, doctype: str) -> None:
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        '[project]\nname = "myapp"\n',
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/fixtures/thing.json": f'[{{"doctype": "Role"}}, {{"doctype": "{doctype}"}}]\n',
+        },
+    )
+    with pytest.raises(AppValidationError, match=f"contains '{doctype}' records"):
+        FixturesCheck().run(app)
+
+
 def test_fixtures_pass_when_the_app_has_no_fixtures(tmp_path: Path) -> None:
     app = _make_app(tmp_path, "myapp", '[project]\nname = "myapp"\n', {"myapp/hooks.py": ""})
     FixturesCheck().run(app)


### PR DESCRIPTION
Related : https://github.com/frappe/pilot/issues/276

Fixture files containing `"doctype": "DocType"` or `"Page"` records fail on import during migrate. `FixturesCheck` now flags them alongside the existing JSON parse check.

FW has also has same fix, so that none can even export such fixtures - https://github.com/frappe/frappe/pull/41442