### PR TITLE
fix: probe site setup state through the site's own database engine

### DIFF
--- a/admin/backend/providers/sites.py
+++ b/admin/backend/providers/sites.py
@@ -92,14 +92,14 @@ class SiteProvider:
             if isinstance(site_config.get("installed_apps"), list):
                 installed_apps = site_config["installed_apps"]
             elif not is_provisioning:
-                apps = query_installed_apps_via_db(site_config)
+                apps = query_installed_apps_via_db(self._bench_root, site_name)
                 if apps is not None:
                     installed_apps = apps
                 else:
                     broken = True
 
             if not is_provisioning and not broken:
-                setup_complete = bool(is_setup_complete(site_config))
+                setup_complete = bool(is_setup_complete(self._bench_root, site_name))
 
         return SiteInfo(
             name=site_name,

--- a/pilot/core/database/__init__.py
+++ b/pilot/core/database/__init__.py
@@ -15,12 +15,14 @@ from pilot.core.database.base import (
     TableSize,
 )
 from pilot.core.database.engines import MariaDB, PostgreSQL, SQLite
+from pilot.core.database.engines.helpers import DEFAULT_CONNECT_TIMEOUT
 from pilot.exceptions import DatabaseError
 
 if TYPE_CHECKING:
     from pilot.config import BenchConfig
 
 __all__ = [
+    "DEFAULT_CONNECT_TIMEOUT",
     "BinlogFile",
     "BinlogStatus",
     "Database",
@@ -80,7 +82,11 @@ def site_database_name(bench_root: Path | str, site_name: str) -> str:
     return read_site_config(bench_root, site_name).get("db_name", "")
 
 
-def make_site_database(bench_root: Path | str, site_name: str) -> Database:
+def make_site_database(
+    bench_root: Path | str,
+    site_name: str,
+    connect_timeout: int = DEFAULT_CONNECT_TIMEOUT,
+) -> Database:
     """Site-specific database connection from site_config.json."""
     config = read_site_config(bench_root, site_name)
     db_type = config.get("db_type", "mariadb")
@@ -91,6 +97,7 @@ def make_site_database(bench_root: Path | str, site_name: str) -> Database:
             user=config["db_user"],
             password=config["db_password"],
             database=config["db_name"],
+            connect_timeout=connect_timeout,
         )
     if db_type == "sqlite":
         # Frappe stores SQLite under sites/<site>/db/, not directly in the site folder.
@@ -103,4 +110,5 @@ def make_site_database(bench_root: Path | str, site_name: str) -> Database:
         password=config["db_password"],
         database=config["db_name"],
         socket=config.get("db_socket") or None,
+        connect_timeout=connect_timeout,
     )

--- a/pilot/core/database/base.py
+++ b/pilot/core/database/base.py
@@ -77,6 +77,11 @@ class Database(ABC):
     @abstractmethod
     def execute(self, query: str, read_only: bool = True) -> QueryResult: ...
 
+    def quote_identifier(self, name: str) -> str:
+        """ANSI double quoting, which PostgreSQL and SQLite both accept.
+        MariaDB overrides it with backticks."""
+        return '"{}"'.format(name.replace('"', ""))
+
     @abstractmethod
     def get_tables(self) -> list[str]: ...
 

--- a/pilot/core/database/engines/helpers.py
+++ b/pilot/core/database/engines/helpers.py
@@ -9,6 +9,10 @@ from pilot.exceptions import DatabaseError
 # exhaust memory. Callers surface the overflow as QueryResult.truncated.
 MAX_ROWS = 5000
 
+# Seconds to wait for a TCP connection before giving up, so an unreachable
+# database server cannot stall a request indefinitely.
+DEFAULT_CONNECT_TIMEOUT = 10
+
 
 def rows_as_dicts(result: QueryResult) -> list[dict]:
     return [dict(zip(result.columns, row, strict=True)) for row in result.rows]

--- a/pilot/core/database/engines/mariadb.py
+++ b/pilot/core/database/engines/mariadb.py
@@ -14,6 +14,7 @@ from pilot.core.database.base import (
     TableSize,
 )
 from pilot.core.database.engines.helpers import (
+    DEFAULT_CONNECT_TIMEOUT,
     MAX_ROWS,
     disk_free,
     file_modified_ms,
@@ -33,6 +34,7 @@ class MariaDB(Database):
         password: str,
         database: str,
         socket: str | None = None,
+        connect_timeout: int = DEFAULT_CONNECT_TIMEOUT,
     ) -> None:
         self._host = host
         self._port = port
