### PR TITLE
UI polish 2: marketplace, app dialogs, settings and site detail

### DIFF
--- a/admin/frontend/dashboard/src/components/apps/AddAppFromGithubDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/AddAppFromGithubDialog.vue
@@ -2,9 +2,7 @@
   <Dialog v-model="open" title="Import app from GitHub" size="md">
     <template #default>
       <div class="space-y-4">
-        <!-- flex-1 stretches each tab's wrapper; the inner span carries the pill
-             background and has no data-slot of its own, so it needs w-full too or
-             the highlight stays content-width inside a stretched slot. -->
+        <!-- The pill span has no data-slot; without w-full the highlight stays content-width. -->
         <TabButtons
           v-model="tab"
           :options="tabOptions"
@@ -38,8 +36,6 @@
 
           <template v-else>
             <p v-if="!gitStatus" class="text-ink-gray-5 text-sm">Loading…</p>
-            <!-- No description: the Connect GitHub button below is the fix, so the
-                 alert only has to name the state. -->
             <Alert
               v-else-if="!gitConnected"
               theme="yellow"
@@ -80,9 +76,7 @@
             </template>
           </template>
 
-          <!-- All three states share one slot inside the field wrapper, so progress,
-               success and error land in the same place as a hint under the input
-               instead of a space-y-4 sibling 16px below it. -->
+          <!-- Progress, success and error share one hint slot under the input. -->
           <ErrorMessage v-if="error" :message="error" class="mt-1.5" />
           <p v-else-if="fetching" class="mt-1.5 text-ink-gray-5 text-sm">Loading branches…</p>
           <p v-else-if="resolving" class="mt-1.5 text-ink-gray-5 text-sm">Checking repository…</p>
@@ -129,15 +123,13 @@ import { gitApi } from '@/api/git'
 import { openTaskDetailPage } from '@/utils/taskRoute'
 
 const props = defineProps({
-  // Set when the marketplace is scoped to one site: the app is installed on it
-  // right after it is fetched, rather than only added to the bench.
+  // When set, the fetched app is also installed on this site.
   siteName: { type: String, default: '' },
 })
 const open = defineModel('open')
 const router = useRouter()
 
 const tab = ref('public')
