### PR TITLE
fix: Show the real engine on the DB analyzer for Postgres benches

### DIFF
--- a/admin/backend/providers/database.py
+++ b/admin/backend/providers/database.py
@@ -38,12 +38,13 @@ class DatabaseDiagnosticsProvider:
         if self._db is None:
             return {"engine": self._engine, "supported": False, "reason": NO_DATABASE_SERVER}
         database = self._require_server()
+        binlog = self._optional(database.get_binlog_status)
         return {
             "engine": self._engine,
             "supported": True,
             "active_connections": self._call(database.get_active_connections),
             "lock_waits": asdict(self._call(database.get_lock_waits)),
-            "binlog": asdict(self._call(database.get_binlog_status)),
+            "binlog": asdict(binlog) if binlog is not None else None,
         }
 
     def get_process_list(self, site: str = "") -> list[dict]:
@@ -106,3 +107,13 @@ class DatabaseDiagnosticsProvider:
             return fn(*args)
         except NotImplementedError as exc:
             raise DatabaseError(NOT_SUPPORTED) from exc
+
+    @staticmethod
+    def _optional(fn, *args):
+        """None for a section this engine has no concept of, so one missing
+        section does not fail the whole payload. Only for reads the UI can
+        omit; a directly requested operation still fails through _call."""
+        try:
+            return fn(*args)
+        except NotImplementedError:
+            return None

--- a/admin/frontend/dashboard/src/pages/database/Analyzer.vue
+++ b/admin/frontend/dashboard/src/pages/database/Analyzer.vue
@@ -8,26 +8,13 @@
         :options="siteOptions"
         class="w-32 sm:w-44"
       />
-      <FormControl type="select" v-model="engine" :options="engineOptions" class="w-32 sm:w-40" />
+      <Badge v-if="diagnostics" :label="engineLabel(configuredEngine)" theme="gray" size="lg" />
     </div>
   </Teleport>
 
   <div class="flex flex-col gap-4">
     <div v-if="loading && !diagnostics" class="flex justify-center py-16">
       <LoadingText />
-    </div>
-
-    <div
-      v-else-if="engine !== configuredEngine"
-      class="flex flex-col items-center gap-1 bg-surface-white py-14 border rounded-lg border-outline-gray-2 text-center"
-    >
-      <span class="size-6 text-ink-gray-3 lucide-database-zap" />
-      <p class="font-medium text-ink-gray-7 text-sm">Not configured on this bench</p>
-      <p class="max-w-sm text-ink-gray-5 text-xs">
-        This bench runs {{ engineLabel(configuredEngine) }}. Switch the selector back to
-        {{ engineLabel(configuredEngine) }}
-        to see its diagnostics.
-      </p>
     </div>
 
     <div
@@ -124,6 +111,7 @@
       </DatabasePanel>
 
       <DatabasePanel
+        v-if="hasBinlogs"
         title="Database Binary Logs"
         subtitle="Manage the binary logs of the database"
         :badge="selectedSite ? 'Server-wide' : ''"
