### PR TITLE
fix: park a migration whose chain task is killed

### DIFF
--- a/pilot/core/bench/migration/operation.py
+++ b/pilot/core/bench/migration/operation.py
@@ -246,6 +246,30 @@ class MigrationOperation:
         if self.next_migrate_site() is None:
             self._complete(on_step)
 
+    def strand(self, reason: str) -> None:
+        """Park a chain whose task died without unwinding: a kill, an OOM, a reboot.
+
+        Every other write to this record happens inside the task process, so a
+        task that never raises leaves the operation spinning in a working state
+        forever - no retry, no restore, and no new update allowed past it.
+        """
+        target = self.state.failure_target
+        if target is None:
+            return
+        self.diagnosis = {"phase": self.state.name, "message": reason, "output_excerpt": ""}
+        if target == "revert_failed":
+            self._transition(target)
+            return
+        self._enter_needs_attention(self.state.name, self._interrupted_site())
+
+    def _interrupted_site(self) -> str | None:
+        """The site whose per-site work was in flight when the chain died."""
+        if self.state == "backing_up":
+            return next((site.name for site in self.sites if site.backup_status == "backing_up"), None)
+        if self.state == "migrating":
+            return next((site.name for site in self.sites if site.migration_status == "running"), None)
+        return None
+
     def retry(self) -> None:
         """Resume the chain from needs_attention so the failed unit runs again."""
         if self.state != "needs_attention":

--- a/pilot/core/bench/migration/state.py
+++ b/pilot/core/bench/migration/state.py
@@ -20,6 +20,7 @@ class MigrationState:
     is_terminal: ClassVar[bool] = False
     is_failure: ClassVar[bool] = False  # paused on a failure, waiting for the user
     starts_work: ClassVar[bool] = False
+    failure_target: ClassVar[str | None] = None  # where work parks when its task dies
     allowed: ClassVar[frozenset[str]] = frozenset()
 
     def next_step(self, operation: "MigrationOperation") -> ChainStep | None:
@@ -51,6 +52,7 @@ class BackingUp(MigrationState):
     name = "backing_up"
     label = "Backing up"
     starts_work = True
+    failure_target = "needs_attention"
     allowed = frozenset({"updating", "migrating", "needs_attention"})
 
     def next_step(self, operation: "MigrationOperation") -> ChainStep | None:
@@ -62,6 +64,7 @@ class Updating(MigrationState):
     name = "updating"
     label = "Updating apps"
     starts_work = True
+    failure_target = "needs_attention"
     allowed = frozenset({"migrating", "needs_attention"})
 
     def next_step(self, operation: "MigrationOperation") -> ChainStep | None:
@@ -72,6 +75,7 @@ class Migrating(MigrationState):
     name = "migrating"
     label = "Migrating"
     starts_work = True
+    failure_target = "needs_attention"
     allowed = frozenset({"completed", "needs_attention"})
 
     def next_step(self, operation: "MigrationOperation") -> ChainStep | None:
@@ -96,6 +100,7 @@ class RevertingApps(MigrationState):
     name = "reverting_apps"
     label = "Reverting app revisions"
     starts_work = True
+    failure_target = "revert_failed"
     allowed = frozenset({"reverting_sites", "restarting", "revert_failed"})
 
     def next_step(self, operation: "MigrationOperation") -> ChainStep | None:
@@ -106,6 +111,7 @@ class RevertingSites(MigrationState):
     name = "reverting_sites"
     label = "Recovering sites"
     starts_work = True
+    failure_target = "revert_failed"
     allowed = frozenset({"restarting", "revert_failed"})
 
     def next_step(self, operation: "MigrationOperation") -> ChainStep | None:
@@ -117,6 +123,7 @@ class Restarting(MigrationState):
     name = "restarting"
     label = "Restarting services"
     starts_work = True
+    failure_target = "revert_failed"
     allowed = frozenset({"reverted", "revert_failed"})
 
     def next_step(self, operation: "MigrationOperation") -> ChainStep | None:

--- a/pilot/core/bench/migration/store.py
+++ b/pilot/core/bench/migration/store.py
@@ -7,8 +7,14 @@ from typing import TYPE_CHECKING
 
 from pilot.core.bench.migration.operation import AppRevision, MigrationOperation, SiteProgress
 from pilot.core.bench.migration.state import get_state
-from pilot.exceptions import BenchError, MigrationConflictError, MigrationNotFoundError
+from pilot.exceptions import (
+    BenchError,
+    MigrationConflictError,
+    MigrationNotFoundError,
+    TaskNotFoundError,
+)
 from pilot.internal.atomic_file import atomic_write_private_text