@@ -40,6 +42,7 @@ class MariaDB(Database):
         self._password = password
         self._database = database
         self._socket = socket
+        self._connect_timeout = connect_timeout
 
     def _connect(self):
         import pymysql
@@ -52,8 +55,12 @@ class MariaDB(Database):
             password=self._password,
             database=self._database or None,
             unix_socket=self._socket,
+            connect_timeout=self._connect_timeout,
             cursorclass=pymysql.cursors.DictCursor,
         )
+
+    def quote_identifier(self, name: str) -> str:
+        return "`{}`".format(name.replace("`", ""))
 
     def execute(self, query: str, read_only: bool = True) -> QueryResult:
         import pymysql
@@ -100,11 +107,10 @@ class MariaDB(Database):
             conn.close()
 
     def get_table_columns(self, table: str) -> list[dict]:
-        safe = table.replace("`", "")
         conn = self._connect()
         try:
             with conn.cursor() as cursor:
-                cursor.execute(f"SHOW COLUMNS FROM `{safe}`")
+                cursor.execute(f"SHOW COLUMNS FROM {self.quote_identifier(table)}")
                 return [{"name": r["Field"], "type": r["Type"]} for r in cursor.fetchall()]
         finally:
             conn.close()

--- a/pilot/core/database/engines/postgres.py
+++ b/pilot/core/database/engines/postgres.py
@@ -11,6 +11,7 @@ from pilot.core.database.base import (
     TableSize,
 )
 from pilot.core.database.engines.helpers import (
+    DEFAULT_CONNECT_TIMEOUT,
     MAX_ROWS,
     disk_free,
     is_local_host,
@@ -21,12 +22,21 @@ from pilot.exceptions import DatabaseError
 
 
 class PostgreSQL(Database):
-    def __init__(self, host: str, port: int, user: str, password: str, database: str) -> None:
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        user: str,
+        password: str,
+        database: str,
+        connect_timeout: int = DEFAULT_CONNECT_TIMEOUT,
+    ) -> None:
         self._host = host
         self._port = port
         self._user = user
         self._password = password
         self._database = database
+        self._connect_timeout = connect_timeout
 
     def _connect(self):
         try:
@@ -39,6 +49,7 @@ class PostgreSQL(Database):
             user=self._user,
             password=self._password,
             dbname=self._database,
+            connect_timeout=self._connect_timeout,
         )
 
     def execute(self, query: str, read_only: bool = True) -> QueryResult:

--- a/pilot/core/database/engines/sqlite.py
+++ b/pilot/core/database/engines/sqlite.py
@@ -59,10 +59,9 @@ class SQLite(Database):
             conn.close()
 
     def get_table_columns(self, table: str) -> list[dict]:
-        safe = table.replace('"', "")
         conn = self._connect()
         try:
-            cursor = conn.execute(f'PRAGMA table_info("{safe}")')
+            cursor = conn.execute(f"PRAGMA table_info({self.quote_identifier(table)})")
             return [{"name": r["name"], "type": r["type"]} for r in cursor.fetchall()]
         finally:
             conn.close()

--- a/pilot/core/site/__init__.py
+++ b/pilot/core/site/__init__.py
@@ -294,16 +294,16 @@ def list_installed_apps(site_config: dict, bench_root: Path, site_name: str) -> 
     return _list_installed_apps(site_config, bench_root, site_name)
 
 
-def query_installed_apps_via_db(site_config: dict) -> list[str] | None:
+def query_installed_apps_via_db(bench_root: Path, site_name: str) -> list[str] | None:
     from pilot.core.site.config import query_installed_apps_via_db as _query_installed_apps_via_db
 
-    return _query_installed_apps_via_db(site_config)
+    return _query_installed_apps_via_db(bench_root, site_name)
 
 
-def is_setup_complete(site_config: dict) -> bool | None:
+def is_setup_complete(bench_root: Path, site_name: str) -> bool | None:
     from pilot.core.site.config import is_setup_complete as _is_setup_complete
 