@@ -248,6 +236,7 @@
 
 <script setup>
 import {
+  Badge,
   Button,
   Checkbox,
   Dialog,
@@ -308,18 +297,18 @@ const binlogColumns = [
   { label: '', key: 'actions', align: 'right', width: '3rem' },
 ]
 
-const engineOptions = [
-  { label: 'MariaDB', value: 'mariadb' },
-  { label: 'PostgreSQL', value: 'postgres' },
-]
+const ENGINE_LABELS = {
+  mariadb: 'MariaDB',
+  postgres: 'PostgreSQL',
+  sqlite: 'SQLite',
+}
 
 const route = useRoute()
 
 const loading = ref(false)
 const error = ref('')
 const diagnostics = ref(null)
-const engine = ref('mariadb')
-const configuredEngine = ref('mariadb')
+const configuredEngine = ref('')
 const sites = ref([])
 const selectedSite = ref('')
 
@@ -428,11 +417,14 @@ const purgeDetails = computed(() => {
 })
 
 const lockColumnsBadge = computed(() =>
-  engine.value === 'postgres' ? "Some columns aren't available for PostgreSQL" : '',
+  configuredEngine.value === 'postgres' ? "Some columns aren't available for PostgreSQL" : '',
 )
 
+// Binary logs are a MariaDB concept; the engine reports no status when it has none.
+const hasBinlogs = computed(() => Boolean(diagnostics.value?.binlog))
+
 // Only sites on this server can be scoped to; a SQLite site owns a file, not a
-// database on the selected engine.
+// database on the bench's engine.
 const siteOptions = computed(() => [
   { label: 'All databases', value: '' },
   ...sites.value
@@ -443,7 +435,7 @@ const siteOptions = computed(() => [
 const scopeBadge = computed(() => selectedSite.value)
 
 function engineLabel(value) {
-  return engineOptions.find((option) => option.value === value)?.label || value
+  return ENGINE_LABELS[value] || value
 }
 
 const MAX_QUERY_LENGTH = 120
@@ -606,10 +598,11 @@ async function load() {
     if (result.error)
       throw new Error(apiErrorMessage(result, 'Could not load database diagnostics.'))
     diagnostics.value = result
-    configuredEngine.value = result.engine || 'mariadb'
-    engine.value = configuredEngine.value
+    configuredEngine.value = result.engine
     if (!result.supported) return
-    await Promise.all([loadSites(), loadSize(), loadProcesses(), loadLockWaits(), loadBinlogs()])
+    const panels = [loadSites(), loadSize(), loadProcesses(), loadLockWaits()]
+    if (hasBinlogs.value) panels.push(loadBinlogs())
+    await Promise.all(panels)
     if (autoRefreshLocks.value) startLockWaitsAutoRefresh()
   } catch (e) {
     error.value = e.message || 'Could not load database diagnostics.'

--- a/admin/frontend/dashboard/src/pages/database/Analyzer.vue
+++ b/admin/frontend/dashboard/src/pages/database/Analyzer.vue
@@ -1,15 +1,12 @@
 <template>
   <Teleport defer to="#header-actions">
-    <div class="flex items-center gap-2">
-      <FormControl
-        v-if="siteOptions.length > 1"
-        type="select"
-        v-model="selectedSite"
-        :options="siteOptions"
-        class="w-32 sm:w-44"
-      />
-      <Badge v-if="diagnostics" :label="engineLabel(configuredEngine)" theme="gray" size="lg" />
-    </div>
+    <FormControl
+      v-if="siteOptions.length > 1"
+      type="select"
+      v-model="selectedSite"
+      :options="siteOptions"
+      class="w-32 sm:w-44"
+    />
   </Teleport>
 
   <div class="flex flex-col gap-4">
@@ -236,7 +233,6 @@
 
 <script setup>
 import {
-  Badge,
   Button,
   Checkbox,
   Dialog,
@@ -296,12 +292,6 @@ const binlogColumns = [
   { label: 'Size', key: 'size', align: 'right', width: 1 },
   { label: '', key: 'actions', align: 'right', width: '3rem' },
 ]
-
-const ENGINE_LABELS = {
-  mariadb: 'MariaDB',
-  postgres: 'PostgreSQL',
-  sqlite: 'SQLite',
-}
 
 const route = useRoute()
 
@@ -433,10 +423,6 @@ const siteOptions = computed(() => [
 ])
 
 const scopeBadge = computed(() => selectedSite.value)
-
-function engineLabel(value) {
-  return ENGINE_LABELS[value] || value
-}
 
 const MAX_QUERY_LENGTH = 120
 

--- a/pilot/core/database/engines/postgres.py
+++ b/pilot/core/database/engines/postgres.py
@@ -43,14 +43,17 @@ class PostgreSQL(Database):
             import psycopg2
         except ImportError as exc:
             raise DatabaseError("psycopg2 is not installed. Run: pip install psycopg2-binary") from exc
-        return psycopg2.connect(
-            host=self._host,
-            port=self._port,
-            user=self._user,
-            password=self._password,
-            dbname=self._database,
-            connect_timeout=self._connect_timeout,
-        )
+        try:
+            return psycopg2.connect(
+                host=self._host,
+                port=self._port,
+                user=self._user,
+                password=self._password,
+                dbname=self._database,
+                connect_timeout=self._connect_timeout,
+            )
+        except psycopg2.Error as exc:
+            raise DatabaseError(f"Could not connect to PostgreSQL at {self._host}:{self._port}: {exc}") from exc
 
     def execute(self, query: str, read_only: bool = True) -> QueryResult:
         conn = self._connect()

--- a/tests/admin/backend/providers/test_database_provider.py
+++ b/tests/admin/backend/providers/test_database_provider.py
@@ -50,6 +50,24 @@ def test_sqlite_bench_has_no_database_server(tmp_path) -> None:
             call()
 
 
+def test_get_diagnostics_reports_no_binlog_for_an_engine_without_one() -> None:
+    """PostgreSQL has no binary log. The section goes null instead of failing
+    the whole payload, which used to leave the page with no engine at all."""
+    db = Mock()
+    db.get_active_connections.return_value = 3
+    db.get_lock_waits.return_value = LockWaitStatus(current_waits=0, total_waits=None, timeout_seconds=None)
+    db.get_binlog_status.side_effect = NotImplementedError
+    provider = DatabaseDiagnosticsProvider(bench_root=None, database=db, engine="postgres")
+
+    assert provider.get_diagnostics() == {
+        "engine": "postgres",
+        "supported": True,
+        "active_connections": 3,
+        "lock_waits": {"current_waits": 0, "total_waits": None, "timeout_seconds": None},
+        "binlog": None,
+    }
+
+
 def test_get_binlog_files_shapes_files_as_dicts() -> None:
     db = Mock()
     db.get_binlog_files.return_value = [BinlogFile(name="mysql-bin.000001", size_bytes=1024, modified_ms=17)]

--- a/tests/pilot/core/test_database.py
+++ b/tests/pilot/core/test_database.py
@@ -211,6 +211,24 @@ def test_mariadb_get_schema_uses_one_connection() -> None:
     assert [c["name"] for c in by_name["beta"]] == ["id"]
 
 
+def test_postgres_connect_failure_surfaces_as_a_database_error() -> None:
+    """A raw driver error escaped _connect and reached the API as an opaque 500,
+    hiding why diagnostics failed."""
+    import sys
+    import types
+
+    fake_psycopg2 = types.ModuleType("psycopg2")
+    fake_psycopg2.Error = type("Error", (Exception,), {})
+    fake_psycopg2.connect = MagicMock(side_effect=fake_psycopg2.Error("connection refused"))
+
+    db = PostgreSQL(host="db.internal", port=5432, user="u", password="p", database="d")
+    with (
+        patch.dict(sys.modules, {"psycopg2": fake_psycopg2}),
+        pytest.raises(DatabaseError, match=r"Could not connect to PostgreSQL at db\.internal:5432"),
+    ):
+        db.get_active_connections()
+
+
 def test_postgres_get_schema_uses_one_connection() -> None:
     db = PostgreSQL(host="h", port=5432, user="u", password="p", database="d")
     fake_cursor = MagicMock()


### PR DESCRIPTION
The DB analyzer was unusable on a PostgreSQL bench, and reported the wrong engine while doing so.

- `get_diagnostics()` unconditionally read binlog status, which PostgreSQL never implements, so the whole payload failed with a 422 even against a healthy connection. The section now goes null instead of sinking the three that do work, and the panel is hidden when the engine reports none.
- With diagnostics failing, the page never learned its engine: `configuredEngine` defaulted to `mariadb` and was only corrected on success, so a Postgres bench was told "This bench runs MariaDB".
- The engine selector was never a filter — a bench has one engine, resolved server-side from `BenchConfig.db_type`. It is now a read-only badge.
- `psycopg2.connect()` sat outside `execute()`'s try block, so connection failures escaped as raw driver errors and were flattened into an opaque 500.

Tests: 100 pass across `test_database.py`, `test_database_provider.py`, `test_databases_view.py`.