+from pilot.internal.tasks.store import TaskStore
 from pilot.utils import make_private_directory
 
 if TYPE_CHECKING:
@@ -74,9 +80,30 @@ class MigrationStore:
             raise MigrationNotFoundError(f"Migration operation not found: {operation_id}")
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-            return MigrationOperation.from_dict(data, self.bench, self)
+            operation = MigrationOperation.from_dict(data, self.bench, self)
         except (OSError, ValueError, KeyError, TypeError) as error:
             raise BenchError(f"Could not load migration operation {path.name}: {error}") from error
+        self._strand_if_abandoned(operation)
+        return operation
+
+    def _strand_if_abandoned(self, operation: MigrationOperation) -> None:
+        """Park an operation whose chain ended without anything advancing the record.
+
+        The task callback covers a killed link. This covers the runs where the
+        callback never got to fire either - a host reboot, or the task wrapper
+        itself being killed - so the operation still heals on the next read.
+        """
+        if operation.state.failure_target is None or not operation.chain:
+            return
+        task_id = operation.chain[-1].get("task_id")
+        if not isinstance(task_id, str):
+            return
+        try:
+            status = TaskStore(self.bench.path).read_status(task_id)
+        except (OSError, ValueError, TaskNotFoundError):
+            return
+        if status.is_terminal:
+            operation.strand(f"The {operation.state.label.lower()} step stopped without reporting back.")
 
     def get_all(self) -> list[MigrationOperation]:
         if not self.root.exists():

--- a/pilot/internal/tasks/callbacks.py
+++ b/pilot/internal/tasks/callbacks.py
@@ -93,11 +93,25 @@ def _reload_workers(meta: dict, args: dict) -> None:
     Bench(Path(meta["bench_root"])).reload_workers(web_only=args.get("web_only", False))
 
 
+def _strand_migration(meta: dict, args: dict) -> None:
+    """Park a migration whose chain link died. Runs for every failed link, so it is
+    a no-op once the link already reported the failure from inside its own process."""
+    from pilot.core.bench import Bench
+    from pilot.exceptions import MigrationNotFoundError
+
+    try:
+        operation = Bench(Path(meta["bench_root"])).migrations.get(args["operation_id"])
+    except MigrationNotFoundError:
+        return
+    operation.strand(f"The {operation.state.label.lower()} step stopped before it could report back.")
+
+
 _OPERATIONS: dict[str, CallbackOperation] = {
     "cleanup-site-restore": _cleanup_site_restore,
     "remove-failed-site": _remove_failed_site,
     "disable-site-ssl": _disable_site_ssl,
     "reload-workers": _reload_workers,
+    "strand-migration": _strand_migration,
 }
 
 

--- a/pilot/tasks/migrate.py
+++ b/pilot/tasks/migrate.py
@@ -1,27 +1,19 @@
-import sys
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pilot.tasks import Task
+from pilot.tasks.migration_chain import MigrationChainTask
 
 
 @dataclass(kw_only=True)
-class MigrateTask(Task):
+class MigrateTask(MigrationChainTask):
     """Chain link: migrate one site, then queue the next site (or complete)."""
 
     command: ClassVar[str] = "migrate"
 
-    operation_id: str
     site: str
 
-    def run(self) -> None:
-        operation = self.bench.migrations.get(self.operation_id)
-        try:
-            operation.migrate_site(self.site, on_step=self.step, on_progress=self.report)
-        except Exception:
-            self.step_failed()
-            sys.exit(1)
-        operation.enqueue_next(handoff_from=operation.chain[-1]["task_id"])
+    def run_step(self, operation) -> None:
+        operation.migrate_site(self.site, on_step=self.step, on_progress=self.report)
 
 
 if __name__ == "__main__":

--- a/pilot/tasks/migration_backup.py
+++ b/pilot/tasks/migration_backup.py
@@ -1,29 +1,20 @@
-import sys
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pilot.tasks import Task
+from pilot.tasks.migration_chain import MigrationChainTask
 
 
 @dataclass(kw_only=True)
-class MigrationBackupTask(Task):
+class MigrationBackupTask(MigrationChainTask):
     """Chain link: back up one site's tables before a migration, then queue the next step."""
 
     command: ClassVar[str] = "migration-backup"
 
-    operation_id: str
     site: str
 