-// flex-1 per option so the subtle rail divides the dialog width evenly.
 const tabOptions = [
   { label: 'Public repository', value: 'public', class: 'flex-1' },
   { label: 'Your GitHub account', value: 'private', class: 'flex-1' },
@@ -162,8 +154,6 @@ const repoOptions = computed(() =>
 const adding = ref(false)
 const error = ref('')
 
-// Nothing can be imported from an unconnected account, so the primary action
-// becomes the fix instead of a disabled button.
 const needsGithubConnection = computed(
   () => tab.value === 'private' && Boolean(gitStatus.value) && !gitConnected.value,
 )
@@ -183,20 +173,17 @@ watch(open, (isOpen) => {
   if (isOpen) reset()
 })
 watch(tab, reset)
-// The field accepts "github.com/frappe/crm" as well as a full URL; every call to
-// the API goes through normalizedRepo so the scheme is always present.
+// Accepts scheme-less URLs; every API call goes through normalizedRepo.
 const normalizedRepo = computed(() => {
   const url = repo.value.trim().replace(/\/+$/, '')
   if (!url) return ''
   return /^https?:\/\//i.test(url) ? url : `https://${url}`
 })
 
-// host/owner/repo, with or without a scheme — enough to know the user has
-// finished typing something fetchable.
+// host/owner/repo, with or without a scheme.
 const REPO_PATTERN = /^(https?:\/\/)?[^/\s]+\.[^/\s]+\/[^/\s]+\/[^/\s]+$/
 
-// Auto-fetches once the URL looks complete, matching the private tab instead of
-// making the user press a button.
+// Auto-fetch once the URL looks complete.
 let repoDebounce
 watch(repo, (value) => {
   fetched.value = false

--- a/admin/frontend/dashboard/src/components/apps/AddAppFromGithubDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/AddAppFromGithubDialog.vue
@@ -38,19 +38,14 @@
 
           <template v-else>
             <p v-if="!gitStatus" class="text-ink-gray-5 text-sm">Loading…</p>
+            <!-- No description: the Connect GitHub button below is the fix, so the
+                 alert only has to name the state. -->
             <Alert
               v-else-if="!gitConnected"
               theme="yellow"
               title="No GitHub account connected"
               :dismissible="false"
-            >
-              <template #description>
-                <p class="text-ink-gray-6 text-p-sm">
-                  Connect a personal access token from Settings → GitHub to browse your
-                  repositories.
-                </p>
-              </template>
-            </Alert>
+            />
             <template v-else>
               <div
                 class="flex items-center gap-2 bg-surface-gray-1 px-3 py-2 border rounded-lg border-outline-gray-2"

--- a/admin/frontend/dashboard/src/components/apps/AddAppFromGithubDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/AddAppFromGithubDialog.vue
@@ -1,16 +1,16 @@
 <template>
-  <Dialog v-model="open" title="Import app from GitHub" size="lg">
+  <Dialog v-model="open" title="Import app from GitHub" size="md">
     <template #default>
       <div class="space-y-4">
-        <div class="border-b border-outline-gray-1">
-          <TabButtons
-            v-model="tab"
-            :options="tabOptions"
-            type="underline"
-            size="md"
-            class="[&>div]:!border-b-0"
-          />
-        </div>
+        <!-- flex-1 stretches each tab's wrapper; the inner span carries the pill
+             background and has no data-slot of its own, so it needs w-full too or
+             the highlight stays content-width inside a stretched slot. -->
+        <TabButtons
+          v-model="tab"
+          :options="tabOptions"
+          size="md"
+          class="w-full [&>div]:w-full [&_[data-slot=tab-button]>span]:w-full"
+        />
 
         <div>
           <template v-if="tab === 'public'">
@@ -27,21 +27,12 @@
                 label="Branch"
                 v-model="branch"
                 :options="branchOptions"
+                :loading="fetching"
                 allowCustomValue
                 placeholder="Search or type a branch…"
                 emptyText="No matching branch. Type one to use it."
                 class="w-40 shrink-0"
               />
-              <Button
-                v-else
-                variant="subtle"
-                class="shrink-0"
-                :loading="fetching"
-                :disabled="!repo.trim()"
-                @click="fetchBranches"
-              >
-                Fetch branches
-              </Button>
             </div>
           </template>
 
@@ -64,7 +55,7 @@
               <div
                 class="flex items-center gap-2 bg-surface-gray-1 px-3 py-2 border rounded-lg border-outline-gray-2"
               >
-                <span class="text-ink-gray-7 text-p-sm">
+                <span class="text-ink-gray-7 text-sm">
                   Connected as
                   <span class="font-medium text-ink-gray-9">{{ gitStatus.username }}</span>
                 </span>
@@ -93,19 +84,29 @@
               </div>
             </template>
           </template>
+
+          <!-- All three states share one slot inside the field wrapper, so progress,
+               success and error land in the same place as a hint under the input
+               instead of a space-y-4 sibling 16px below it. -->
+          <ErrorMessage v-if="error" :message="error" class="mt-1.5" />
+          <p v-else-if="fetching" class="mt-1.5 text-ink-gray-5 text-sm">Loading branches…</p>
+          <p v-else-if="resolving" class="mt-1.5 text-ink-gray-5 text-sm">Checking repository…</p>
+          <p
+            v-else-if="foundName"
+            class="mt-1.5 flex items-center gap-1 text-ink-green-8 text-sm"
+          >
+            <span class="size-3.5 shrink-0 lucide-check"></span>
+            Found {{ foundName
+            }}<template v-if="siteName">, will be installed on {{ siteName }}</template>
+          </p>
         </div>
-
-        <p v-if="resolving" class="text-ink-gray-5 text-sm">Checking repository…</p>
-        <p v-else-if="foundName" class="flex items-center gap-1.5 text-ink-green-6 text-sm">
-          <span class="size-4 lucide-circle-check"></span>
-          Found {{ foundName }}<template v-if="siteName">, will be installed on {{ siteName }}</template>
-        </p>
-
-        <ErrorMessage v-if="error" :message="error" />
 
         <div class="flex justify-end gap-2">
           <Button variant="subtle" @click="open = false">Cancel</Button>
-          <Button variant="solid" :disabled="!canSubmit" :loading="adding" @click="submit">
+          <Button v-if="needsGithubConnection" variant="solid" @click="goToGithubSettings"
+            >Connect GitHub</Button
+          >
+          <Button v-else variant="solid" :disabled="!canSubmit" :loading="adding" @click="submit">
             {{ siteName ? 'Import and install' : 'Import app' }}
           </Button>
         </div>
@@ -141,9 +142,10 @@ const open = defineModel('open')
 const router = useRouter()
 
 const tab = ref('public')
+// flex-1 per option so the subtle rail divides the dialog width evenly.
 const tabOptions = [
-  { label: 'Public repository', value: 'public' },
-  { label: 'Your GitHub account', value: 'private' },
+  { label: 'Public repository', value: 'public', class: 'flex-1' },
+  { label: 'Your GitHub account', value: 'private', class: 'flex-1' },
 ]
 const repo = ref('')
 const branch = ref('')
@@ -165,6 +167,17 @@ const repoOptions = computed(() =>
 const adding = ref(false)
 const error = ref('')
 
+// Nothing can be imported from an unconnected account, so the primary action
+// becomes the fix instead of a disabled button.
+const needsGithubConnection = computed(
+  () => tab.value === 'private' && Boolean(gitStatus.value) && !gitConnected.value,
+)
+
+function goToGithubSettings() {
+  open.value = false
+  router.push({ name: 'Settings', params: { section: 'general', subSection: 'github' } })
+}
+
 const resolving = ref(false)
 const foundName = ref('')
 const canSubmit = computed(() =>
@@ -175,13 +188,34 @@ watch(open, (isOpen) => {
   if (isOpen) reset()
 })
 watch(tab, reset)
-watch(repo, () => {
+// The field accepts "github.com/frappe/crm" as well as a full URL; every call to
+// the API goes through normalizedRepo so the scheme is always present.
+const normalizedRepo = computed(() => {
+  const url = repo.value.trim().replace(/\/+$/, '')
+  if (!url) return ''
+  return /^https?:\/\//i.test(url) ? url : `https://${url}`
+})
+
+// host/owner/repo, with or without a scheme — enough to know the user has
+// finished typing something fetchable.
+const REPO_PATTERN = /^(https?:\/\/)?[^/\s]+\.[^/\s]+\/[^/\s]+\/[^/\s]+$/
+
+// Auto-fetches once the URL looks complete, matching the private tab instead of
+// making the user press a button.
+let repoDebounce
+watch(repo, (value) => {
   fetched.value = false
   branches.value = []
   foundName.value = ''
+  if (tab.value !== 'public') return
+  clearTimeout(repoDebounce)
+  if (!REPO_PATTERN.test(value.trim().replace(/\/+$/, ''))) return
+  const url = normalizedRepo.value
+  repoDebounce = setTimeout(() => loadBranchesFor(url), 600)
 })
 
 function reset() {
+  clearTimeout(repoDebounce)
   repo.value = ''
   branch.value = ''
   fetched.value = false
@@ -208,11 +242,6 @@ async function loadBranchesFor(url) {
   } finally {
     fetching.value = false
   }
-}
-
-function fetchBranches() {
-  const url = repo.value.trim()
-  if (url) loadBranchesFor(url)
 }
 
 async function loadGitStatus() {
@@ -244,7 +273,7 @@ async function resolveApp() {
   foundName.value = ''
   error.value = ''
   try {
-    const d = await gitApi.resolve(repo.value.trim(), branch.value.trim())
+    const d = await gitApi.resolve(normalizedRepo.value, branch.value.trim())
     if (d.name) foundName.value = d.name
     else error.value = apiErrorMessage(d, 'Could not find a Frappe app in this repository.')
   } catch (e) {
@@ -261,7 +290,7 @@ async function submit() {
   try {
     const result = await appsApi.add({
       name: foundName.value,
-      repo: repo.value.trim(),
+      repo: normalizedRepo.value,
       branch: branch.value.trim(),
       sites: props.siteName ? [props.siteName] : [],
     })

--- a/admin/frontend/dashboard/src/components/apps/InstallAppDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/InstallAppDialog.vue
@@ -8,18 +8,11 @@
     :disabled="!selection || targetInstalled"
     @confirm="confirmInstall"
   >
-    <!-- The title names the app, so the subject block and the 'Install on'
-         label it used to sit above are both redundant. Meta sits in a
-         fixed-width right column so long site names truncate instead of
-         crowding it. -->
-    <!-- Selected, not interactive: it is the confirmed target, just not a choice. -->
     <SiteRow v-if="targetSite" :label="targetSite.name" selected :interactive="false">
       <template #suffix>
         <span class="w-20 text-ink-gray-5 text-sm text-right shrink-0">
           {{ siteMeta(targetSite) }}
         </span>
-        <!-- The check is what says "already installed" — it must not cost the row
-             its app count. -->
         <span
           v-if="targetInstalled"
           class="size-4 text-ink-gray-9 shrink-0 lucide-check"
@@ -96,8 +89,7 @@ const error = ref('')
 const appLabel = computed(() => props.app?.title || props.app?.name || '')
 
 const presetSite = computed(() => props.sites.find((s) => s.name === props.siteName) || null)
-// A bench with one site has nothing to choose between, so it behaves like a
-// preset: the row is shown for confirmation but never asks for a decision.
+// A single-site bench behaves like a preset: shown for confirmation, never asked.
 const soleSite = computed(() => (props.sites.length === 1 ? props.sites[0] : null))
 const targetSite = computed(() => presetSite.value || soleSite.value)
 const targetInstalled = computed(() => Boolean(targetSite.value && isInstalled(targetSite.value)))

--- a/admin/frontend/dashboard/src/components/apps/InstallAppDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/InstallAppDialog.vue
@@ -1,52 +1,71 @@
 <template>
   <ActionDialog
     v-model:open="open"
-    title="Install app"
-    :subject="{ name: app?.name, label: appLabel, badge: app?.label, description: app?.description, logo: app?.logo_url }"
+    :title="`Install ${appLabel} on`"
     :error="error"
     confirm-label="Install"
     :loading="installing"
-    :disabled="!selection || presetInstalled"
+    :disabled="!selection || targetInstalled"
     @confirm="confirmInstall"
   >
-    <div class="space-y-2">
-      <p class="font-medium text-ink-gray-5 text-sm">Install on</p>
+    <!-- The title names the app, so the subject block and the 'Install on'
+         label it used to sit above are both redundant. Meta sits in a
+         fixed-width right column so long site names truncate instead of
+         crowding it. -->
+    <!-- Selected, not interactive: it is the confirmed target, just not a choice. -->
+    <SiteRow v-if="targetSite" :label="targetSite.name" selected :interactive="false">
+      <template #suffix>
+        <span class="w-20 text-ink-gray-5 text-sm text-right shrink-0">
+          {{ siteMeta(targetSite) }}
+        </span>
+        <!-- The check is what says "already installed" — it must not cost the row
+             its app count. -->
+        <span
+          v-if="targetInstalled"
+          class="size-4 text-ink-gray-9 shrink-0 lucide-check"
+          aria-label="Already installed"
+        />
+      </template>
+    </SiteRow>
+
+    <div v-else class="gap-1.5 grid max-h-80 overflow-y-auto">
+      <SiteRow
+        v-if="showAllSitesOption"
+        label="All sites"
+        icon="lucide-layout-grid"
+        :selected="selection === 'all'"
+        @click="selection = 'all'"
+      >
+        <template #suffix>
+          <span class="w-20 text-ink-gray-5 text-sm text-right shrink-0">
+            {{ installableSites.length }} sites
+          </span>
+        </template>
+      </SiteRow>
 
       <SiteRow
-        v-if="presetSite"
-        :label="presetSite.name"
-        :subtitle="presetInstalled ? 'Already installed' : siteVersion(presetSite)"
-        :icon="presetInstalled ? 'lucide-check' : 'lucide-globe'"
-        :checked="presetInstalled"
-        :interactive="false"
-      />
+        v-for="s in sites"
+        :key="s.name"
+        :label="s.name"
+        :disabled="isInstalled(s)"
+        :selected="selection === s.name"
+        @click="selection = s.name"
+      >
+        <template #suffix>
+          <span class="w-20 text-ink-gray-5 text-sm text-right shrink-0">
+            {{ siteMeta(s) }}
+          </span>
+          <span
+            v-if="isInstalled(s)"
+            class="size-4 text-ink-gray-9 shrink-0 lucide-check"
+            aria-label="Already installed"
+          />
+        </template>
+      </SiteRow>
 
-      <div v-else class="gap-2 grid max-h-80 overflow-y-auto">
-        <SiteRow
-          v-if="showAllSitesOption"
-          label="All sites"
-          :subtitle="`Installs on ${installableSites.length} sites`"
-          icon="lucide-layout-grid"
-          :selected="selection === 'all'"
-          @click="selection = 'all'"
-        />
-
-        <SiteRow
-          v-for="s in sites"
-          :key="s.name"
-          :label="s.name"
-          :subtitle="isInstalled(s) ? 'Already installed' : siteVersion(s)"
-          :icon="isInstalled(s) ? 'lucide-check' : 'lucide-globe'"
-          :checked="isInstalled(s)"
-          :disabled="isInstalled(s)"
-          :selected="selection === s.name"
-          @click="selection = s.name"
-        />
-
-        <p v-if="!sites.length" class="py-6 text-ink-gray-5 text-p-sm text-center">
-          No sites available on this bench.
-        </p>
-      </div>
+      <p v-if="!sites.length" class="py-6 text-ink-gray-5 text-p-sm text-center">
+        No sites available on this bench.
+      </p>
     </div>
   </ActionDialog>
 </template>
@@ -75,11 +94,15 @@ const error = ref('')
 const appLabel = computed(() => props.app?.title || props.app?.name || '')
 
 const presetSite = computed(() => props.sites.find((s) => s.name === props.siteName) || null)
-const presetInstalled = computed(() => Boolean(presetSite.value && isInstalled(presetSite.value)))
+// A bench with one site has nothing to choose between, so it behaves like a
+// preset: the row is shown for confirmation but never asks for a decision.
+const soleSite = computed(() => (props.sites.length === 1 ? props.sites[0] : null))
+const targetSite = computed(() => presetSite.value || soleSite.value)
+const targetInstalled = computed(() => Boolean(targetSite.value && isInstalled(targetSite.value)))
 
 watch(open, (isOpen) => {
   if (!isOpen) return
-  selection.value = props.siteName || null
+  selection.value = props.siteName || soleSite.value?.name || null
   error.value = ''
 })
 
@@ -91,9 +114,9 @@ function isInstalled(site) {
   return Boolean(props.app && site.installed_apps?.includes(props.app.name))
 }
 
-function siteVersion(site) {
-  const match = /^version-(\d+)/.exec(site.framework_branch || '')
-  return match ? `Version ${match[1]}` : ''
+function siteMeta(site) {
+  const n = site.installed_apps?.length || 0
+  return `${n} app${n === 1 ? '' : 's'}`
 }
 
 async function startInstall(site) {

--- a/admin/frontend/dashboard/src/components/apps/InstallAppDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/InstallAppDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <ActionDialog
     v-model:open="open"
-    title="Install App"
+    title="Install app"
     :subject="{ name: app?.name, label: appLabel, badge: app?.label, description: app?.description, logo: app?.logo_url }"
     :error="error"
     confirm-label="Install"
@@ -10,7 +10,7 @@
     @confirm="confirmInstall"
   >
     <div class="space-y-2">
-      <p class="font-medium text-ink-gray-5 text-p-xs uppercase tracking-wide">Install on</p>
+      <p class="font-medium text-ink-gray-5 text-sm">Install on</p>
 
       <SiteRow
         v-if="presetSite"
@@ -43,7 +43,7 @@
           @click="selection = s.name"
         />
 
-        <p v-if="!sites.length" class="py-6 text-ink-gray-5 text-sm text-center">
+        <p v-if="!sites.length" class="py-6 text-ink-gray-5 text-p-sm text-center">
           No sites available on this bench.
         </p>
       </div>

--- a/admin/frontend/dashboard/src/components/apps/InstallAppDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/InstallAppDialog.vue
@@ -23,6 +23,7 @@
         <span
           v-if="targetInstalled"
           class="size-4 text-ink-gray-9 shrink-0 lucide-check"
+          role="img"
           aria-label="Already installed"
         />
       </template>
@@ -58,6 +59,7 @@
           <span
             v-if="isInstalled(s)"
             class="size-4 text-ink-gray-9 shrink-0 lucide-check"
+            role="img"
             aria-label="Already installed"
           />
         </template>

--- a/admin/frontend/dashboard/src/components/apps/UpdateAppsDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/UpdateAppsDialog.vue
@@ -9,47 +9,53 @@
           Your bench is up to date.
         </p>
         <template v-else>
-          <div class="flex items-center justify-between">
-            <span class="text-ink-gray-5 text-sm">{{ selected.size }} of {{ appNames.length }} selected</span>
-            <Button variant="ghost" size="sm" @click="toggleAll">
-              {{ selected.size === appNames.length ? 'Unselect all' : 'Select all' }}
-            </Button>
-          </div>
-          <!-- The row is the control (role=checkbox + aria-checked), so the inner
-               Checkbox is inert decoration: tabindex/aria-hidden reach the real
-               <input> via Checkbox's attr passthrough, so it is neither tabbable
-               nor announced twice. -->
-          <div class="flex flex-col gap-0.5 max-h-80 overflow-y-auto">
-            <button
-              v-for="name in appNames"
-              :key="name"
-              type="button"
-              role="checkbox"
-              :aria-checked="selected.has(name)"
-              class="flex items-center gap-2.5 hover:bg-surface-gray-2 p-2 rounded text-left transition-colors"
-              @click="toggle(name)"
-            >
-              <AppIcon :name="name" class="rounded size-8 shrink-0" />
-              <span class="flex-1 min-w-0">
-                <p class="font-medium text-ink-gray-8 text-sm truncate">
-                  {{ titleMap[name] || name }}
-                </p>
-                <p
-                  v-if="updates[name]"
-                  class="flex items-center gap-1 font-mono text-ink-gray-5 text-xs truncate"
-                >
-                  {{ updates[name].current }}
-                  <span class="lucide-arrow-right size-3 shrink-0 text-ink-gray-4" />
-                  <span class="text-ink-green-7">{{ updates[name].target }}</span>
-                </p>
+          <!-- Counter and list are one group, so they sit closer than the dialog's
+               gap-4 between blocks. -->
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center justify-between">
+              <span class="text-ink-gray-5 text-sm">
+                {{ selected.size }} of {{ appNames.length }} selected
               </span>
-              <Checkbox
-                :model-value="selected.has(name)"
-                class="pointer-events-none shrink-0"
-                tabindex="-1"
-                aria-hidden="true"
-              />
-            </button>
+              <Button variant="ghost" size="sm" @click="toggleAll">
+                {{ selected.size === appNames.length ? 'Unselect all' : 'Select all' }}
+              </Button>
+            </div>
+            <!-- The row is the control (role=checkbox + aria-checked), so the inner
+                 Checkbox is inert decoration: tabindex/aria-hidden reach the real
+                 <input> via Checkbox's attr passthrough, so it is neither tabbable
+                 nor announced twice. Clicking the name still toggles. -->
+            <div class="flex flex-col gap-3 max-h-80 overflow-y-auto">
+              <button
+                v-for="name in appNames"
+                :key="name"
+                type="button"
+                role="checkbox"
+                :aria-checked="selected.has(name)"
+                class="flex items-center gap-2.5 pr-2 text-left"
+                @click="toggle(name)"
+              >
+                <AppIcon :name="name" class="rounded-md size-8 shrink-0" />
+                <span class="flex-1 min-w-0">
+                  <p class="font-medium text-ink-gray-8 text-base truncate">
+                    {{ titleMap[name] || name }}
+                  </p>
+                  <p
+                    v-if="updates[name]"
+                    class="flex items-center gap-1 mt-0.5 font-mono text-ink-gray-5 text-p-xs truncate"
+                  >
+                    {{ updates[name].current }}
+                    <span class="lucide-arrow-right size-3 shrink-0 text-ink-gray-4" />
+                    <span class="text-ink-green-7">{{ updates[name].target }}</span>
+                  </p>
+                </span>
+                <Checkbox
+                  :model-value="selected.has(name)"
+                  class="pointer-events-none shrink-0"
+                  tabindex="-1"
+                  aria-hidden="true"
+                />
+              </button>
+            </div>
           </div>
 
           <div class="flex flex-col gap-2 pt-2">

--- a/admin/frontend/dashboard/src/components/apps/UpdateAppsDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/UpdateAppsDialog.vue
@@ -9,8 +9,6 @@
           Your bench is up to date.
         </p>
         <template v-else>
-          <!-- Counter and list are one group, so they sit closer than the dialog's
-               gap-4 between blocks. -->
           <div class="flex flex-col gap-2">
             <div class="flex items-center justify-between">
               <span class="text-ink-gray-5 text-sm">
@@ -20,10 +18,8 @@
                 {{ selected.size === appNames.length ? 'Unselect all' : 'Select all' }}
               </Button>
             </div>
-            <!-- The row is the control (role=checkbox + aria-checked), so the inner
-                 Checkbox is inert decoration: tabindex/aria-hidden reach the real
-                 <input> via Checkbox's attr passthrough, so it is neither tabbable
-                 nor announced twice. Clicking the name still toggles. -->
+            <!-- The row is the checkbox; the inner Checkbox is inert decoration
+                 (tabindex/aria-hidden reach its <input> via attr passthrough). -->
             <div class="flex flex-col gap-3 max-h-80 overflow-y-auto">
               <button
                 v-for="name in appNames"

--- a/admin/frontend/dashboard/src/components/apps/UpdateAppsDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/UpdateAppsDialog.vue
@@ -15,29 +15,40 @@
               {{ selected.size === appNames.length ? 'Unselect all' : 'Select all' }}
             </Button>
           </div>
-          <div class="flex flex-col gap-1 max-h-80 overflow-y-auto">
+          <!-- The row is the control (role=checkbox + aria-checked), so the inner
+               Checkbox is inert decoration: tabindex/aria-hidden reach the real
+               <input> via Checkbox's attr passthrough, so it is neither tabbable
+               nor announced twice. -->
+          <div class="flex flex-col gap-0.5 max-h-80 overflow-y-auto">
             <button
               v-for="name in appNames"
               :key="name"
               type="button"
-              class="flex items-center gap-3 hover:bg-surface-gray-1 p-2 rounded-lg text-left transition-colors"
+              role="checkbox"
+              :aria-checked="selected.has(name)"
+              class="flex items-center gap-2.5 hover:bg-surface-gray-2 p-2 rounded text-left transition-colors"
               @click="toggle(name)"
             >
-              <AppIcon :name="name" class="rounded-lg size-8 shrink-0" />
+              <AppIcon :name="name" class="rounded size-8 shrink-0" />
               <span class="flex-1 min-w-0">
                 <p class="font-medium text-ink-gray-8 text-sm truncate">
                   {{ titleMap[name] || name }}
                 </p>
                 <p
                   v-if="updates[name]"
-                  class="mt-1 flex items-center gap-1 font-mono text-ink-gray-5 text-xs truncate"
+                  class="flex items-center gap-1 font-mono text-ink-gray-5 text-xs truncate"
                 >
                   {{ updates[name].current }}
                   <span class="lucide-arrow-right size-3 shrink-0 text-ink-gray-4" />
                   <span class="text-ink-green-7">{{ updates[name].target }}</span>
                 </p>
               </span>
-              <Checkbox :model-value="selected.has(name)" class="pointer-events-none shrink-0" />
+              <Checkbox
+                :model-value="selected.has(name)"
+                class="pointer-events-none shrink-0"
+                tabindex="-1"
+                aria-hidden="true"
+              />
             </button>
           </div>
 
@@ -51,7 +62,7 @@
 
         <ErrorMessage v-if="error" :message="error" />
 
-        <div class="flex justify-end gap-2 pt-4 border-t border-outline-gray-1">
+        <div class="flex justify-end gap-2 pt-2">
           <Button variant="ghost" @click="open = false">Cancel</Button>
           <Button
             v-if="appNames.length"

--- a/admin/frontend/dashboard/src/components/common/ActionDialog.vue
+++ b/admin/frontend/dashboard/src/components/common/ActionDialog.vue
@@ -6,22 +6,22 @@
           <div v-if="subject" class="flex items-center gap-3">
             <span
               v-if="subject.icon"
-              class="place-items-center grid bg-surface-gray-2 rounded-[10px] size-11 shrink-0"
+              class="place-items-center grid bg-surface-gray-2 rounded-[10px] size-9 shrink-0"
             >
-              <span class="size-5 text-ink-gray-7" :class="subject.icon" />
+              <span class="size-4 text-ink-gray-7" :class="subject.icon" />
             </span>
             <AppIcon
               v-else
               :name="subject.name || subject.label"
               :label="subject.label"
               :logo="subject.logo || ''"
-              class="rounded-[10px] size-11"
-              initial-class="text-lg"
+              class="rounded-[10px] size-9"
+              initial-class="text-base"
             />
             <div class="min-w-0">
               <div class="flex items-center gap-1.5">
                 <p class="font-medium text-ink-gray-8 text-base truncate">{{ subject.label }}</p>
-                <span v-if="subject.badge" class="text-ink-gray-5 text-p-xs shrink-0">
+                <span v-if="subject.badge" class="text-ink-gray-5 text-xs shrink-0">
                   {{ subject.badge }}
                 </span>
               </div>
@@ -31,8 +31,6 @@
             </div>
           </div>
         </slot>
-
-        <div v-if="$slots.subject || subject" class="border-outline-gray-2 border-t" />
 
         <slot />
 

--- a/admin/frontend/dashboard/src/components/marketplace/MarketplaceAppCard.vue
+++ b/admin/frontend/dashboard/src/components/marketplace/MarketplaceAppCard.vue
@@ -12,10 +12,10 @@
       <div class="min-w-0">
         <div class="flex items-center gap-1.5">
           <span class="font-medium text-ink-gray-8 text-base truncate">{{ app.title }}</span>
-          <span v-if="app.label" class="text-ink-gray-5 text-p-xs shrink-0">{{ app.label }}</span>
+          <span v-if="app.label" class="text-ink-gray-5 text-xs shrink-0">{{ app.label }}</span>
           <Badge v-if="app.nightly" theme="orange" variant="subtle" label="Nightly" size="sm" />
         </div>
-        <div class="text-ink-gray-5 text-p-sm truncate">
+        <div class="text-ink-gray-5 text-sm truncate">
           {{ app.description }}
         </div>
       </div>
@@ -26,10 +26,7 @@
             <span class="size-4 text-ink-green-6 lucide-check"></span>
           </span>
         </Tooltip>
-        <Tooltip
-          v-else-if="!app.compatible"
-          :text="`Requires ${app.needs ? `Frappe ${props.app.needs}` : 'a newer Frappe'} version`"
-        >
+        <Tooltip v-else-if="!app.compatible" :text="requirementLabel">
           <Button
             variant="ghost"
             label="Install"
@@ -43,7 +40,7 @@
           <Button variant="ghost" label="Install" class="group" @click="$emit('install', app)">
             <template #icon>
               <LucideDownload
-                class="size-4 transition-transform duration-150 ease-[var(--ease-out)] [@media(hover:hover)]:group-hover:translate-y-0.5 group-active:scale-95 group-active:duration-100"
+                class="size-4 transition-transform duration-150 ease-[var(--ease-out)] group-active:scale-95 group-active:duration-100"
               />
             </template>
           </Button>
@@ -51,9 +48,9 @@
       </slot>
     </div>
 
-    <Dialog v-model="showIncompatible" :options="{ title: 'Incompatible App', size: 'sm' }">
+    <Dialog v-model="showIncompatible" :options="{ title: 'Incompatible app', size: 'sm' }">
       <template #body-content>
-        <p class="text-ink-gray-7 text-sm">{{ incompatibleReason }}</p>
+        <p class="text-ink-gray-7 text-p-sm">{{ incompatibleReason }}</p>
         <div class="flex flex-col gap-1.5 mt-3 text-sm">
           <div class="flex justify-between">
             <span class="text-ink-gray-5">Current version</span>
@@ -81,6 +78,10 @@ const props = defineProps({
 defineEmits(['install'])
 
 const showIncompatible = ref(false)
+
+const requirementLabel = computed(() =>
+  props.app.needs ? `Needs Frappe ${props.app.needs}` : 'Needs a newer Frappe version',
+)
 
 const incompatibleReason = computed(
   () =>

--- a/admin/frontend/dashboard/src/components/marketplace/MarketplaceAppCard.vue
+++ b/admin/frontend/dashboard/src/components/marketplace/MarketplaceAppCard.vue
@@ -15,7 +15,7 @@
           <span v-if="app.label" class="text-ink-gray-5 text-xs shrink-0">{{ app.label }}</span>
           <Badge v-if="app.nightly" theme="orange" variant="subtle" label="Nightly" size="sm" />
         </div>
-        <div class="text-ink-gray-5 text-sm truncate">
+        <div class="mt-0.5 text-ink-gray-5 text-p-sm truncate">
           {{ app.description }}
         </div>
       </div>
@@ -23,7 +23,7 @@
       <slot name="actions">
         <Tooltip v-if="app.installed" text="Installed">
           <span class="place-items-center grid size-7 shrink-0" role="img" aria-label="Installed">
-            <span class="size-4 text-ink-green-6 lucide-check"></span>
+            <span class="size-4 text-ink-gray-9 lucide-check"></span>
           </span>
         </Tooltip>
         <Tooltip v-else-if="!app.compatible" :text="requirementLabel">

--- a/admin/frontend/dashboard/src/components/marketplace/MarketplaceFilters.vue
+++ b/admin/frontend/dashboard/src/components/marketplace/MarketplaceFilters.vue
@@ -72,8 +72,6 @@ const worksWithMenu = computed(() => [
   })),
 ])
 
-// Once an app is chosen the "Works with" prefix is redundant, and keeping it
-// overflowed the trigger.
 const worksWithLabel = computed(() => {
   const selected = props.worksWithOptions.find((option) => option.name === worksWithModel.value)
   return selected ? selected.title : 'Works with'

--- a/admin/frontend/dashboard/src/components/marketplace/MarketplaceFilters.vue
+++ b/admin/frontend/dashboard/src/components/marketplace/MarketplaceFilters.vue
@@ -15,7 +15,7 @@
       <div class="flex gap-2">
         <Dropdown :options="worksWithMenu" placement="bottom-end">
           <template #default="{ open }">
-            <Button class="w-32 [&>.truncate]:flex-1 [&>.truncate]:text-left" :active="open">
+            <Button class="[&>.truncate]:flex-1 [&>.truncate]:text-left" :active="open">
               <template #suffix><span class="size-4 shrink-0 lucide-chevron-down" /></template>
               {{ worksWithLabel }}
             </Button>
@@ -29,26 +29,16 @@
       </div>
     </div>
 
-    <div class="flex flex-wrap gap-1.5 mt-3">
-      <button
-        v-for="pill in PILLS"
-        :key="pill"
-        type="button"
-        class="px-3 py-0.5 border rounded-full text-p-sm transition duration-150 ease-[var(--ease-out)] active:scale-[0.97]"
-        :class="pill === pillModel
-          ? 'bg-surface-gray-3 border-outline-gray-2 text-ink-gray-9'
-          : 'border-outline-gray-2 text-ink-gray-6 hover:bg-surface-gray-1 hover:text-ink-gray-8'"
-        @click="pillModel = pill"
-      >
-        {{ pill }}
-      </button>
+    <!-- Scrolls rather than clips: TabButtons' rail is overflow-hidden and does not wrap. -->
+    <div class="mt-3 overflow-x-auto">
+      <TabButtons v-model="pillModel" :options="pillOptions" type="ghost" />
     </div>
   </div>
 </template>
 
 <script setup>
 import { computed, h } from 'vue'
-import { Button, Dropdown, FormControl } from 'frappe-ui'
+import { Button, Dropdown, FormControl, TabButtons } from 'frappe-ui'
 import LucideSearch from '~icons/lucide/search'
 import GithubMark from '@/components/icons/GithubMark.vue'
 import { PILLS } from '@/utils/marketplaceCategories'
@@ -61,6 +51,8 @@ defineEmits(['add-from-github'])
 const searchModel = defineModel('search', { type: String })
 const pillModel = defineModel('pill', { type: String })
 const worksWithModel = defineModel('worksWith', { type: String })
+
+const pillOptions = PILLS.map((pill) => ({ label: pill, value: pill }))
 
 function appLogo(option) {
   if (!option.logo_url) return null
@@ -80,8 +72,10 @@ const worksWithMenu = computed(() => [
   })),
 ])
 
+// Once an app is chosen the "Works with" prefix is redundant, and keeping it
+// overflowed the trigger.
 const worksWithLabel = computed(() => {
   const selected = props.worksWithOptions.find((option) => option.name === worksWithModel.value)
-  return selected ? `Works with ${selected.title}` : 'Works with'
+  return selected ? selected.title : 'Works with'
 })
 </script>

--- a/admin/frontend/dashboard/src/components/settings/General.vue
+++ b/admin/frontend/dashboard/src/components/settings/General.vue
@@ -22,12 +22,13 @@
         :label="section.label"
         :description="section.description"
       >
-        <!-- Icon-only, so the row's action still needs an accessible name. -->
+        <!-- Icon-only: `label` is not rendered but becomes the accessible name. A
+             plain aria-label attr would be overwritten by Button's own. -->
         <Button
           size="sm"
           variant="ghost"
           icon="lucide-chevron-right"
-          :aria-label="`${section.action || 'Manage'} ${section.label}`"
+          :label="`${section.action || 'Manage'} ${section.label}`"
           @click="openSection = section"
         />
       </SettingsRow>

--- a/admin/frontend/dashboard/src/components/settings/General.vue
+++ b/admin/frontend/dashboard/src/components/settings/General.vue
@@ -22,9 +22,14 @@
         :label="section.label"
         :description="section.description"
       >
-        <Button size="sm" variant="subtle" @click="openSection = section">
-          {{ section.action || 'Manage' }}
-        </Button>
+        <!-- Icon-only, so the row's action still needs an accessible name. -->
+        <Button
+          size="sm"
+          variant="ghost"
+          icon="lucide-chevron-right"
+          :aria-label="`${section.action || 'Manage'} ${section.label}`"
+          @click="openSection = section"
+        />
       </SettingsRow>
 
       <Version />

--- a/admin/frontend/dashboard/src/components/settings/Git.vue
+++ b/admin/frontend/dashboard/src/components/settings/Git.vue
@@ -3,20 +3,18 @@
     <span class="size-5 text-ink-gray-4 animate-spin lucide-loader-circle"></span>
   </div>
   <div v-else class="space-y-6">
-    <Alert v-if="!connected" theme="blue" title="Why connect GitHub?" :dismissible="false">
+    <Alert v-if="!connected" theme="blue" title="Connect GitHub" :dismissible="false">
       <template #description>
         <p class="text-ink-gray-6 text-p-sm">
-          Connecting a GitHub account lets you install private apps and browse your repositories
-          from the "Add app from GitHub" dialog. Generate a
+          Install private apps and browse your repos. Paste a
           <a
             :href="tokenHelpUrl"
             target="_blank"
             rel="noopener"
             class="underline underline-offset-2"
+            >token</a
           >
-            personal access token</a
-          >
-          with <code class="text-xs">repo</code> scope, then paste it below.
+          with <code class="text-xs">repo</code> scope below.
         </p>
       </template>
     </Alert>

--- a/admin/frontend/dashboard/src/components/settings/SettingsSectionRows.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsSectionRows.vue
@@ -10,9 +10,14 @@
       :label="section.label"
       :description="section.description"
     >
-      <Button size="sm" variant="subtle" @click="openSection = section">
-        {{ section.action || 'Manage' }}
-      </Button>
+      <!-- Icon-only, so the row's action still needs an accessible name. -->
+      <Button
+        size="sm"
+        variant="ghost"
+        icon="lucide-chevron-right"
+        :aria-label="`${section.action || 'Manage'} ${section.label}`"
+        @click="openSection = section"
+      />
     </SettingsRow>
   </div>
 </template>

--- a/admin/frontend/dashboard/src/components/settings/SettingsSectionRows.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsSectionRows.vue
@@ -10,12 +10,13 @@
       :label="section.label"
       :description="section.description"
     >
-      <!-- Icon-only, so the row's action still needs an accessible name. -->
+      <!-- Icon-only: `label` is not rendered but becomes the accessible name. A
+           plain aria-label attr would be overwritten by Button's own. -->
       <Button
         size="sm"
         variant="ghost"
         icon="lucide-chevron-right"
-        :aria-label="`${section.action || 'Manage'} ${section.label}`"
+        :label="`${section.action || 'Manage'} ${section.label}`"
         @click="openSection = section"
       />
     </SettingsRow>

--- a/admin/frontend/dashboard/src/components/sites/Backups.vue
+++ b/admin/frontend/dashboard/src/components/sites/Backups.vue
@@ -2,8 +2,8 @@
   <div class="space-y-4 mt-5">
     <div class="flex sm:flex-row flex-col sm:justify-between sm:items-center gap-3">
       <div>
-        <p class="font-medium text-ink-gray-8 text-sm">Automated backups</p>
-        <p class="mt-0.5 text-ink-gray-5 text-sm">{{ scheduleSummary }}</p>
+        <p class="font-medium text-ink-gray-8 text-base">Automated backups</p>
+        <p class="mt-0.5 text-ink-gray-5 text-p-sm">{{ scheduleSummary }}</p>
       </div>
       <div class="flex items-center gap-2 shrink-0">
         <Button variant="subtle" size="sm" @click="configRef.open()"

--- a/admin/frontend/dashboard/src/components/sites/ChooseSiteDialog.vue
+++ b/admin/frontend/dashboard/src/components/sites/ChooseSiteDialog.vue
@@ -1,19 +1,15 @@
 <template>
-  <Dialog v-model="open" :options="{ title: 'Which site are you browsing for?', size: 'md' }">
+  <Dialog v-model="open" :options="{ title: 'Choose site', size: 'md' }">
     <template #body-content>
-      <p v-if="!sites.length" class="py-6 text-ink-gray-5 text-sm text-center">
+      <p v-if="!sites.length" class="py-6 text-ink-gray-5 text-p-sm text-center">
         No sites on this bench yet. Create a site to install apps.
       </p>
 
       <template v-else>
-        <p class="mb-4 text-ink-gray-6 text-p-sm">
-          Installed apps are marked, and installs target this site.
-        </p>
-
-        <div class="gap-2 grid max-h-96 overflow-y-auto">
+        <div class="gap-0.5 grid max-h-96 overflow-y-auto">
           <SiteRow
             label="All sites"
-            subtitle="Browse every available app"
+            subtitle="Every available app"
             icon="lucide-layout-grid"
             :selected="!site"
             @click="choose('')"

--- a/admin/frontend/dashboard/src/components/sites/ChooseSiteDialog.vue
+++ b/admin/frontend/dashboard/src/components/sites/ChooseSiteDialog.vue
@@ -6,16 +6,15 @@
       </p>
 
       <template v-else>
-        <div class="gap-0.5 grid max-h-96 overflow-y-auto">
+        <div class="gap-1.5 grid max-h-96 overflow-y-auto">
           <SiteRow
             label="All sites"
-            subtitle="Every available app"
             icon="lucide-layout-grid"
             :selected="!site"
             @click="choose('')"
           >
             <template #suffix>
-              <span v-if="!site" class="size-4 text-ink-gray-8 shrink-0 lucide-check" />
+              <span v-if="!site" class="size-4 text-ink-gray-9 shrink-0 lucide-check" />
             </template>
           </SiteRow>
 
@@ -23,12 +22,17 @@
             v-for="s in sites"
             :key="s.name"
             :label="s.name"
-            :subtitle="siteSubtitle(s)"
             :selected="s.name === site"
             @click="choose(s.name)"
           >
             <template #suffix>
-              <span v-if="s.name === site" class="size-4 text-ink-gray-8 shrink-0 lucide-check" />
+              <span class="w-20 text-ink-gray-5 text-sm text-right shrink-0">
+                {{ siteMeta(s) }}
+              </span>
+              <span
+                v-if="s.name === site"
+                class="size-4 text-ink-gray-9 shrink-0 lucide-check"
+              />
             </template>
           </SiteRow>
         </div>
@@ -47,11 +51,9 @@ defineProps({
 const open = defineModel('open')
 const site = defineModel('site')
 
-function siteSubtitle(s) {
+function siteMeta(s) {
   const count = s.installed_apps?.length || 0
-  const match = /^version-(\d+)/.exec(s.framework_branch || '')
-  const version = match ? ` · Version ${match[1]}` : ''
-  return `${count} app${count === 1 ? '' : 's'}${version}`
+  return `${count} app${count === 1 ? '' : 's'}`
 }
 
 function choose(name) {

--- a/admin/frontend/dashboard/src/components/sites/SiteRow.vue
+++ b/admin/frontend/dashboard/src/components/sites/SiteRow.vue
@@ -23,8 +23,6 @@ const props = defineProps({
   interactive: { type: Boolean, default: true },
 })
 
-// Borderless: hover and selection are carried by the surface step alone, so
-// selected sits one step above hover to stay readable.
 const stateClass = computed(() => {
   if (props.disabled) return 'opacity-60 cursor-not-allowed'
   if (props.selected) return 'bg-surface-gray-3'

--- a/admin/frontend/dashboard/src/components/sites/SiteRow.vue
+++ b/admin/frontend/dashboard/src/components/sites/SiteRow.vue
@@ -2,17 +2,12 @@
   <component
     :is="interactive ? 'button' : 'div'"
     :type="interactive ? 'button' : null"
-    class="flex items-center gap-2.5 p-2 rounded min-w-0 text-left"
+    class="flex items-center gap-2.5 p-2.5 rounded min-w-0 text-left"
     :class="[stateClass, interactive && 'transition duration-150 ease-[var(--ease-out)] active:scale-[0.98]']"
     :disabled="interactive && disabled ? true : null"
   >
-    <span class="place-items-center grid bg-surface-gray-2 rounded size-6 shrink-0">
-      <span class="size-3.5" :class="[icon, checked ? 'text-ink-green-6' : 'text-ink-gray-6']" />
-    </span>
-    <div class="flex-1 min-w-0">
-      <p class="font-medium text-ink-gray-8 text-sm truncate">{{ label }}</p>
-      <p v-if="subtitle" class="text-ink-gray-5 text-sm truncate">{{ subtitle }}</p>
-    </div>
+    <span class="size-4 text-ink-gray-6 shrink-0" :class="icon" />
+    <p class="flex-1 text-ink-gray-8 text-base truncate">{{ label }}</p>
     <slot name="suffix" />
   </component>
 </template>
@@ -22,16 +17,14 @@ import { computed } from 'vue'
 
 const props = defineProps({
   label: { type: String, required: true },
-  subtitle: { type: String, default: '' },
   icon: { type: String, default: 'lucide-globe' },
-  checked: { type: Boolean, default: false },
   selected: { type: Boolean, default: false },
   disabled: { type: Boolean, default: false },
   interactive: { type: Boolean, default: true },
 })
 
-// Borderless: selection and hover are carried by the surface step alone, so
-// selected has to sit one step above hover to stay readable.
+// Borderless: hover and selection are carried by the surface step alone, so
+// selected sits one step above hover to stay readable.
 const stateClass = computed(() => {
   if (props.disabled) return 'opacity-60 cursor-not-allowed'
   if (props.selected) return 'bg-surface-gray-3'

--- a/admin/frontend/dashboard/src/components/sites/SiteRow.vue
+++ b/admin/frontend/dashboard/src/components/sites/SiteRow.vue
@@ -2,16 +2,16 @@
   <component
     :is="interactive ? 'button' : 'div'"
     :type="interactive ? 'button' : null"
-    class="flex items-center gap-3 p-3 border rounded-lg min-w-0 text-left"
+    class="flex items-center gap-2.5 p-2 rounded min-w-0 text-left"
     :class="[stateClass, interactive && 'transition duration-150 ease-[var(--ease-out)] active:scale-[0.98]']"
     :disabled="interactive && disabled ? true : null"
   >
-    <span class="place-items-center grid bg-surface-gray-2 rounded-md size-8 shrink-0">
-      <span class="size-4" :class="[icon, checked ? 'text-ink-green-6' : 'text-ink-gray-6']" />
+    <span class="place-items-center grid bg-surface-gray-2 rounded size-6 shrink-0">
+      <span class="size-3.5" :class="[icon, checked ? 'text-ink-green-6' : 'text-ink-gray-6']" />
     </span>
     <div class="flex-1 min-w-0">
       <p class="font-medium text-ink-gray-8 text-sm truncate">{{ label }}</p>
-      <p v-if="subtitle" class="text-ink-gray-5 text-p-sm truncate">{{ subtitle }}</p>
+      <p v-if="subtitle" class="text-ink-gray-5 text-sm truncate">{{ subtitle }}</p>
     </div>
     <slot name="suffix" />
   </component>
@@ -30,9 +30,11 @@ const props = defineProps({
   interactive: { type: Boolean, default: true },
 })
 
+// Borderless: selection and hover are carried by the surface step alone, so
+// selected has to sit one step above hover to stay readable.
 const stateClass = computed(() => {
-  if (props.disabled) return 'border-outline-gray-2 opacity-60 cursor-not-allowed'
-  if (props.selected) return 'border-outline-gray-4 bg-surface-gray-1'
-  return props.interactive ? 'border-outline-gray-2 hover:bg-surface-gray-1' : 'border-outline-gray-2'
+  if (props.disabled) return 'opacity-60 cursor-not-allowed'
+  if (props.selected) return 'bg-surface-gray-3'
+  return props.interactive ? 'hover:bg-surface-gray-2' : ''
 })
 </script>

--- a/admin/frontend/dashboard/src/pages/marketplace/Marketplace.vue
+++ b/admin/frontend/dashboard/src/pages/marketplace/Marketplace.vue
@@ -45,7 +45,7 @@
     <!-- Marketplace Apps -->
 
     <template v-else-if="isFiltered">
-      <section v-if="filteredApps.length" class="mt-6">
+      <section v-if="filteredApps.length" class="mt-12">
         <h2 class="font-medium text-ink-gray-9 text-base">
           {{ filteredHeading }}
         </h2>
@@ -62,7 +62,7 @@
     </template>
 
     <template v-else>
-      <section v-if="otherBenchApps.length" class="mt-6">
+      <section v-if="otherBenchApps.length" class="mt-12">
         <h2 class="font-medium text-ink-gray-9 text-base">Your custom apps</h2>
         <div class="gap-x-6 gap-y-4 grid grid-cols-1 md:grid-cols-2 mt-3">
           <MarketplaceAppCard
@@ -74,7 +74,7 @@
         </div>
       </section>
 
-      <section v-if="frappeApps.length" class="mt-6">
+      <section v-if="frappeApps.length" :class="otherBenchApps.length ? 'mt-10' : 'mt-12'">
         <h2 class="font-medium text-ink-gray-9 text-base">From Frappe</h2>
         <div class="gap-x-6 gap-y-4 grid grid-cols-1 md:grid-cols-2 mt-3">
           <MarketplaceAppCard
@@ -86,7 +86,7 @@
         </div>
       </section>
 
-      <section v-if="communityApps.length" class="mt-6">
+      <section v-if="communityApps.length" class="mt-10">
         <h2 class="font-medium text-ink-gray-9 text-base">Community</h2>
         <div class="gap-x-6 gap-y-4 grid grid-cols-1 md:grid-cols-2 mt-3">
           <MarketplaceAppCard

--- a/admin/frontend/dashboard/src/pages/marketplace/Marketplace.vue
+++ b/admin/frontend/dashboard/src/pages/marketplace/Marketplace.vue
@@ -1,16 +1,13 @@
 <template>
-  <div class="mx-auto max-w-3xl">
+  <div class="mx-auto max-w-3xl pb-40">
     <!-- Header -->
     <div class="flex justify-between items-start gap-4 pt-4 pb-2">
       <div class="flex flex-col items-start">
         <div class="flex items-center gap-2.5">
-          <!-- !font-semibold: responsive text-* classes bake font-weight 420 and would override it -->
-          <h1 class="!font-semibold text-ink-gray-9 text-2xl sm:text-3xl tracking-tight">
-            Explore Frappe Marketplace
-          </h1>
+          <h1 class="font-semibold text-ink-gray-9 text-xl">Explore Frappe Marketplace</h1>
           <span
             v-if="benchVersionLabel"
-            class="inline-flex items-center gap-1 bg-surface-gray-2 px-2 py-0.5 rounded-full h-min text-ink-gray-6 text-p-xs shrink-0"
+            class="inline-flex items-center gap-1 bg-surface-gray-2 px-2 py-0.5 rounded-full h-min text-ink-gray-6 text-xs shrink-0"
           >
             <span class="size-3 lucide-box"></span> {{ benchVersionLabel }}
           </span>
@@ -19,20 +16,15 @@
           Open source apps built by developers worldwide for the Frappe ecosystem
         </p>
       </div>
-      <button
-        type="button"
-        class="group inline-flex items-center bg-surface-gray-2 hover:bg-surface-gray-3 active:scale-[0.97] mt-1 px-2.5 py-1 rounded-full h-min text-ink-gray-7 text-p-sm shrink-0 transition duration-200 ease-[var(--ease-out)]"
-        @click="showChooseSite = true"
-      >
-        <span
-          class="size-3.5 text-ink-gray-5 mr-1.5"
-          :class="currentSiteName ? 'lucide-globe' : 'lucide-layout-grid'"
-        />
+      <Button class="shrink-0" @click="showChooseSite = true">
+        <template #prefix>
+          <span class="size-4 text-ink-gray-5 lucide-globe" />
+        </template>
         {{ siteLabel }}
-        <span
-          class="size-3.5 text-ink-gray-5 max-w-0 ml-0 opacity-0 overflow-hidden group-hover:max-w-4 group-hover:ml-1 group-hover:opacity-100 transition-[max-width,margin,opacity] duration-200 ease-[var(--ease-out)] lucide-square-pen"
-        />
-      </button>
+        <template #suffix>
+          <span class="size-4 text-ink-gray-5 lucide-chevron-down" />
+        </template>
+      </Button>
     </div>
 
     <!-- Filters -->
@@ -53,10 +45,10 @@
     <!-- Marketplace Apps -->
 
     <template v-else-if="isFiltered">
-      <section v-if="filteredApps.length" class="mt-12">
-        <p class="font-medium text-ink-gray-9 text-base">
+      <section v-if="filteredApps.length" class="mt-6">
+        <h2 class="font-medium text-ink-gray-9 text-base">
           {{ filteredHeading }}
-        </p>
+        </h2>
         <div class="gap-x-6 gap-y-4 grid grid-cols-1 md:grid-cols-2 mt-3">
           <MarketplaceAppCard
             v-for="app in filteredApps"
@@ -70,8 +62,8 @@
     </template>
 
     <template v-else>
-      <section v-if="otherBenchApps.length" class="mt-12">
-        <p class="font-medium text-ink-gray-9 text-base">Your custom apps</p>
+      <section v-if="otherBenchApps.length" class="mt-6">
+        <h2 class="font-medium text-ink-gray-9 text-base">Your custom apps</h2>
         <div class="gap-x-6 gap-y-4 grid grid-cols-1 md:grid-cols-2 mt-3">
           <MarketplaceAppCard
             v-for="app in otherBenchApps"
@@ -82,8 +74,8 @@
         </div>
       </section>
 
-      <section v-if="frappeApps.length" :class="otherBenchApps.length ? 'mt-10' : 'mt-12'">
-        <p class="font-medium text-ink-gray-9 text-base">From Frappe</p>
+      <section v-if="frappeApps.length" class="mt-6">
+        <h2 class="font-medium text-ink-gray-9 text-base">From Frappe</h2>
         <div class="gap-x-6 gap-y-4 grid grid-cols-1 md:grid-cols-2 mt-3">
           <MarketplaceAppCard
             v-for="app in frappeApps"
@@ -94,8 +86,8 @@
         </div>
       </section>
 
-      <section v-if="communityApps.length" class="mt-10">
-        <p class="font-medium text-ink-gray-9 text-base">Community</p>
+      <section v-if="communityApps.length" class="mt-6">
+        <h2 class="font-medium text-ink-gray-9 text-base">Community</h2>
         <div class="gap-x-6 gap-y-4 grid grid-cols-1 md:grid-cols-2 mt-3">
           <MarketplaceAppCard
             v-for="app in communityApps"
@@ -128,7 +120,7 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
-import { ErrorMessage, LoadingText } from 'frappe-ui'
+import { Button, ErrorMessage, LoadingText } from 'frappe-ui'
 import AddAppFromGithubDialog from '@/components/apps/AddAppFromGithubDialog.vue'
 import ChooseSiteDialog from '@/components/sites/ChooseSiteDialog.vue'
 import InstallAppDialog from '@/components/apps/InstallAppDialog.vue'

--- a/admin/frontend/dashboard/src/pages/sites/SiteDetail.vue
+++ b/admin/frontend/dashboard/src/pages/sites/SiteDetail.vue
@@ -10,17 +10,17 @@
     <div class="relative -mx-4 sm:-mx-6 -mt-6 px-4 sm:px-6 pt-6 pb-7 overflow-hidden">
       <div class="absolute inset-0 pointer-events-none dot-field" aria-hidden="true" />
       <div
-        class="relative flex justify-between items-center gap-3 bg-surface-base p-2 sm:p-4 border rounded-xl border-outline-gray-2"
+        class="relative flex justify-between items-center gap-3 mt-2 bg-surface-base p-2 sm:p-4 border rounded-xl border-outline-gray-2"
       >
         <div class="flex items-center gap-3 min-w-0">
           <span
-            class="place-items-center grid bg-surface-elevation-1 border rounded-xl border-outline-gray-2 size-10 sm:size-12 text-ink-gray-6 shrink-0"
+            class="place-items-center grid bg-surface-gray-2 rounded-lg size-9 sm:size-10 text-ink-gray-6 shrink-0"
           >
-            <span class="size-5 sm:size-6 lucide-globe" />
+            <span class="size-4 sm:size-5 lucide-globe" />
           </span>
           <div class="min-w-0">
             <div class="flex items-center gap-2 min-w-0">
-              <h1 class="font-semibold text-ink-gray-9 text-base sm:text-xl truncate">
+              <h1 class="font-medium text-ink-gray-9 text-lg truncate">
                 {{ site.name }}
               </h1>
               <Badge
@@ -268,8 +268,8 @@ onMounted(() => {
 <style scoped>
 .dot-field {
   background-image: radial-gradient(var(--outline-gray-3) 1.1px, transparent 1.3px);
-  background-size: 20px 20px;
-  background-position: -8px -8px;
-  mask-image: linear-gradient(to bottom, rgb(0 0 0 / 0.95), transparent 90%);
+  background-size: 12px 12px;
+  background-position: -5px -5px;
+  mask-image: linear-gradient(to bottom, rgb(0 0 0 / 0.95), transparent 100%);
 }
 </style>


### PR DESCRIPTION
A pass over the Marketplace, its dialogs, Settings and the Site detail hero — mostly spacing, type scale and state styling, plus a few behavioural fixes noted below.

## Behaviour

- **Repo URLs without a scheme now work.** Branch lookup, app resolution and import each trimmed the raw field value, so `github.com/frappe/crm` failed even though the field asks for a repository URL. Normalised once, and every call routed through it.
- **Branches auto-fetch on the public tab**, matching the private tab, which already loaded them on selection. The "Fetch branches" button is gone.
- **An unconnected GitHub account gets a way out** — the disabled "Import app" becomes "Connect GitHub" and routes to Settings → GitHub.
- **A one-site bench is no longer asked which site to install on.** The row renders selected but inert and Install is live on open, instead of sitting disabled behind a click on the only row there was.

## UI

- Install dialog: the title names the app (`Install ERPNext on`), so the subject block repeating the app you just clicked is gone. App counts sit in a fixed-width right column; an already-installed site keeps its count with a check beside it.
- Site picker rows lose `subtitle` and `checked` — no caller set either — leaving a single-line row with a suffix slot.
- Settings sections use chevrons: "Manage"/"Change" described the button rather than the destination, and these rows open a sub-page.
- Site detail hero: filled gray tile instead of an outlined one on a near-identical surface, smaller icon, denser dot field, and the site name at a true 16px (it was rendering 17px because the responsive step overrode the base size).
- Updates dialog, marketplace list and Backups header: spacing and type-scale corrections, single-line labels moved to the tight scale and wrapping copy to the loose one.

## Accessibility

`Button` merges its own `aria-label` from `label` after `$attrs`, so an `aria-label` passed as an attribute is silently dropped — the icon-only settings chevrons were announcing as unlabelled buttons. They pass `label` now. The install dialog's "already installed" check gained `role="img"`, since `aria-label` on a bare span is ignored.

## Notes for review

- Rebased onto current `develop`; the GitHub dialog conflicted with recent upstream work and both sides were kept — `allowCustomValue` on the branch field, and the `siteName` prop's "will be installed on" hint, "Import and install" label and `sites:` payload.
- `9c45b662`'s message claims scheme-less URLs work; the actual fix landed in `f80e0fe2`.
- Verified by compile and code review only — not yet exercised in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)