### PR TITLE
fix(config): read shared DB tables from bench.toml until migration runs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,4 +144,4 @@ jwks_audience = "bench-fleet"
 
 The host-wide system/DB/slow-query monitor log paths (`system_log_path`/`db_log_path`/`slow_query_log_path`) are not configurable at all, in `bench.toml` or `common_config.toml` - they're fixed at `cli_root()/system/logs/{system-stats.log,db-stats.log,slow-queries.json}` (see `pilot/config/monitor.py`).
 
-A pre-upgrade bench whose `bench.toml` still carries these fields directly is migrated by the `merge_common_config` patch - see [pilot/patches](../pilot/patches) and `pilot admin run-patches`.
+A pre-upgrade bench whose `bench.toml` still carries these fields directly is migrated by the `merge_common_config` patch - see [pilot/patches](../pilot/patches) and `pilot admin run-patches`. Until that patch runs, a host with no `common_config.toml` reads these tables from each bench's own `bench.toml`, so an unmigrated bench keeps the servers and credentials it was set up with instead of falling back to the defaults.

--- a/pilot/config/bench.py
+++ b/pilot/config/bench.py
@@ -132,9 +132,9 @@ class BenchConfig:
     @classmethod
     def from_file(cls, path: Path) -> "BenchConfig":
         """Read a bench.toml at an arbitrary path. Host-shared fields only
-        merge in correctly when `path` sits at the real `<benches_root>/
-        <bench>/bench.toml` depth (see `_benches_root`) - a standalone file
-        elsewhere merges with an empty CommonConfig instead."""
+        merge in from common_config.toml when `path` sits at the real
+        `<benches_root>/<bench>/bench.toml` depth (see `_benches_root`); a
+        standalone file falls back to the tables it carries itself."""
         with path.open("rb") as fh:
             data = tomllib.load(fh)
         config = cls._from_dict(data, common=cls._read_common(path))
@@ -176,8 +176,11 @@ class BenchConfig:
 
     @classmethod
     def _from_dict(cls, data: dict, *, common: CommonConfig | None = None, strict: bool = False) -> "BenchConfig":
+        """Without a common_config.toml to merge, the shared tables come from
+        this bench.toml itself - a pre-migration file still carries them, and
+        its real values must win over the dataclass defaults."""
         cls._report_unknown_fields(data, strict=strict)
-        common = common or CommonConfig()
+        common = common or CommonConfig.from_raw_dict(data)
         bench_data = data.get("bench", {})
         apps = [
             AppConfig(
@@ -331,9 +334,13 @@ class BenchConfig:
 
     @classmethod
     def _read_common(cls, bench_root: Path | None) -> CommonConfig | None:
-        """The host-shared config this bench merges with, or None if bench_root
-        is unknown (only _validate_serialized calls it without one)."""
-        return CommonConfig.read(cls._benches_root(bench_root)) if bench_root else None
+        """The host-shared config this bench merges with, or None when there is
+        no such file - an unknown bench_root (only _validate_serialized calls it
+        without one), or a host that has not been migrated to it yet."""
+        if bench_root is None:
+            return None
+        benches_root = cls._benches_root(bench_root)
+        return CommonConfig.read(benches_root) if CommonConfig.path(benches_root).exists() else None
 
     @classmethod
     def exists(cls, bench_root: Path) -> bool:

--- a/tests/pilot/config/test_bench_toml_fixtures.py
+++ b/tests/pilot/config/test_bench_toml_fixtures.py
@@ -38,15 +38,13 @@ def test_representative_bench_toml_loads_and_round_trips(
     assert BenchConfig.from_file(round_trip_path) == config
 
 
-def test_from_file_on_a_standalone_fixture_ignores_its_own_common_fields() -> None:
-    """development_postgres.toml carries real postgres/jwks values, but
-    from_file() on a bare path (no common_config.toml two levels up) merges
-    an empty CommonConfig instead of reading them - see from_file()'s
-    docstring. This documents that known limitation explicitly."""
+def test_from_file_on_a_standalone_fixture_reads_its_own_common_fields() -> None:
+    """development_postgres.toml carries real postgres/jwks values and has no
+    common_config.toml two levels up, so from_file() keeps what it declares."""
     config = BenchConfig.from_file(FIXTURES / "development_postgres.toml")
-    assert config.postgres.host == "localhost"  # CommonConfig() default, not the fixture's "db.internal"
-    assert config.postgres.root_password == ""  # not the fixture's "fixture-postgres-password"
-    assert config.admin.jwks_url == ""  # not the fixture's real jwks_url
+    assert config.postgres.host == "db.internal"
+    assert config.postgres.root_password == "fixture-postgres-password"
+    assert config.admin.jwks_url == "https://identity.example.test/.well-known/jwks.json"
 
 
 def test_from_file_at_the_real_benches_root_depth_merges_common_config(tmp_path: Path) -> None:

--- a/tests/pilot/config/test_common_config.py
+++ b/tests/pilot/config/test_common_config.py
@@ -2,10 +2,33 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pilot.config import BenchConfig
 from pilot.config.common import CommonConfig
 from pilot.config.letsencrypt import LetsEncryptConfig
 from pilot.config.mariadb import MariaDBConfig
 from pilot.config.postgres import PostgresConfig
+
+_BENCH_TOML = """
+[bench]
+name = "test-bench"
+python = "3.14"
+
+[[apps]]
+name = "frappe"
+repo = "https://github.com/frappe/frappe"
+branch = "version-16"
+
+[redis]
+cache_port = 13000
+queue_port = 11000
+"""
+
+
+def _write_bench(benches_root: Path, shared_tables: str = "") -> Path:
+    bench_dir = benches_root / "test-bench"
+    bench_dir.mkdir(parents=True, exist_ok=True)
+    (bench_dir / "bench.toml").write_text(_BENCH_TOML + shared_tables)
+    return bench_dir
 
 
 def test_path_resolves_next_to_benches_root(tmp_path: Path) -> None:
@@ -52,3 +75,34 @@ def test_read_ignores_stale_postgres_instance_keys(tmp_path: Path) -> None:
 def test_jwks_omitted_from_output_when_unset(tmp_path: Path) -> None:
     CommonConfig().write(tmp_path)
     assert "[admin]" not in CommonConfig.path(tmp_path).read_text()
+
+
+def test_bench_toml_tables_used_while_common_config_is_missing(tmp_path: Path) -> None:
+    """A bench that predates common_config.toml keeps the servers its own
+    bench.toml points at, instead of silently falling back to the defaults."""
+    bench_dir = _write_bench(
+        tmp_path,
+        '\n[mariadb]\nport = 3306\nroot_password = "mariadbpw"\n'
+        '\n[postgres]\nport = 5432\nroot_password = "postgrespw"\n',
+    )
+
+    config = BenchConfig.read(bench_dir)
+
+    assert (config.mariadb.port, config.mariadb.root_password) == (3306, "mariadbpw")
+    assert (config.postgres.port, config.postgres.root_password) == (5432, "postgrespw")
+
+
+def test_common_config_wins_over_bench_toml_tables(tmp_path: Path) -> None:
+    bench_dir = _write_bench(tmp_path, '\n[postgres]\nport = 5432\nroot_password = "stale"\n')
+    CommonConfig(postgres=PostgresConfig(port=5433, root_password="shared")).write(tmp_path)
+
+    config = BenchConfig.read(bench_dir)
+
+    assert (config.postgres.port, config.postgres.root_password) == (5433, "shared")
+
+
+def test_defaults_apply_when_no_file_carries_shared_tables(tmp_path: Path) -> None:
+    config = BenchConfig.read(_write_bench(tmp_path))
+
+    assert config.postgres.port == PostgresConfig().port
+    assert config.mariadb.port == MariaDBConfig().port


### PR DESCRIPTION
`BenchConfig` took `[mariadb]`/`[postgres]`/`[letsencrypt]`/`admin.jwks_*` only from `common_config.toml`. With no such file - every bench created before the config split, on any host where the `merge_common_config` patch hasn't run (it only runs during `pilot update`) - the tables the bench.toml itself carries were dropped and replaced with `CommonConfig()` defaults.

That stayed invisible while those defaults matched what benches already had. #312 changed them to 3310/5450, so an unmigrated bench now resolves to a port nothing listens on and an empty root password: `new-site` bakes the wrong `db_port` into `site_config.json`, and `drop-site` dies with `psycopg2.OperationalError: connection refused` on port 5450.

Fix: fall back to the bench.toml's own tables when there is no `common_config.toml` to merge, through the `CommonConfig.from_raw_dict` path that already parses them. `common_config.toml` still wins wherever it exists, so migrated hosts are unaffected.