-    def run(self) -> None:
-        operation = self.bench.migrations.get(self.operation_id)
-        try:
-            operation.back_up_site(self.site, on_step=self.step, on_progress=self.report)
-        except Exception:
-            self.step_failed()
-            sys.exit(1)
-        operation.enqueue_next(handoff_from=operation.chain[-1]["task_id"])
+    def run_step(self, operation) -> None:
+        operation.back_up_site(self.site, on_step=self.step, on_progress=self.report)
 
 
 if __name__ == "__main__":
     MigrationBackupTask.main()
-

--- a/pilot/tasks/migration_chain.py
+++ b/pilot/tasks/migration_chain.py
@@ -1,0 +1,34 @@
+import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from pilot.tasks import Task, on_cancel, on_failure
+
+if TYPE_CHECKING:
+    from pilot.core.bench.migration.operation import MigrationOperation
+
+
+@dataclass(kw_only=True)
+class MigrationChainTask(Task):
+    """One link of a migration chain: run its step, then queue whatever the operation wants next."""
+
+    operation_id: str
+
+    def run(self) -> None:
+        operation = self.bench.migrations.get(self.operation_id)
+        try:
+            self.run_step(operation)
+        except Exception:
+            self.step_failed()
+            sys.exit(1)
+        operation.enqueue_next(handoff_from=operation.chain[-1]["task_id"])
+
+    def run_step(self, operation: "MigrationOperation") -> None:
+        raise NotImplementedError
+
+    @on_failure
+    @on_cancel
+    def strand_migration(self) -> dict:
+        """A killed link never reaches its own error handling, so the operation is
+        parked from outside instead - by the wrapper, or by task reconciliation."""
+        return {"operation_id": self.operation_id}

--- a/pilot/tasks/restart_services.py
+++ b/pilot/tasks/restart_services.py
@@ -1,26 +1,17 @@
-import sys
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pilot.tasks import Task
+from pilot.tasks.migration_chain import MigrationChainTask
 
 
 @dataclass(kw_only=True)
-class RestartServicesTask(Task):
+class RestartServicesTask(MigrationChainTask):
     """Chain link: restart services to finish a restore, then mark the operation reverted."""
 
     command: ClassVar[str] = "restart-services"
 
-    operation_id: str
-
-    def run(self) -> None:
-        operation = self.bench.migrations.get(self.operation_id)
-        try:
-            operation.restart(on_step=self.step)
-        except Exception:
-            self.step_failed()
-            sys.exit(1)
-        operation.enqueue_next(handoff_from=operation.chain[-1]["task_id"])
+    def run_step(self, operation) -> None:
+        operation.restart(on_step=self.step)
 
 
 if __name__ == "__main__":

--- a/pilot/tasks/revert_apps.py
+++ b/pilot/tasks/revert_apps.py
@@ -1,26 +1,17 @@
-import sys
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pilot.tasks import Task
+from pilot.tasks.migration_chain import MigrationChainTask
 
 
 @dataclass(kw_only=True)
-class RevertAppsTask(Task):
+class RevertAppsTask(MigrationChainTask):
     """Chain link: roll app revisions back and rebuild, then queue the next revert step."""
 
     command: ClassVar[str] = "revert-apps"
 
-    operation_id: str
-
-    def run(self) -> None:
-        operation = self.bench.migrations.get(self.operation_id)
-        try:
-            operation.revert_apps(on_step=self.step, on_progress=self.report)
-        except Exception:
-            self.step_failed()
-            sys.exit(1)
-        operation.enqueue_next(handoff_from=operation.chain[-1]["task_id"])
+    def run_step(self, operation) -> None:
+        operation.revert_apps(on_step=self.step, on_progress=self.report)
 
 
 if __name__ == "__main__":

--- a/pilot/tasks/revert_site.py
+++ b/pilot/tasks/revert_site.py
@@ -1,27 +1,19 @@
-import sys
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pilot.tasks import Task
+from pilot.tasks.migration_chain import MigrationChainTask
 
 
 @dataclass(kw_only=True)
-class RevertSiteTask(Task):
+class RevertSiteTask(MigrationChainTask):
     """Chain link: restore one site's database and clear its cache, then queue the next site."""
 
     command: ClassVar[str] = "revert-site"
 
-    operation_id: str
     site: str
 
-    def run(self) -> None:
-        operation = self.bench.migrations.get(self.operation_id)
-        try:
-            operation.revert_site(self.site, on_step=self.step, on_progress=self.report)
-        except Exception:
-            self.step_failed()
-            sys.exit(1)
-        operation.enqueue_next(handoff_from=operation.chain[-1]["task_id"])
+    def run_step(self, operation) -> None:
+        operation.revert_site(self.site, on_step=self.step, on_progress=self.report)
 
 
 if __name__ == "__main__":