-    return _is_setup_complete(site_config)
+    return _is_setup_complete(bench_root, site_name)
 
 
 def set_site_ssl_flag(sites_root: Path, site_name: str, enabled: bool) -> None:

--- a/pilot/core/site/config.py
+++ b/pilot/core/site/config.py
@@ -11,6 +11,7 @@ from pilot.exceptions import BenchError
 from pilot.internal.atomic_file import exclusive_file_lock, replace_private_text_locked
 
 _PROBE_CONNECT_TIMEOUT = 5
+_TRUE_SINGLES_VALUES = frozenset({"1", "true"})
 
 PROTECTED_CONFIG_KEYS = frozenset(
     {
@@ -82,7 +83,9 @@ def is_setup_complete(bench_root: Path, site_name: str) -> bool | None:
     )
     if rows is None:
         return None
-    return bool(rows) and str(rows[0][0]).strip() == "1"
+    if not rows:
+        return False
+    return str(rows[0][0]).strip().lower() in _TRUE_SINGLES_VALUES
 
 
 def _query_site_database(

--- a/pilot/core/site/config.py
+++ b/pilot/core/site/config.py
@@ -3,17 +3,14 @@ from __future__ import annotations
 import copy
 import json
 import re
+from collections.abc import Callable
 from pathlib import Path
 
+from pilot.core.database import Database, make_site_database
 from pilot.exceptions import BenchError
 from pilot.internal.atomic_file import exclusive_file_lock, replace_private_text_locked
 
-_DB_SOCKET_CANDIDATES = [
-    "/var/run/mysqld/mysqld.sock",
-    "/run/mysqld/mysqld.sock",
-    "/tmp/mysql.sock",
-    "/usr/local/var/mysql/mysql.sock",
-]
+_PROBE_CONNECT_TIMEOUT = 5
 
 PROTECTED_CONFIG_KEYS = frozenset(
     {
@@ -53,64 +50,51 @@ _SENSITIVE_CONFIG_KEY_PARTS = (
 def list_installed_apps(site_config: dict, bench_root: Path, site_name: str) -> list[str]:
     if isinstance(site_config.get("installed_apps"), list):
         return site_config["installed_apps"]
-    apps = query_installed_apps_via_db(site_config)
+    apps = query_installed_apps_via_db(bench_root, site_name)
     if apps is not None:
         return apps
     return query_installed_apps_via_frappe(bench_root, site_name)
 
 
-def query_installed_apps_via_db(site_config: dict) -> list[str] | None:
-    output = _run_mysql_query(site_config, "SELECT app_name FROM `tabInstalled Application` ORDER BY idx")
-    if output is None:
-        return None
-    return [line.strip() for line in output.splitlines() if line.strip()]
-
-
-def is_setup_complete(site_config: dict) -> bool | None:
-    output = _run_mysql_query(
-        site_config,
-        "SELECT value FROM `tabSingles` WHERE doctype='System Settings' AND field='setup_complete'",
+def query_installed_apps_via_db(bench_root: Path, site_name: str) -> list[str] | None:
+    """None means the site database was unreachable, not that it has no apps."""
+    rows = _query_site_database(
+        bench_root,
+        site_name,
+        lambda database: (
+            f"SELECT app_name FROM {database.quote_identifier('tabInstalled Application')} ORDER BY idx"
+        ),
     )
-    if output is None:
+    if rows is None:
         return None
-    return output.strip() == "1"
+    return [str(row[0]).strip() for row in rows if row and str(row[0]).strip()]
 
 
-def _run_mysql_query(site_config: dict, sql: str) -> str | None:
-    import shutil
-    import subprocess
-
-    db_name = site_config.get("db_name", "")
-    db_password = site_config.get("db_password", "")
-    db_host = site_config.get("db_host") or "localhost"
-    db_port = int(site_config.get("db_port") or 3306)
-    if not db_name or not db_password:
+def is_setup_complete(bench_root: Path, site_name: str) -> bool | None:
+    """None means the site database was unreachable, so setup state is unknown."""
+    rows = _query_site_database(
+        bench_root,
+        site_name,
+        lambda database: (
+            f"SELECT value FROM {database.quote_identifier('tabSingles')} "
+            "WHERE doctype = 'System Settings' AND field = 'setup_complete'"
+        ),
+    )
+    if rows is None:
         return None
+    return bool(rows) and str(rows[0][0]).strip() == "1"
 
-    cli = shutil.which("mariadb") or shutil.which("mysql")
-    if not cli:
-        return None
 
-    conn_args = [f"--user={db_name}", f"--password={db_password}"]
-    if db_host in ("localhost", "127.0.0.1", ""):
-        socket_path = next((socket for socket in _DB_SOCKET_CANDIDATES if Path(socket).exists()), None)
-        if socket_path:
-            conn_args.append(f"--socket={socket_path}")
-        else:
-            conn_args += ["--host=127.0.0.1", f"--port={db_port}"]
-    else:
-        conn_args += [f"--host={db_host}", f"--port={db_port}"]
-
+def _query_site_database(
+    bench_root: Path,
+    site_name: str,
+    build_query: Callable[[Database], str],
+) -> list[list] | None:
+    """Read-only probe against a site's own database, whichever engine backs it.
+    `build_query` receives the engine so identifiers get quoted its way."""
     try:
-        result = subprocess.run(
-            [cli, *conn_args, "--batch", "--skip-column-names", db_name, "-e", sql],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode != 0:
-            return None
-        return result.stdout
+        database = make_site_database(bench_root, site_name, connect_timeout=_PROBE_CONNECT_TIMEOUT)
+        return database.execute(build_query(database)).rows
     except Exception:
         return None
 

--- a/tests/admin/backend/providers/test_site_provider.py
+++ b/tests/admin/backend/providers/test_site_provider.py
@@ -6,6 +6,18 @@ from pathlib import Path
 import pytest
 
 from admin.backend.providers.sites import SiteProvider
+from pilot.core.database.base import QueryResult
+
+
+class _FakeDatabase:
+    def __init__(self, rows: list[list]) -> None:
+        self._rows = rows
+
+    def quote_identifier(self, name: str) -> str:
+        return f'"{name}"'
+
+    def execute(self, query: str, read_only: bool = True) -> QueryResult:
+        return QueryResult(columns=["value"], rows=self._rows, duration_ms=0.0)
 
 
 def _make_site(sites: Path, name: str, config: dict) -> None:
@@ -48,3 +60,29 @@ def test_site_provider_defaults_setup_complete_false_without_db_access(tmp_path:
     info = SiteProvider(tmp_path).get_one("site.localhost")
 
     assert info.setup_complete is False
+
+
+def test_site_provider_reads_setup_complete_for_postgres_site(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sites = tmp_path / "sites"
+    _make_site(
+        sites,
+        "pg.localhost",
+        {
+            "db_type": "postgres",
+            "db_name": "site_db",
+            "db_user": "site_db",
+            "db_password": "secret",
+            "db_port": 5432,
+            "installed_apps": ["frappe"],
+        },
+    )
+    monkeypatch.setattr(
+        "pilot.core.site.config.make_site_database",
+        lambda *args, **kwargs: _FakeDatabase([["1"]]),
+    )
+
+    info = SiteProvider(tmp_path).get_one("pg.localhost")
+
+    assert info.setup_complete is True

--- a/tests/pilot/core/test_site_config.py
+++ b/tests/pilot/core/test_site_config.py
@@ -1,34 +1,137 @@
 from __future__ import annotations
 
-import subprocess
+import json
+import sqlite3
+from pathlib import Path
 
 import pytest
 
-from pilot.core.site.config import is_setup_complete
+from pilot.core.database.base import QueryResult
+from pilot.core.database.engines import MariaDB, PostgreSQL
+from pilot.core.site import config as site_config
+from pilot.exceptions import DatabaseError
 
-_DB_CONFIG = {"db_name": "site_db", "db_password": "secret"}
-
-
-def _fake_run(stdout: str, returncode: int = 0):
-    def run(*args, **kwargs):
-        return subprocess.CompletedProcess(args, returncode, stdout=stdout, stderr="")
-
-    return run
+_BENCH_ROOT = Path("/bench")
 
 
-def test_is_setup_complete_true(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/mariadb")
-    monkeypatch.setattr(subprocess, "run", _fake_run("1\n"))
-
-    assert is_setup_complete(_DB_CONFIG) is True
+def _mariadb() -> MariaDB:
+    return MariaDB(host="localhost", port=3306, user="u", password="p", database="site_db")
 
 
-def test_is_setup_complete_false(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr("shutil.which", lambda _: "/usr/bin/mariadb")
-    monkeypatch.setattr(subprocess, "run", _fake_run("0\n"))
-
-    assert is_setup_complete(_DB_CONFIG) is False
+def _postgres() -> PostgreSQL:
+    return PostgreSQL(host="localhost", port=5432, user="u", password="p", database="site_db")
 
 
-def test_is_setup_complete_none_without_db_credentials() -> None:
-    assert is_setup_complete({}) is None
+def _make_sqlite_site(bench_root: Path, site_name: str, setup_complete: str, apps: list[str]) -> None:
+    """A real SQLite site, so the probe runs against an actual Frappe-shaped schema."""
+    site_path = bench_root / "sites" / site_name
+    (site_path / "db").mkdir(parents=True)
+    (site_path / "site_config.json").write_text(json.dumps({"db_type": "sqlite", "db_name": "site_db"}))
+
+    connection = sqlite3.connect(site_path / "db" / "site_db.db")
+    with connection:
+        connection.execute("CREATE TABLE `tabSingles` (doctype TEXT, field TEXT, value TEXT)")
+        connection.execute(
+            "INSERT INTO `tabSingles` VALUES ('System Settings', 'setup_complete', ?)",
+            (setup_complete,),
+        )
+        connection.execute("CREATE TABLE `tabInstalled Application` (app_name TEXT, idx INTEGER)")
+        connection.executemany(
+            "INSERT INTO `tabInstalled Application` VALUES (?, ?)",
+            [(app, index) for index, app in enumerate(apps)],
+        )
+    connection.close()
+
+
+def _stub_database(monkeypatch: pytest.MonkeyPatch, engine, rows: list[list]) -> list[str]:
+    """Keep the real engine so identifier quoting is exercised, stub the wire."""
+    executed: list[str] = []
+
+    def execute(self, query: str, read_only: bool = True) -> QueryResult:
+        executed.append(query)
+        return QueryResult(columns=["value"], rows=rows, duration_ms=0.0)
+
+    monkeypatch.setattr(type(engine), "execute", execute)
+    monkeypatch.setattr(site_config, "make_site_database", lambda *args, **kwargs: engine)
+    return executed
+
+
+def test_is_setup_complete_true_on_mariadb(monkeypatch: pytest.MonkeyPatch) -> None:
+    executed = _stub_database(monkeypatch, _mariadb(), [["1"]])
+
+    assert site_config.is_setup_complete(_BENCH_ROOT, "site.localhost") is True
+    assert "`tabSingles`" in executed[0]
+
+
+def test_is_setup_complete_false_on_mariadb(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_database(monkeypatch, _mariadb(), [["0"]])
+
+    assert site_config.is_setup_complete(_BENCH_ROOT, "site.localhost") is False
+
+
+def test_is_setup_complete_true_on_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
+    executed = _stub_database(monkeypatch, _postgres(), [["1"]])
+
+    assert site_config.is_setup_complete(_BENCH_ROOT, "postgres.localhost") is True
+    assert '"tabSingles"' in executed[0]
+    assert "`" not in executed[0]
+
+
+def test_is_setup_complete_false_when_setting_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _stub_database(monkeypatch, _postgres(), [])
+
+    assert site_config.is_setup_complete(_BENCH_ROOT, "postgres.localhost") is False
+
+
+def test_is_setup_complete_none_when_database_unreachable(monkeypatch: pytest.MonkeyPatch) -> None:
+    def unreachable(*args, **kwargs):
+        raise DatabaseError("connection refused")
+
+    monkeypatch.setattr(site_config, "make_site_database", unreachable)
+
+    assert site_config.is_setup_complete(_BENCH_ROOT, "site.localhost") is None
+
+
+def test_is_setup_complete_none_when_site_config_missing(tmp_path: Path) -> None:
+    assert site_config.is_setup_complete(tmp_path, "missing.localhost") is None
+
+
+def test_query_installed_apps_via_db_on_postgres(monkeypatch: pytest.MonkeyPatch) -> None:
+    executed = _stub_database(monkeypatch, _postgres(), [["frappe"], ["erpnext"]])
+
+    apps = site_config.query_installed_apps_via_db(_BENCH_ROOT, "postgres.localhost")
+
+    assert apps == ["frappe", "erpnext"]
+    assert '"tabInstalled Application"' in executed[0]
+
+
+def test_is_setup_complete_true_on_sqlite(tmp_path: Path) -> None:
+    """SQLite sites have no db_password, which used to short-circuit the probe."""
+    _make_sqlite_site(tmp_path, "sqlite.localhost", "1", ["frappe"])
+
+    assert site_config.is_setup_complete(tmp_path, "sqlite.localhost") is True
+
+
+def test_is_setup_complete_false_on_sqlite(tmp_path: Path) -> None:
+    _make_sqlite_site(tmp_path, "sqlite.localhost", "0", ["frappe"])
+
+    assert site_config.is_setup_complete(tmp_path, "sqlite.localhost") is False
+
+
+def test_query_installed_apps_via_db_on_sqlite(tmp_path: Path) -> None:
+    _make_sqlite_site(tmp_path, "sqlite.localhost", "1", ["frappe", "erpnext"])
+
+    apps = site_config.query_installed_apps_via_db(tmp_path, "sqlite.localhost")
+
+    assert apps == ["frappe", "erpnext"]
+
+
+def test_query_installed_apps_via_db_none_when_database_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unreachable(*args, **kwargs):
+        raise DatabaseError("connection refused")
+
+    monkeypatch.setattr(site_config, "make_site_database", unreachable)
+
+    assert site_config.query_installed_apps_via_db(_BENCH_ROOT, "site.localhost") is None

--- a/tests/pilot/core/test_site_config.py
+++ b/tests/pilot/core/test_site_config.py
@@ -77,6 +77,23 @@ def test_is_setup_complete_true_on_postgres(monkeypatch: pytest.MonkeyPatch) -> 
     assert "`" not in executed[0]
 
 
+@pytest.mark.parametrize("stored", ["true", "TRUE", " true "])
+def test_is_setup_complete_accepts_postgres_boolean_spelling(
+    monkeypatch: pytest.MonkeyPatch, stored: str
+) -> None:
+    """set_single_value writes a Python bool: psycopg2 renders it 'true', mysqlclient '1'."""
+    _stub_database(monkeypatch, _postgres(), [[stored]])
+
+    assert site_config.is_setup_complete(_BENCH_ROOT, "postgres.localhost") is True
+
+
+@pytest.mark.parametrize("stored", ["0", "false", "", "t", "yes"])
+def test_is_setup_complete_rejects_other_values(monkeypatch: pytest.MonkeyPatch, stored: str) -> None:
+    _stub_database(monkeypatch, _postgres(), [[stored]])
+
+    assert site_config.is_setup_complete(_BENCH_ROOT, "postgres.localhost") is False
+
+
 def test_is_setup_complete_false_when_setting_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_database(monkeypatch, _postgres(), [])
 


### PR DESCRIPTION
Postgres and SQLite sites always showed "Setup site" in the dashboard, even after the setup wizard had completed.

`is_setup_complete` and `query_installed_apps_via_db` shelled out to the `mariadb`/`mysql` CLI regardless of the site's `db_type`, and quoted identifiers with MySQL backticks. On a Postgres site the probe either hit the local MariaDB socket looking for a database that lives in Postgres, or failed to speak the protocol on 5432 — the subprocess exited non-zero, the probe returned `None`, and `SiteProvider` coerced that to `setup_complete=False`. SQLite failed earlier still: the probe required a `db_password`, which SQLite sites don't have.

Both probes now go through `make_site_database()`, so each site is queried with its own engine, and identifier quoting is the engine's job — backticks for MariaDB, ANSI double quotes for Postgres and SQLite. This also drops the requirement that a MySQL client binary be installed on the host.

The `None` = "unreachable" contract is unchanged, so a down database still reads as unknown rather than as not-set-up.

The removed CLI call had a 5s timeout the drivers didn't, so connect timeouts are now explicit: engines default to 10s, these probes pass 5s.

## Tests

`tests/pilot/core/test_site_config.py` covers MariaDB and Postgres quoting, unreachable/missing-config cases, and runs three probes end-to-end against a real SQLite site.