--- a/pilot/tasks/update.py
+++ b/pilot/tasks/update.py
@@ -1,26 +1,17 @@
-import sys
 from dataclasses import dataclass
 from typing import ClassVar
 
-from pilot.tasks import Task
+from pilot.tasks.migration_chain import MigrationChainTask
 
 
 @dataclass(kw_only=True)
-class UpdateTask(Task):
+class UpdateTask(MigrationChainTask):
     """Chain link: update/reinstall/rebuild apps, then queue the first site migration."""
 
     command: ClassVar[str] = "update"
 
-    operation_id: str
-
-    def run(self) -> None:
-        operation = self.bench.migrations.get(self.operation_id)
-        try:
-            operation.update_apps(on_step=self.step, on_progress=self.report)
-        except Exception:
-            self.step_failed()
-            sys.exit(1)
-        operation.enqueue_next(handoff_from=operation.chain[-1]["task_id"])
+    def run_step(self, operation) -> None:
+        operation.update_apps(on_step=self.step, on_progress=self.report)
 
 
 if __name__ == "__main__":

--- a/tests/pilot/core/test_migration_operation.py
+++ b/tests/pilot/core/test_migration_operation.py
@@ -665,3 +665,129 @@ def test_bypass_patch_auto_resumes_migration(tmp_path: Path) -> None:
     assert operation.state == "migrating"
     assert operation.failed_site is None
     assert operation.sites[0].migration_status == "pending"
+
+
+def _write_task_status(bench_root: Path, task_id: str, status: str) -> None:
+    task_dir = bench_root / "tasks" / task_id
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "status").write_text(status, encoding="utf-8")
+
+
+def test_strand_parks_a_working_operation_for_the_user(tmp_path: Path) -> None:
+    """A killed chain link never raises, so nothing else would ever move this record."""
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    operation = MigrationStore(mock_bench).create_site_migrate("site1.localhost")
+    operation.state = get_state("updating")
+
+    operation.strand("The update was killed")
+
+    assert operation.state == "needs_attention"
+    assert operation.return_state == "updating"
+    assert operation.diagnosis["message"] == "The update was killed"
+    assert operation.diagnosis["phase"] == "updating"
+
+
+def test_strand_blames_the_site_that_was_in_flight(tmp_path: Path) -> None:
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    store = MigrationStore(mock_bench)
+    operation = store._create("update", apps=[], apps_filter=None, sites=["one.local", "two.local"])
+    operation.state = get_state("migrating")
+    operation.sites[0].migration_status = "success"
+    operation.sites[1].migration_status = "running"
+
+    operation.strand("The migration was killed")
+
+    assert operation.state == "needs_attention"
+    assert operation.failed_site == "two.local"
+
+    operation.retry()
+
+    assert operation.state == "migrating"
+    assert operation.sites[1].migration_status == "pending"
+
+
+def test_strand_sends_a_dying_revert_to_revert_failed(tmp_path: Path) -> None:
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    operation = MigrationStore(mock_bench).create_site_migrate("site1.localhost")
+    operation.state = get_state("reverting_sites")
+
+    operation.strand("The restore was killed")
+
+    assert operation.state == "revert_failed"
+
+
+def test_strand_leaves_a_settled_operation_alone(tmp_path: Path) -> None:
+    """Every failed link fires the callback, including one that already reported."""
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    operation = MigrationStore(mock_bench).create_site_migrate("site1.localhost")
+    operation.state = get_state("needs_attention")
+    operation.diagnosis = {"patch": "frappe.patches.expected"}
+
+    operation.strand("The migration was killed")
+
+    assert operation.state == "needs_attention"
+    assert operation.diagnosis == {"patch": "frappe.patches.expected"}
+
+
+def test_reading_an_operation_parks_it_when_its_chain_task_is_dead(tmp_path: Path) -> None:
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    store = MigrationStore(mock_bench)
+    operation = store.create_site_migrate("site1.localhost")
+    operation.state = get_state("updating")
+    operation.chain.append({"command": "update", "task_id": "20260731-120000-abc123"})
+    store.save(operation)
+    _write_task_status(tmp_path, "20260731-120000-abc123", "failed")
+
+    assert store.get(operation.id).state == "needs_attention"
+    assert store.current() is not None
+
+
+def test_reading_an_operation_leaves_a_live_chain_task_running(tmp_path: Path) -> None:
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    store = MigrationStore(mock_bench)
+    operation = store.create_site_migrate("site1.localhost")
+    operation.state = get_state("updating")
+    operation.chain.append({"command": "update", "task_id": "20260731-120000-abc123"})
+    store.save(operation)
+    _write_task_status(tmp_path, "20260731-120000-abc123", "running")
+
+    assert store.get(operation.id).state == "updating"
+
+
+def test_reading_an_operation_survives_a_pruned_task_record(tmp_path: Path) -> None:
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    store = MigrationStore(mock_bench)
+    operation = store.create_site_migrate("site1.localhost")
+    operation.state = get_state("updating")
+    operation.chain.append({"command": "update", "task_id": "20260731-120000-dead99"})
+    store.save(operation)
+
+    assert store.get(operation.id).state == "updating"

--- a/tests/pilot/managers/task/test_task_callbacks.py
+++ b/tests/pilot/managers/task/test_task_callbacks.py
@@ -186,3 +186,63 @@ def test_cleanup_site_restore_refuses_symlinked_upload_root(tmp_path: Path) -> N
         )
 
     assert upload_dir.exists()
+
+
+def _bench_root(tmp_path: Path) -> Path:
+    (tmp_path / "bench.toml").write_text('[bench]\nname = "test-bench"\npython = "3.14"\n')
+    return tmp_path
+
+
+def test_strand_migration_operation_parks_the_operation(tmp_path: Path) -> None:
+    from unittest.mock import MagicMock
+
+    from pilot.core.bench.migration.state import get_state
+    from pilot.core.bench.migration.store import MigrationStore
+
+    bench_root = _bench_root(tmp_path)
+    mock_bench = MagicMock()
+    mock_bench.path = bench_root
+    store = MigrationStore(mock_bench)
+    operation = store.create_site_migrate("site1.localhost")
+    operation.state = get_state("updating")
+    store.save(operation)
+
+    callbacks.run_callback(
+        {"operation": "strand-migration", "args": {"operation_id": operation.id}},
+        {"bench_root": str(bench_root)},
+    )
+
+    assert store.get(operation.id).state == "needs_attention"
+
+
+def test_strand_migration_operation_ignores_a_deleted_operation(tmp_path: Path) -> None:
+    callbacks.run_callback(
+        {"operation": "strand-migration", "args": {"operation_id": "20260731-120000-abc123"}},
+        {"bench_root": str(_bench_root(tmp_path))},
+    )
+
+
+def test_every_migration_chain_task_declares_the_strand_callback() -> None:
+    from unittest.mock import MagicMock
+
+    from pilot.internal.tasks.runner import discover_tasks
+    from pilot.tasks.callbacks import task_callbacks_for
+    from pilot.tasks.migration_chain import MigrationChainTask
+
+    chain_tasks = [task for task in discover_tasks() if issubclass(task, MigrationChainTask)]
+    assert {task.command for task in chain_tasks} == {
+        "migration-backup",
+        "update",
+        "migrate",
+        "revert-apps",
+        "revert-site",
+        "restart-services",
+    }
+
+    expected = {"operation": "strand-migration", "args": {"operation_id": "op-1"}}
+    for task_class in chain_tasks:
+        args = {"site": "site1.localhost"} if "site" in task_class.__dataclass_fields__ else {}
+        task = task_class(bench=MagicMock(), bench_root=Path("/bench"), operation_id="op-1", **args)
+        declared = task_callbacks_for(task)
+        assert declared["on_failure"] == expected
+        assert declared["on_cancel"] == expected


### PR DESCRIPTION
A killed chain task never reaches the `except` blocks that move a migration to `needs_attention`, so the operation froze mid-flight: the UI spun on "Updating" forever, Retry/Restore stayed hidden (both gated on `needs_attention`), and `store.current()` blocked every future update with `MigrationConflictError`. Recovery meant hand-editing the operation JSON.

Hit on a real bench — task `20260731-173422-815719` took a SIGTERM partway through `update_apps` and exited `-15`.

Each working state now declares the state it parks in, and `MigrationOperation.strand()` moves it there from outside the task process. Two callers:

- a `strand-migration` callback declared by every chain link, fired by the task wrapper on a kill and by `TaskProcess.reconcile()` for an orphaned link
- `MigrationStore.get()`, when the last chain task is terminal but the record still claims work is in progress — covers a reboot or a killed wrapper, where the callback never runs either

The six chain tasks were identical apart from the call they wrapped, so they now share `MigrationChainTask`.
