### PR TITLE
fix(ui): settings dialog polish and a WAF rule builder rebuild

### DIFF
--- a/admin/frontend/dashboard/src/components/common/EmptyState.vue
+++ b/admin/frontend/dashboard/src/components/common/EmptyState.vue
@@ -1,13 +1,17 @@
 <template>
   <div
-    class="flex flex-col items-center gap-4 px-6 py-12 text-center"
-    :class="bordered ? 'border border-outline-gray-2 border-dashed rounded-xl' : ''"
+    class="flex flex-col items-center px-6 text-center"
+    :class="[
+      bordered ? 'border border-outline-gray-2 border-dashed rounded-xl' : '',
+      compact ? 'gap-3 py-6' : 'gap-4 py-12',
+    ]"
   >
     <span
       v-if="icon"
-      class="place-items-center grid bg-surface-gray-2 rounded-lg size-10 text-ink-gray-5 shrink-0"
+      class="place-items-center grid bg-surface-gray-2 text-ink-gray-5 shrink-0"
+      :class="compact ? 'rounded-md size-8' : 'rounded-lg size-10'"
     >
-      <span class="size-5" :class="icon" />
+      <span :class="[compact ? 'size-4' : 'size-5', icon]" />
     </span>
     <div>
       <p class="font-medium text-ink-gray-7 text-base">{{ title }}</p>
@@ -24,5 +28,8 @@ defineProps({
   description: { type: String, default: '' },
   // Off when the state already sits inside a bordered panel.
   bordered: { type: Boolean, default: true },
+  // For empty states that sit among other content rather than filling a page:
+  // full height there makes the absence the tallest thing in view.
+  compact: { type: Boolean, default: false },
 })
 </script>

--- a/admin/frontend/dashboard/src/components/common/EmptyState.vue
+++ b/admin/frontend/dashboard/src/components/common/EmptyState.vue
@@ -28,8 +28,7 @@ defineProps({
   description: { type: String, default: '' },
   // Off when the state already sits inside a bordered panel.
   bordered: { type: Boolean, default: true },
-  // For empty states that sit among other content rather than filling a page:
-  // full height there makes the absence the tallest thing in view.
+  // For empty states that sit among other content rather than filling a page.
   compact: { type: Boolean, default: false },
 })
 </script>

--- a/admin/frontend/dashboard/src/components/common/WafAnalytics.vue
+++ b/admin/frontend/dashboard/src/components/common/WafAnalytics.vue
@@ -2,7 +2,7 @@
   <div v-if="data && data.log_present" class="mb-6">
     <div class="flex items-center gap-2 mb-3">
       <span class="size-4 text-ink-gray-6 lucide-shield-alert" />
-      <h2 class="font-semibold text-ink-gray-9 text-base">Web Application Firewall</h2>
+      <h2 class="font-semibold text-ink-gray-9 text-base">Web application firewall</h2>
       <span
         v-if="data.mode === 'DetectionOnly'"
         class="bg-surface-amber-2 px-2 py-0.5 rounded-full text-ink-amber-3 text-xs"

--- a/admin/frontend/dashboard/src/components/settings/Firewall.vue
+++ b/admin/frontend/dashboard/src/components/settings/Firewall.vue
@@ -13,14 +13,14 @@
       </template>
     </Alert>
 
-    <Switch
+    <SettingsSwitch
       label="Enable firewall"
       description="Restrict who can reach Pilot and deployed sites; off means open."
       :model-value="enabled"
       @update:model-value="(v) => (enabled = v)"
     />
 
-    <Switch
+    <SettingsSwitch
       label="Block by default"
       description="Only allowed IPs below can reach the server; off allows all except blocked ones."
       :model-value="defaultPolicy === 'deny'"
@@ -45,36 +45,38 @@
         <Button variant="subtle" icon-left="plus" @click="addRule">Add rule</Button>
       </div>
 
-      <div
+      <EmptyState
         v-if="!rules.length"
-        class="flex flex-col items-center gap-2.5 py-10 border border-dashed rounded-lg border-outline-gray-2 text-center"
-      >
-        <div class="flex justify-center items-center bg-surface-gray-2 rounded-full size-11">
-          <span class="size-5 text-ink-gray-5 lucide-shield"></span>
-        </div>
-        <p class="font-medium text-ink-gray-7 text-sm">No firewall rules</p>
-        <p class="max-w-xs text-ink-gray-5 text-xs">
-          {{ defaultPolicy === 'allow'
+        icon="lucide-shield"
+        title="No firewall rules"
+        :description="
+          defaultPolicy === 'allow'
             ? 'Everyone can reach the server. Add a rule to block specific IPs or ranges.'
-            : 'No one can reach the server. Add an Allow rule for the IPs that should have access.' }}
-        </p>
-      </div>
+            : 'No one can reach the server. Add an Allow rule for the IPs that should have access.'
+        "
+      />
 
       <div v-else class="space-y-3">
         <div v-for="(rule, index) in rules" :key="index" class="flex items-end gap-2">
           <div class="space-y-1.5 w-28 shrink-0">
-            <p v-if="index === 0" class="font-medium text-ink-gray-7 text-sm">Action</p>
+            <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">Action</p>
             <Select v-model="rule.action" :options="ACTION_OPTIONS" class="w-full" />
           </div>
           <div class="flex-1 space-y-1.5">
-            <p v-if="index === 0" class="font-medium text-ink-gray-7 text-sm">IP / CIDR</p>
+            <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">IP / CIDR</p>
             <TextInput v-model="rule.ip" placeholder="203.0.113.4 or 10.0.0.0/8" class="w-full" />
           </div>
           <div class="flex-1 space-y-1.5">
-            <p v-if="index === 0" class="font-medium text-ink-gray-7 text-sm">Note</p>
+            <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">Note</p>
             <TextInput v-model="rule.description" placeholder="optional" class="w-full" />
           </div>
-          <Button variant="subtle" icon="lucide-x" @click="removeRule(index)" />
+          <Button
+            variant="subtle"
+            icon="lucide-x"
+            label="Remove rule"
+            tooltip="Remove rule"
+            @click="removeRule(index)"
+          />
         </div>
       </div>
     </div>
@@ -89,7 +91,9 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
-import { Alert, Button, ErrorMessage, Select, Spinner, Switch, TextInput, toast } from 'frappe-ui'
+import { Alert, Button, ErrorMessage, Select, Spinner, TextInput, toast } from 'frappe-ui'
+import EmptyState from '@/components/common/EmptyState.vue'
+import SettingsSwitch from '@/components/settings/SettingsSwitch.vue'
 import { apiErrorMessage } from '@/api/client'
 import { settingsApi } from '@/api/settings'
 

--- a/admin/frontend/dashboard/src/components/settings/Firewall.vue
+++ b/admin/frontend/dashboard/src/components/settings/Firewall.vue
@@ -86,8 +86,6 @@
       </div>
     </div>
 
-    <!-- Cross-field problems (lockout) and server failures; single-field
-         problems sit at their row and hold the button instead. -->
     <ErrorMessage v-if="error" :message="error" />
 
     <div v-if="rules.length" class="flex justify-end">
@@ -147,8 +145,7 @@ const canSave = computed(() =>
 )
 
 function validate() {
-  // Block-by-default with no Allow rule blocks everyone, including you. Kept as
-  // a save-time message: it is a property of the whole ruleset, not one input.
+  // Block-by-default with no Allow rule blocks everyone, including you.
   if (
     enabled.value &&
     defaultPolicy.value === 'deny' &&

--- a/admin/frontend/dashboard/src/components/settings/Firewall.vue
+++ b/admin/frontend/dashboard/src/components/settings/Firewall.vue
@@ -58,34 +58,42 @@
       />
 
       <div v-else class="space-y-3">
-        <div v-for="(rule, index) in rules" :key="index" class="flex items-end gap-2">
-          <div class="space-y-1.5 w-28 shrink-0">
-            <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">Action</p>
-            <Select v-model="rule.action" :options="ACTION_OPTIONS" class="w-full" />
+        <div v-for="(rule, index) in rules" :key="index">
+          <div class="flex items-end gap-2">
+            <div class="space-y-1.5 w-28 shrink-0">
+              <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">Action</p>
+              <Select v-model="rule.action" :options="ACTION_OPTIONS" class="w-full" />
+            </div>
+            <div class="flex-1 space-y-1.5">
+              <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">IP / CIDR</p>
+              <TextInput v-model="rule.ip" placeholder="203.0.113.4 or 10.0.0.0/8" class="w-full" />
+            </div>
+            <div class="flex-1 space-y-1.5">
+              <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">Note</p>
+              <TextInput v-model="rule.description" placeholder="optional" class="w-full" />
+            </div>
+            <Button
+              variant="subtle"
+              icon="lucide-x"
+              label="Remove rule"
+              tooltip="Remove rule"
+              @click="removeRule(index)"
+            />
           </div>
-          <div class="flex-1 space-y-1.5">
-            <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">IP / CIDR</p>
-            <TextInput v-model="rule.ip" placeholder="203.0.113.4 or 10.0.0.0/8" class="w-full" />
-          </div>
-          <div class="flex-1 space-y-1.5">
-            <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">Note</p>
-            <TextInput v-model="rule.description" placeholder="optional" class="w-full" />
-          </div>
-          <Button
-            variant="subtle"
-            icon="lucide-x"
-            label="Remove rule"
-            tooltip="Remove rule"
-            @click="removeRule(index)"
-          />
+          <!-- Under the row it belongs to, not pooled at the bottom of the page. -->
+          <p v-if="ipError(rule)" class="mt-1.5 text-ink-red-6 text-p-sm">{{ ipError(rule) }}</p>
         </div>
       </div>
     </div>
 
+    <!-- Cross-field problems (lockout) and server failures; single-field
+         problems sit at their row and hold the button instead. -->
     <ErrorMessage v-if="error" :message="error" />
 
     <div v-if="rules.length" class="flex justify-end">
-      <Button variant="solid" :loading="saving" @click="save">Save changes</Button>
+      <Button variant="solid" :loading="saving" :disabled="!canSave" @click="save">
+        Save changes
+      </Button>
     </div>
   </div>
 </template>
@@ -128,13 +136,19 @@ function removeRule(index) {
   rules.value.splice(index, 1)
 }
 
+// A wrong fill shows at its own row; empty or invalid IPs just hold the button.
+function ipError(rule) {
+  const ip = rule.ip.trim()
+  if (!ip || IP_PATTERN.test(ip)) return ''
+  return `'${rule.ip}' is not a valid IP or CIDR.`
+}
+const canSave = computed(() =>
+  rules.value.every((r) => r.ip.trim() && IP_PATTERN.test(r.ip.trim())),
+)
+
 function validate() {
-  for (const [index, rule] of rules.value.entries()) {
-    if (!rule.ip.trim()) return `Rule ${index + 1} needs an IP address or range.`
-    if (!IP_PATTERN.test(rule.ip.trim()))
-      return `Rule ${index + 1}: '${rule.ip}' is not a valid IP or CIDR.`
-  }
-  // Block-by-default with no Allow rule blocks everyone, including you.
+  // Block-by-default with no Allow rule blocks everyone, including you. Kept as
+  // a save-time message: it is a property of the whole ruleset, not one input.
   if (
     enabled.value &&
     defaultPolicy.value === 'deny' &&

--- a/admin/frontend/dashboard/src/components/settings/Firewall.vue
+++ b/admin/frontend/dashboard/src/components/settings/Firewall.vue
@@ -46,6 +46,7 @@
       </div>
 
       <EmptyState
+        compact
         v-if="!rules.length"
         icon="lucide-shield"
         title="No firewall rules"

--- a/admin/frontend/dashboard/src/components/settings/General.vue
+++ b/admin/frontend/dashboard/src/components/settings/General.vue
@@ -7,11 +7,19 @@
   </div>
   <div v-else>
     <ErrorMessage v-if="error" :message="error" class="mb-4" />
-    <div class="divide-y divide-outline-alpha-gray-1">
-      <SettingsRow label="Allow developer mode" description="Enables per-site developer mode and code editor.">
+    <div class="-mx-2.5 divide-y divide-outline-alpha-gray-1">
+      <SettingsRow
+        label="Allow developer mode"
+        description="Enables per-site developer mode and code editor."
+        interactive
+        @click="!saving && toggleAllowDeveloperMode(!allowDeveloperMode)"
+      >
+        <!-- The Switch handles its own clicks; without stop the row would toggle
+             a second time and land back where it started. -->
         <Switch
           :model-value="allowDeveloperMode"
           :disabled="saving"
+          @click.stop
           @update:model-value="toggleAllowDeveloperMode"
         />
       </SettingsRow>
@@ -19,18 +27,13 @@
       <SettingsRow
         v-for="section in sections"
         :key="section.id"
+        as="button"
+        interactive
         :label="section.label"
         :description="section.description"
+        @click="openSection = section"
       >
-        <!-- Icon-only: `label` is not rendered but becomes the accessible name. A
-             plain aria-label attr would be overwritten by Button's own. -->
-        <Button
-          size="sm"
-          variant="ghost"
-          icon="lucide-chevron-right"
-          :label="`${section.action || 'Manage'} ${section.label}`"
-          @click="openSection = section"
-        />
+        <span class="size-4 text-ink-gray-5 lucide-chevron-right" aria-hidden="true" />
       </SettingsRow>
 
       <Version />
@@ -40,7 +43,7 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { Button, ErrorMessage, Spinner, Switch, toast } from 'frappe-ui'
+import { ErrorMessage, Spinner, Switch, toast } from 'frappe-ui'
 import { settingsApi } from '@/api/settings'
 import { useSession } from '@/composables/auth/useSession'
 import SettingsRow from '@/components/settings/SettingsRow.vue'

--- a/admin/frontend/dashboard/src/components/settings/Git.vue
+++ b/admin/frontend/dashboard/src/components/settings/Git.vue
@@ -52,8 +52,7 @@
       />
       <ErrorMessage v-if="error" :message="error" />
       <div class="flex justify-end">
-        <!-- The token is the one required field - the username can be inferred
-             from it. Enter on the field still hits the in-function guard. -->
+        <!-- The token is the one required field; Enter still hits the guard. -->
         <Button variant="solid" :loading="connecting" :disabled="!token.trim()" @click="verifyAndConnect">
           {{ connected ? 'Update Token' : 'Verify & Connect' }}
         </Button>

--- a/admin/frontend/dashboard/src/components/settings/Git.vue
+++ b/admin/frontend/dashboard/src/components/settings/Git.vue
@@ -52,7 +52,9 @@
       />
       <ErrorMessage v-if="error" :message="error" />
       <div class="flex justify-end">
-        <Button variant="solid" :loading="connecting" @click="verifyAndConnect">
+        <!-- The token is the one required field - the username can be inferred
+             from it. Enter on the field still hits the in-function guard. -->
+        <Button variant="solid" :loading="connecting" :disabled="!token.trim()" @click="verifyAndConnect">
           {{ connected ? 'Update Token' : 'Verify & Connect' }}
         </Button>
       </div>

--- a/admin/frontend/dashboard/src/components/settings/Git.vue
+++ b/admin/frontend/dashboard/src/components/settings/Git.vue
@@ -24,7 +24,7 @@
       class="flex sm:flex-row sm:justify-between sm:items-center flex-col gap-3"
     >
       <div>
-        <p class="font-medium text-ink-gray-8 text-sm">Connected as {{ username }}</p>
+        <p class="font-medium text-ink-gray-8 text-base">Connected as {{ username }}</p>
         <p class="text-ink-gray-5 text-p-sm">GitHub · Personal access token</p>
       </div>
       <div class="flex items-center gap-2">

--- a/admin/frontend/dashboard/src/components/settings/LLM.vue
+++ b/admin/frontend/dashboard/src/components/settings/LLM.vue
@@ -103,8 +103,6 @@
         </div>
       </details>
 
-      <!-- Server failures only - a missing required field disables the button
-           instead of narrating itself down here. -->
       <ErrorMessage v-if="error" :message="error" />
       <div class="flex justify-end">
         <Button variant="solid" :loading="saving" :disabled="!canSave" @click="save">
@@ -161,8 +159,7 @@ const apiBaseError = computed(() => {
   return `${providerLabel.value} needs the endpoint of your server, e.g. http://your-host:8000/v1`
 })
 
-// Every required field, so Connect stays dead until the form could succeed -
-// what used to be four "X is required." messages after the click.
+// Connect stays dead until every required field is filled.
 const canSave = computed(
   () =>
     Boolean(provider.value) &&
@@ -177,9 +174,7 @@ const modelPlaceholder = computed(() => {
   if (!models.value.length && !hasApiKey.value) return 'Enter the API key to load models'
   return 'Search models…'
 })
-// An empty picklist with no key entered is a missing key, not a missing provider —
-// say so rather than leaving a silently empty dropdown. Self-hosted types the model
-// by hand, so it never reaches here.
+// An empty picklist with no key entered is a missing key - say so.
 const modelsHint = computed(() => {
   if (!provider.value || modelsLoading.value || models.value.length) return ''
   if (needsApiBase.value && !hasApiBase.value) return ''
@@ -191,8 +186,7 @@ async function fetchModels(providerValue) {
   models.value = []
   modelsError.value = ''
   if (!providerValue || freeTextModel.value) return
-  // Providers without a static catalog list models from their own API, so the key
-  // is sent along; the backend falls back to the key already saved in bench.toml.
+  // The key is sent along; the backend falls back to the saved one.
   if (modelsNeedApiKey.value && !hasApiKey.value) return
   if (needsApiBase.value && !hasApiBase.value) return
   modelsLoading.value = true

--- a/admin/frontend/dashboard/src/components/settings/LLM.vue
+++ b/admin/frontend/dashboard/src/components/settings/LLM.vue
@@ -103,9 +103,11 @@
         </div>
       </details>
 
+      <!-- Server failures only - a missing required field disables the button
+           instead of narrating itself down here. -->
       <ErrorMessage v-if="error" :message="error" />
       <div class="flex justify-end">
-        <Button variant="solid" :loading="saving" :disabled="Boolean(apiBaseError)" @click="save">
+        <Button variant="solid" :loading="saving" :disabled="!canSave" @click="save">
           {{ connected ? 'Update' : 'Connect' }}
         </Button>
       </div>
@@ -158,6 +160,16 @@ const apiBaseError = computed(() => {
   if (!provider.value || !needsApiBase.value || hasApiBase.value) return ''
   return `${providerLabel.value} needs the endpoint of your server, e.g. http://your-host:8000/v1`
 })
+
+// Every required field, so Connect stays dead until the form could succeed -
+// what used to be four "X is required." messages after the click.
+const canSave = computed(
+  () =>
+    Boolean(provider.value) &&
+    Boolean(model.value.trim()) &&
+    hasApiKey.value &&
+    (!needsApiBase.value || hasApiBase.value),
+)
 
 const modelPlaceholder = computed(() => {
   if (!provider.value) return 'Select a provider first'
@@ -228,22 +240,6 @@ async function load() {
 }
 
 async function save() {
-  if (!provider.value) {
-    error.value = 'Provider is required.'
-    return
-  }
-  if (!model.value.trim()) {
-    error.value = 'Model is required.'
-    return
-  }
-  if (needsApiBase.value && !apiBase.value.trim()) {
-    error.value = 'API base URL is required for a self-hosted provider.'
-    return
-  }
-  if (!apiKeySet.value && !apiKey.value.trim()) {
-    error.value = 'API key is required.'
-    return
-  }
   saving.value = true
   error.value = ''
   try {

--- a/admin/frontend/dashboard/src/components/settings/LLM.vue
+++ b/admin/frontend/dashboard/src/components/settings/LLM.vue
@@ -17,7 +17,7 @@
       class="flex sm:flex-row flex-col sm:justify-between sm:items-center gap-3"
     >
       <div>
-        <p class="font-medium text-ink-gray-8 text-sm">Connected to {{ providerLabel }}</p>
+        <p class="font-medium text-ink-gray-8 text-base">Connected to {{ providerLabel }}</p>
         <p class="text-ink-gray-5 text-p-sm">Model {{ model || '—' }} · API key set</p>
       </div>
       <Button
@@ -84,7 +84,7 @@
 
       <details class="group">
         <summary
-          class="flex items-center gap-1.5 text-ink-gray-6 text-sm cursor-pointer select-none"
+          class="flex items-center gap-1.5 text-ink-gray-6 text-base cursor-pointer select-none"
         >
           <span
             class="size-4 transition-transform group-open:rotate-90 lucide-chevron-right"

--- a/admin/frontend/dashboard/src/components/settings/S3Bucket.vue
+++ b/admin/frontend/dashboard/src/components/settings/S3Bucket.vue
@@ -16,7 +16,7 @@
       class="flex sm:flex-row flex-col sm:justify-between sm:items-center gap-3"
     >
       <div>
-        <p class="font-medium text-ink-gray-8 text-sm">Connected to {{ bucket }}</p>
+        <p class="font-medium text-ink-gray-8 text-base">Connected to {{ bucket }}</p>
         <p class="text-ink-gray-5 text-p-sm">{{ providerLabel }} · Access key {{ accessKey }}</p>
       </div>
       <Button

--- a/admin/frontend/dashboard/src/components/settings/S3Bucket.vue
+++ b/admin/frontend/dashboard/src/components/settings/S3Bucket.vue
@@ -51,8 +51,6 @@
           class="w-full"
         />
       </div>
-      <!-- Server failures only - a missing required field disables the button
-           instead of narrating itself down here. -->
       <ErrorMessage v-if="error" :message="error" />
       <div class="flex justify-end">
         <Button variant="solid" :loading="saving" :disabled="!canSave" @click="save">

--- a/admin/frontend/dashboard/src/components/settings/S3Bucket.vue
+++ b/admin/frontend/dashboard/src/components/settings/S3Bucket.vue
@@ -51,9 +51,11 @@
           class="w-full"
         />
       </div>
+      <!-- Server failures only - a missing required field disables the button
+           instead of narrating itself down here. -->
       <ErrorMessage v-if="error" :message="error" />
       <div class="flex justify-end">
-        <Button variant="solid" :loading="saving" @click="save">
+        <Button variant="solid" :loading="saving" :disabled="!canSave" @click="save">
           {{ connected ? 'Update' : 'Connect' }}
         </Button>
       </div>
@@ -99,6 +101,16 @@ watch(provider, () => {
   }
 })
 
+// Every required field, so Connect stays dead until the form could succeed.
+const canSave = computed(
+  () =>
+    Boolean(accessKey.value.trim()) &&
+    Boolean(bucket.value.trim()) &&
+    Boolean(provider.value) &&
+    Boolean(region.value) &&
+    (secretKeySet.value || Boolean(secretKey.value.trim())),
+)
+
 async function load() {
   loading.value = true
   try {
@@ -118,14 +130,6 @@ async function load() {
 }
 
 async function save() {
-  if (!accessKey.value.trim() || !bucket.value.trim() || !provider.value || !region.value) {
-    error.value = 'Access key, bucket, provider, and region are required.'
-    return
-  }
-  if (!secretKeySet.value && !secretKey.value.trim()) {
-    error.value = 'Secret key is required.'
-    return
-  }
   saving.value = true
   error.value = ''
   try {

--- a/admin/frontend/dashboard/src/components/settings/Security.vue
+++ b/admin/frontend/dashboard/src/components/settings/Security.vue
@@ -7,7 +7,7 @@
 
   <Dialog v-model="showRevokePrompt" :options="{ title: 'Password changed', size: 'md' }">
     <template #body-content>
-      <p class="text-ink-gray-7 text-p-sm">
+      <p class="text-ink-gray-7 text-p-base">
         Revoke every other active session? Anyone signed in elsewhere will be signed out
         immediately — this browser stays signed in.
       </p>

--- a/admin/frontend/dashboard/src/components/settings/Sessions.vue
+++ b/admin/frontend/dashboard/src/components/settings/Sessions.vue
@@ -6,13 +6,12 @@
     <div v-if="activityLoading" class="flex justify-center items-center h-40">
       <Spinner size="lg" class="text-ink-gray-4" />
     </div>
-    <div
+    <EmptyState
       v-else-if="!activity.length"
-      class="flex flex-col items-center gap-2.5 py-10 border border-dashed rounded-lg border-outline-gray-2 text-center"
-    >
-      <p class="font-medium text-ink-gray-7 text-sm">No activity recorded</p>
-      <p class="max-w-xs text-ink-gray-5 text-xs">Actions taken by this session will show up here.</p>
-    </div>
+      icon="lucide-history"
+      title="No activity recorded"
+      description="Actions taken by this session will show up here."
+    />
     <ListView
       v-else
       :columns="activityColumns"
@@ -22,7 +21,14 @@
     >
       <template #cell="{ column, row, item }">
         <div v-if="column.key === 'actions'" class="flex justify-end">
-          <Button variant="ghost" size="sm" icon="lucide-info" @click="openDetail(row)" />
+          <Button
+            variant="ghost"
+            size="sm"
+            icon="lucide-info"
+            label="Activity details"
+            tooltip="Details"
+            @click="openDetail(row)"
+          />
         </div>
         <ListRowItem v-else :column="column" :row="row" :item="item" :align="column.align" />
       </template>
@@ -36,16 +42,12 @@
       {{ loadError }}
     </div>
     <template v-else>
-      <div
+      <EmptyState
         v-if="!activeTokens.length"
-        class="flex flex-col items-center gap-2.5 py-10 border border-dashed rounded-lg border-outline-gray-2 text-center"
-      >
-        <div class="flex justify-center items-center bg-surface-gray-2 rounded-full size-11">
-          <span class="size-5 text-ink-gray-5 lucide-key-round"></span>
-        </div>
-        <p class="font-medium text-ink-gray-7 text-sm">No active sessions</p>
-        <p class="max-w-xs text-ink-gray-5 text-xs">Sign-ins appear here while their tokens are valid.</p>
-      </div>
+        icon="lucide-key-round"
+        title="No active sessions"
+        description="Sign-ins appear here while their tokens are valid."
+      />
 
       <ListView
         v-else
@@ -58,7 +60,14 @@
           <div v-if="column.key === 'actions'" class="flex justify-end">
             <Dropdown :options="menuOptions(row)" placement="left">
               <template #default="{ open }">
-                <Button variant="ghost" size="sm" :active="open" icon="lucide-ellipsis" />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  :active="open"
+                  icon="lucide-ellipsis"
+                  label="Session actions"
+                  tooltip="Actions"
+                />
               </template>
             </Dropdown>
           </div>
@@ -70,11 +79,11 @@
 
   <Dialog v-model="showRevoke" :options="{ title: 'Revoke session', size: 'md' }">
     <template #body-content>
-      <p class="text-ink-gray-7 text-p-sm">
+      <p class="text-ink-gray-7 text-p-base">
         Revoke this session? Its token stops working immediately and whoever holds it must sign in
         again.
       </p>
-      <p class="mt-2 font-mono text-ink-gray-5 text-xs">{{ revoking?.ip }}</p>
+      <p class="mt-2 font-mono text-ink-gray-5 text-sm">{{ revoking?.ip }}</p>
       <div class="flex justify-end gap-2 mt-4">
         <Button variant="ghost" @click="showRevoke = false">Cancel</Button>
         <Button variant="solid" theme="red" :loading="revokeBusy" @click="confirmRevoke">
@@ -99,6 +108,7 @@
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
 import { Button, Dialog, Dropdown, ListRowItem, ListView, Spinner, toast } from 'frappe-ui'
+import EmptyState from '@/components/common/EmptyState.vue'
 import { sessionApi } from '@/api/session'
 import { auditApi } from '@/api/audit'
 import { commandLabel, fmtDateTime, relativeTime } from '@/utils/taskFormat'

--- a/admin/frontend/dashboard/src/components/settings/Sessions.vue
+++ b/admin/frontend/dashboard/src/components/settings/Sessions.vue
@@ -7,6 +7,7 @@
       <Spinner size="lg" class="text-ink-gray-4" />
     </div>
     <EmptyState
+      compact
       v-else-if="!activity.length"
       icon="lucide-history"
       title="No activity recorded"
@@ -43,6 +44,7 @@
     </div>
     <template v-else>
       <EmptyState
+        compact
         v-if="!activeTokens.length"
         icon="lucide-key-round"
         title="No active sessions"

--- a/admin/frontend/dashboard/src/components/settings/SettingsDialog.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsDialog.vue
@@ -2,12 +2,17 @@
   <Dialog v-model="open" bare size="4xl">
     <template #default="{ close }">
       <div class="relative flex sm:h-[70vh] max-h-[85vh]">
+        <!-- Sizing, padding and tokens taken from frappe-ui's own SettingsDialog
+             (SettingsSidebar: bg-surface-sidebar, p-2, 220px, outline-gray-1).
+             surface-sidebar is theme-aware by design - a light gray against the
+             panel in light mode, transparent in dark, where the panel is already
+             raised off the backdrop. -->
         <div
-          class="flex-col p-4 sm:border-r border-outline-gray-2 w-full sm:w-52 shrink-0"
+          class="flex-col bg-surface-sidebar p-2 sm:border-r border-outline-gray-1 w-full sm:w-[220px] shrink-0"
           :class="activeSection ? 'hidden sm:flex' : 'flex'"
         >
           <h3
-            class="mb-1 p-2 pb-3 border-b sm:border-b-0 border-outline-gray-2 font-semibold text-ink-gray-9 text-base"
+            class="mb-1 p-2 pb-3 border-b sm:border-b-0 border-outline-gray-1 font-semibold text-ink-gray-9 text-base"
           >
             Settings
           </h3>
@@ -16,6 +21,8 @@
             class="sm:hidden top-3 right-3 absolute"
             variant="ghost"
             icon="lucide-x"
+            label="Close settings"
+            tooltip="Close"
             @click="close"
           />
           <div class="flex flex-col gap-2 sm:gap-0.5 pt-2 sm:pt-0">
@@ -25,8 +32,12 @@
               :variant="isMobile ? 'subtle' : 'ghost'"
               :size="isMobile ? 'md' : 'sm'"
               class="!justify-start border sm:border-0 w-full"
-              :class="currentSection === section.id ? 'sm:!bg-surface-gray-3 sm:!text-ink-gray-9 !text-ink-gray-6' : '!text-ink-gray-6'"
-              @click="activeSection = section.id"
+              :class="
+                currentSection === section.id
+                  ? 'sm:!bg-surface-elevation-3 sm:!shadow-sm sm:!text-ink-gray-9 !text-ink-gray-6'
+                  : '!text-ink-gray-6'
+              "
+              @click="guarded(() => (activeSection = section.id))"
             >
               <template #prefix>
                 <span :class="section.icon" class="size-4"></span>
@@ -35,8 +46,11 @@
             </Button>
           </div>
         </div>
+        <!-- px-[4.4rem] pt-10 pb-16 is frappe-ui's SettingsHeader/SettingsBody
+             padding. Kept off below sm, where 70px a side would leave a column
+             barely wider than the words in it. -->
         <div
-          class="flex-col flex-1 p-6 overflow-y-auto"
+          class="flex-col flex-1 px-6 sm:px-[4.4rem] pt-6 sm:pt-10 pb-10 sm:pb-16 overflow-y-auto"
           :class="activeSection ? 'flex' : 'hidden sm:flex'"
         >
           <div class="flex justify-between items-center pb-4">
@@ -47,14 +61,19 @@
                 class="-ml-2"
                 variant="subtle"
                 icon="lucide-arrow-left"
+                label="Back"
+                tooltip="Back"
                 @click="goBack"
               />
               <h3 class="font-semibold text-ink-gray-9 text-lg">{{ headerTitle }}</h3>
             </div>
             <div id="settings-header-actions" class="contents"></div>
           </div>
-          <General v-if="currentSection === 'general'" v-model:open-section="subSection" />
-          <Security v-else-if="currentSection === 'security'" v-model:open-section="subSection" />
+          <General v-if="currentSection === 'general'" v-model:open-section="guardedSubSection" />
+          <Security
+            v-else-if="currentSection === 'security'"
+            v-model:open-section="guardedSubSection"
+          />
           <Sessions
             v-else-if="currentSection === 'sessions'"
             v-model:nested-view="nestedView"
@@ -65,12 +84,25 @@
       </div>
     </template>
   </Dialog>
+
+  <Dialog v-model="showDiscard" :options="{ title: 'Unsaved changes', size: 'sm' }">
+    <template #body-content>
+      <p class="text-ink-gray-7 text-p-base">
+        You have changes here that have not been saved. Leaving loses them.
+      </p>
+      <div class="flex justify-end gap-2 mt-4">
+        <Button variant="subtle" @click="showDiscard = false">Keep editing</Button>
+        <Button variant="solid" theme="red" @click="discardAndGo">Discard</Button>
+      </div>
+    </template>
+  </Dialog>
 </template>
 
 <script setup>
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { Dialog, Button } from 'frappe-ui'
+import { hasUnsavedChanges } from '@/composables/common/useUnsavedChanges'
 import General from '@/components/settings/General.vue'
 import Security from '@/components/settings/Security.vue'
 import Sessions from '@/components/settings/Sessions.vue'
@@ -78,11 +110,47 @@ import SystemInfo from '@/components/settings/SystemInfo.vue'
 import { useIsMobile } from '@/composables/common/useIsMobile'
 import { GENERAL_SECTIONS, SECURITY_SECTIONS } from '@/components/settings/sections'
 
-const open = defineModel()
+const openModel = defineModel()
 
 const isMobile = useIsMobile()
 const route = useRoute()
 const router = useRouter()
+
+// Every way out of a panel funnels through here: the sidebar, the back arrow,
+// opening a sub-section, and dismissing the dialog. Moving between panels is a
+// route *param* change on the one Settings record, so a component-level
+// onBeforeRouteLeave never sees it - the gate has to sit at the call sites.
+//
+// When nothing is dirty this runs the action straight through, so the ordinary
+// case is unchanged.
+const showDiscard = ref(false)
+let pendingNav = null
+function guarded(action) {
+  if (!hasUnsavedChanges()) return action()
+  pendingNav = action
+  showDiscard.value = true
+}
+function discardAndGo() {
+  // Taken before the dialog closes: closing trips the watcher below, and relying
+  // on that landing after this line would make the whole thing depend on watcher
+  // flush timing.
+  const action = pendingNav
+  pendingNav = null
+  showDiscard.value = false
+  action?.()
+}
+watch(showDiscard, (shown) => {
+  if (!shown) pendingNav = null
+})
+
+// Closing is guarded; opening never is.
+const open = computed({
+  get: () => openModel.value,
+  set: (value) => {
+    if (value) openModel.value = true
+    else guarded(() => (openModel.value = false))
+  },
+})
 
 const sections = computed(() => [
   { id: 'general', label: 'General', icon: 'lucide-settings' },
@@ -115,6 +183,12 @@ const subSection = computed({
       params: { section: currentSection.value, subSection: section?.id },
     }),
 })
+// What General and Security bind to. Guarded here rather than in `subSection`
+// itself so goBack() and discardAndGo() can still move without re-asking.
+const guardedSubSection = computed({
+  get: () => subSection.value,
+  set: (section) => guarded(() => (subSection.value = section)),
+})
 
 // Sessions doesn't use the sub-section registry (its "sub-pages" are individual,
 // dynamically-fetched sessions, not a fixed list) - the same :subSection route slot
@@ -137,8 +211,10 @@ const headerTitle = computed(() => {
 })
 
 function goBack() {
-  if (sessionJti.value) sessionJti.value = null
-  else if (subSection.value) subSection.value = null
-  else activeSection.value = null
+  guarded(() => {
+    if (sessionJti.value) sessionJti.value = null
+    else if (subSection.value) subSection.value = null
+    else activeSection.value = null
+  })
 }
 </script>

--- a/admin/frontend/dashboard/src/components/settings/SettingsDialog.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsDialog.vue
@@ -1,16 +1,11 @@
 <template>
   <Dialog v-model="open" bare size="5xl">
     <template #default="{ close }">
-      <!-- Full viewport height, less the chrome the Dialog puts around the panel
-           itself: the overlay's scroll wrapper adds py-4 and DialogContent adds
-           my-8, so a literal 100vh overflows by exactly 96px and makes the
-           overlay scroll with the bottom corners off-screen. -->
+      <!-- 6rem = the Dialog's own chrome (overlay py-4 + content my-8); a
+           literal 100vh overflows and sets the overlay scrolling. -->
       <div class="relative flex sm:h-[calc(100vh-6rem)] max-h-[calc(100vh-6rem)]">
-        <!-- Sizing, padding and tokens taken from frappe-ui's own SettingsDialog
-             (SettingsSidebar: bg-surface-sidebar, p-2, 220px, outline-gray-1).
-             surface-sidebar is theme-aware by design - a light gray against the
-             panel in light mode, transparent in dark, where the panel is already
-             raised off the backdrop. -->
+        <!-- Sizing and tokens from frappe-ui's own SettingsSidebar.
+             surface-sidebar is theme-aware: light gray in light, transparent in dark. -->
         <div
           class="flex-col bg-surface-sidebar p-2 sm:border-r border-outline-gray-1 w-full sm:w-[220px] shrink-0"
           :class="activeSection ? 'hidden sm:flex' : 'flex'"
@@ -50,9 +45,7 @@
             </Button>
           </div>
         </div>
-        <!-- px-[4.4rem] pt-10 pb-16 is frappe-ui's SettingsHeader/SettingsBody
-             padding. Kept off below sm, where 70px a side would leave a column
-             barely wider than the words in it. -->
+        <!-- frappe-ui's SettingsHeader/SettingsBody padding; off below sm. -->
         <div
           class="flex-col flex-1 px-6 sm:px-[4.4rem] pt-6 sm:pt-10 pb-10 sm:pb-16 overflow-y-auto"
           :class="activeSection ? 'flex' : 'hidden sm:flex'"
@@ -120,13 +113,8 @@ const isMobile = useIsMobile()
 const route = useRoute()
 const router = useRouter()
 
-// Every way out of a panel funnels through here: the sidebar, the back arrow,
-// opening a sub-section, and dismissing the dialog. Moving between panels is a
-// route *param* change on the one Settings record, so a component-level
-// onBeforeRouteLeave never sees it - the gate has to sit at the call sites.
-//
-// When nothing is dirty this runs the action straight through, so the ordinary
-// case is unchanged.
+// Every exit funnels through here. Panel switching is a route *param* change
+// on one record, so onBeforeRouteLeave never fires for it.
 const showDiscard = ref(false)
 let pendingNav = null
 function guarded(action) {
@@ -135,9 +123,7 @@ function guarded(action) {
   showDiscard.value = true
 }
 function discardAndGo() {
-  // Taken before the dialog closes: closing trips the watcher below, and relying
-  // on that landing after this line would make the whole thing depend on watcher
-  // flush timing.
+  // Read before closing: closing trips the watcher below, which nulls it.
   const action = pendingNav
   pendingNav = null
   showDiscard.value = false
@@ -162,9 +148,7 @@ const sections = computed(() => [
   { id: 'sessions', label: 'Sessions', icon: 'lucide-monitor' },
   { id: 'system-info', label: 'System Info', icon: 'lucide-info' },
 ])
-// Both section and sub-section are routed (deep-linkable, back button
-// closes/steps back). Sub-section options come from a shared registry so
-// this dialog can resolve a route id without General/Security exposing one.
+// Section and sub-section are routed, so views are deep-linkable.
 const activeSection = computed({
   get: () => route.params.section || null,
   set: (id) => router.push(id ? { name: 'Settings', params: { section: id } } : { name: 'Settings' }),
@@ -187,25 +171,20 @@ const subSection = computed({
       params: { section: currentSection.value, subSection: section?.id },
     }),
 })
-// What General and Security bind to. Guarded here rather than in `subSection`
-// itself so goBack() and discardAndGo() can still move without re-asking.
+// Guarded here, not in `subSection`, so goBack() can move without re-asking.
 const guardedSubSection = computed({
   get: () => subSection.value,
   set: (section) => guarded(() => (subSection.value = section)),
 })
 
-// Sessions doesn't use the sub-section registry (its "sub-pages" are individual,
-// dynamically-fetched sessions, not a fixed list) - the same :subSection route slot
-// carries a jti instead, so a specific session's activity view is a real deep link.
+// For Sessions the :subSection route slot carries a jti instead.
 const sessionJti = computed({
   get: () => (currentSection.value === 'sessions' ? route.params.subSection || null : null),
   set: (jti) =>
     router.push({ name: 'Settings', params: { section: 'sessions', subSection: jti || undefined } }),
 })
 
-// Sessions reports the human title (an IP, once it resolves the jti) since the route
-// only carries the raw id - reset whenever the visible section changes so re-entering
-// the tab later never inherits a stale title.
+// Reset on section change so a stale title is never inherited.
 const nestedView = ref(null)
 watch(currentSection, () => (nestedView.value = null))
 

--- a/admin/frontend/dashboard/src/components/settings/SettingsDialog.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsDialog.vue
@@ -1,7 +1,11 @@
 <template>
-  <Dialog v-model="open" bare size="4xl">
+  <Dialog v-model="open" bare size="5xl">
     <template #default="{ close }">
-      <div class="relative flex sm:h-[70vh] max-h-[85vh]">
+      <!-- Full viewport height, less the chrome the Dialog puts around the panel
+           itself: the overlay's scroll wrapper adds py-4 and DialogContent adds
+           my-8, so a literal 100vh overflows by exactly 96px and makes the
+           overlay scroll with the bottom corners off-screen. -->
+      <div class="relative flex sm:h-[calc(100vh-6rem)] max-h-[calc(100vh-6rem)]">
         <!-- Sizing, padding and tokens taken from frappe-ui's own SettingsDialog
              (SettingsSidebar: bg-surface-sidebar, p-2, 220px, outline-gray-1).
              surface-sidebar is theme-aware by design - a light gray against the
@@ -59,7 +63,7 @@
                 v-if="subSection || sessionJti || activeSection"
                 :class="{ 'sm:hidden': !subSection && !sessionJti }"
                 class="-ml-2"
-                variant="subtle"
+                variant="ghost"
                 icon="lucide-arrow-left"
                 label="Back"
                 tooltip="Back"

--- a/admin/frontend/dashboard/src/components/settings/SettingsRow.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsRow.vue
@@ -1,10 +1,7 @@
 <template>
   <div class="flex justify-between items-center gap-x-2.5 py-3 first:pt-0 last:pb-0">
     <div class="flex flex-col gap-1">
-      <!-- 14/13, matching frappe-ui's own InputLabel (text-base) and
-           InputDescription (text-p-sm): a Switch row rendered by the library sits
-           directly above these, so anything else reads as two type scales in one
-           list. The description is stacked copy that wraps, hence text-p-sm. -->
+      <!-- Matches frappe-ui's InputLabel (text-base) / InputDescription (text-p-sm). -->
       <p class="font-medium text-ink-gray-8 text-base">{{ label }}</p>
       <p v-if="description" class="text-ink-gray-6 text-p-sm">{{ description }}</p>
     </div>

--- a/admin/frontend/dashboard/src/components/settings/SettingsRow.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsRow.vue
@@ -1,8 +1,12 @@
 <template>
   <div class="flex justify-between items-center gap-x-2.5 py-3 first:pt-0 last:pb-0">
     <div class="flex flex-col gap-1">
-      <p class="font-medium text-ink-gray-8 text-sm leading-normal">{{ label }}</p>
-      <p v-if="description" class="text-ink-gray-6 text-sm">{{ description }}</p>
+      <!-- 14/13, matching frappe-ui's own InputLabel (text-base) and
+           InputDescription (text-p-sm): a Switch row rendered by the library sits
+           directly above these, so anything else reads as two type scales in one
+           list. The description is stacked copy that wraps, hence text-p-sm. -->
+      <p class="font-medium text-ink-gray-8 text-base">{{ label }}</p>
+      <p v-if="description" class="text-ink-gray-6 text-p-sm">{{ description }}</p>
     </div>
     <div class="ml-4 shrink-0">
       <slot />

--- a/admin/frontend/dashboard/src/components/settings/SettingsRow.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsRow.vue
@@ -1,5 +1,13 @@
 <template>
-  <div class="flex justify-between items-center gap-x-2.5 py-3 first:pt-0 last:pb-0">
+  <!-- `as="button"` when the row itself is the control. A row whose slot already
+       holds one stays a div and forwards the click: a control nested in a button
+       is invalid markup, and the inner one stops receiving its own clicks. -->
+  <component
+    :is="as"
+    :type="as === 'button' ? 'button' : undefined"
+    class="flex justify-between items-center gap-x-2.5 px-2.5 py-3"
+    :class="interactive ? 'w-full rounded transition-colors cursor-pointer text-left hover:bg-surface-gray-1' : ''"
+  >
     <div class="flex flex-col gap-1">
       <!-- Matches frappe-ui's InputLabel (text-base) / InputDescription (text-p-sm). -->
       <p class="font-medium text-ink-gray-8 text-base">{{ label }}</p>
@@ -8,9 +16,14 @@
     <div class="ml-4 shrink-0">
       <slot />
     </div>
-  </div>
+  </component>
 </template>
 
 <script setup>
-defineProps({ label: { type: String, required: true }, description: { type: String, default: '' } })
+defineProps({
+  label: { type: String, required: true },
+  description: { type: String, default: '' },
+  as: { type: String, default: 'div', validator: (as) => ['div', 'button'].includes(as) },
+  interactive: { type: Boolean, default: false },
+})
 </script>

--- a/admin/frontend/dashboard/src/components/settings/SettingsSectionRows.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsSectionRows.vue
@@ -3,28 +3,24 @@
     <component :is="openSection.component" @passwordChanged="handlePasswordChanged" />
   </div>
 
-  <div v-else class="divide-y divide-outline-alpha-gray-1">
+  <!-- -mx cancels the rows' own padding, so their text still lines up with the
+       section heading while a hovered row reads as inset. -->
+  <div v-else class="-mx-2.5 divide-y divide-outline-alpha-gray-1">
     <SettingsRow
       v-for="section in sections"
       :key="section.id"
+      as="button"
+      interactive
       :label="section.label"
       :description="section.description"
+      @click="openSection = section"
     >
-      <!-- Icon-only: `label` is not rendered but becomes the accessible name. A
-           plain aria-label attr would be overwritten by Button's own. -->
-      <Button
-        size="sm"
-        variant="ghost"
-        icon="lucide-chevron-right"
-        :label="`${section.action || 'Manage'} ${section.label}`"
-        @click="openSection = section"
-      />
+      <span class="size-4 text-ink-gray-5 lucide-chevron-right" aria-hidden="true" />
     </SettingsRow>
   </div>
 </template>
 
 <script setup>
-import { Button } from 'frappe-ui'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
 
 defineProps({ sections: { type: Array, required: true } })

--- a/admin/frontend/dashboard/src/components/settings/SettingsSwitch.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsSwitch.vue
@@ -1,0 +1,25 @@
+<template>
+  <Switch v-bind="$attrs" :class="LABEL_CLASSES">
+    <template v-for="(_, name) in $slots" #[name]="slotProps">
+      <slot :name="name" v-bind="slotProps ?? {}" />
+    </template>
+  </Switch>
+</template>
+
+<script setup>
+// frappe-ui's Switch renders its label through InputLabel, which is regular
+// weight in ink-gray-5. That is right for a form field, but in this dialog a
+// Switch sits in the same list as SettingsRow, whose label is medium ink-gray-8
+// - side by side the library default reads as disabled text. The size is
+// already right (InputLabel is text-base), so only colour and weight move.
+//
+// Styled through the data-slot hooks the library documents rather than
+// `labelClasses`, which is deprecated and no longer applied.
+import { Switch } from 'frappe-ui'
+
+defineOptions({ inheritAttrs: false })
+
+const LABEL_CLASSES =
+  "[&_[data-slot='label']]:font-medium [&_[data-slot='label']]:text-ink-gray-8 " +
+  "[&_[data-slot='description']]:text-ink-gray-6"
+</script>

--- a/admin/frontend/dashboard/src/components/settings/SettingsSwitch.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsSwitch.vue
@@ -7,14 +7,9 @@
 </template>
 
 <script setup>
-// frappe-ui's Switch renders its label through InputLabel, which is regular
-// weight in ink-gray-5. That is right for a form field, but in this dialog a
-// Switch sits in the same list as SettingsRow, whose label is medium ink-gray-8
-// - side by side the library default reads as disabled text. The size is
-// already right (InputLabel is text-base), so only colour and weight move.
-//
-// Styled through the data-slot hooks the library documents rather than
-// `labelClasses`, which is deprecated and no longer applied.
+// Switch's default label (regular ink-gray-5) reads as disabled next to a
+// SettingsRow. Styled via data-slot hooks: `labelClasses` is deprecated and
+// no longer applied, so passing it only warns.
 import { Switch } from 'frappe-ui'
 
 defineOptions({ inheritAttrs: false })

--- a/admin/frontend/dashboard/src/components/settings/SshKeys.vue
+++ b/admin/frontend/dashboard/src/components/settings/SshKeys.vue
@@ -13,6 +13,7 @@
       {{ loadError }}
     </div>
     <EmptyState
+      compact
       v-else-if="!rows.length"
       icon="lucide-key-round"
       title="No SSH keys"

--- a/admin/frontend/dashboard/src/components/settings/SshKeys.vue
+++ b/admin/frontend/dashboard/src/components/settings/SshKeys.vue
@@ -12,12 +12,12 @@
     >
       {{ loadError }}
     </div>
-    <div
+    <EmptyState
       v-else-if="!rows.length"
-      class="py-12 border border-dashed rounded-xl border-outline-gray-2 text-ink-gray-5 text-p-sm text-center"
-    >
-      No SSH keys.
-    </div>
+      icon="lucide-key-round"
+      title="No SSH keys"
+      description="Add a public key to give its holder SSH access to this server."
+    />
     <ListView
       v-else
       :columns="columns"
@@ -32,6 +32,8 @@
             size="sm"
             theme="red"
             icon="lucide-trash-2"
+            label="Remove SSH key"
+            tooltip="Remove SSH key"
             @click="promptRemove(row)"
           />
         </div>
@@ -59,11 +61,11 @@
 
   <Dialog v-model="showRemove" :options="{ title: 'Remove SSH key', size: 'md' }">
     <template #body-content>
-      <p v-if="isLastKey" class="text-ink-gray-7 text-p-sm">
+      <p v-if="isLastKey" class="text-ink-gray-7 text-p-base">
         This is the last authorized key. It can't be removed, or you'd lose SSH access to this
         server.
       </p>
-      <p v-else class="text-ink-gray-7 text-p-sm">
+      <p v-else class="text-ink-gray-7 text-p-base">
         Remove <span class="font-semibold text-ink-gray-8 break-all">{{ removing?.label }}</span>?
         Whoever holds the matching private key loses SSH access.
       </p>
@@ -80,6 +82,7 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { Button, Dialog, ErrorMessage, FormControl, ListRowItem, ListView, Spinner, toast } from 'frappe-ui'
+import EmptyState from '@/components/common/EmptyState.vue'
 import { apiErrorMessage } from '@/api/client'
 import { sshKeysApi } from '@/api/sshKeys'
 

--- a/admin/frontend/dashboard/src/components/settings/SshKeys.vue
+++ b/admin/frontend/dashboard/src/components/settings/SshKeys.vue
@@ -55,7 +55,9 @@
       <ErrorMessage v-if="error" :message="error" class="mt-2" />
       <div class="flex justify-end gap-2 mt-4">
         <Button variant="ghost" @click="showAdd = false">Cancel</Button>
-        <Button variant="solid" :loading="adding" @click="add">Add key</Button>
+        <Button variant="solid" :loading="adding" :disabled="!newKey.trim()" @click="add">
+          Add key
+        </Button>
       </div>
     </template>
   </Dialog>
@@ -130,10 +132,6 @@ function openAdd() {
 }
 
 async function add() {
-  if (!newKey.value.trim()) {
-    error.value = 'Paste a public key to add.'
-    return
-  }
   adding.value = true
   error.value = ''
   try {

--- a/admin/frontend/dashboard/src/components/settings/SystemInfo.vue
+++ b/admin/frontend/dashboard/src/components/settings/SystemInfo.vue
@@ -11,8 +11,8 @@
           :key="label"
           class="flex justify-between items-center py-2.5"
         >
-          <span class="text-ink-gray-7 text-sm">{{ label }}</span>
-          <span class="text-ink-gray-9 text-sm">{{ value }}</span>
+          <span class="text-ink-gray-7 text-base">{{ label }}</span>
+          <span class="text-ink-gray-9 text-base">{{ value }}</span>
         </div>
       </div>
     </div>
@@ -25,10 +25,10 @@
           :key="label"
           class="flex justify-between items-center py-2.5"
         >
-          <span class="text-ink-gray-7 text-sm">{{ label }}</span>
-          <span class="text-ink-gray-9 text-sm">{{ value }}</span>
+          <span class="text-ink-gray-7 text-base">{{ label }}</span>
+          <span class="text-ink-gray-9 text-base">{{ value }}</span>
         </div>
-        <p v-if="!Object.keys(info.runtime).length" class="py-2.5 text-ink-gray-5 text-sm">
+        <p v-if="!Object.keys(info.runtime).length" class="py-2.5 text-ink-gray-5 text-p-sm">
           No runtime versions detected.
         </p>
       </div>

--- a/admin/frontend/dashboard/src/components/settings/TwoFactor.vue
+++ b/admin/frontend/dashboard/src/components/settings/TwoFactor.vue
@@ -4,7 +4,7 @@
   </div>
   <div v-else class="space-y-5">
     <div class="flex justify-between items-center">
-      <p class="font-medium text-ink-gray-8 text-sm">
+      <p class="font-medium text-ink-gray-8 text-base">
         Devices
         <span class="font-normal text-ink-gray-5">
           ({{ devices.length }} of {{ status.max_devices }})
@@ -27,19 +27,12 @@
       an existing device's setup key to add another authenticator app.
     </div>
 
-    <div
+    <EmptyState
       v-if="!devices.length"
-      class="flex flex-col items-center gap-2.5 py-10 border border-dashed rounded-lg border-outline-gray-2 text-center"
-    >
-      <div class="flex justify-center items-center bg-surface-gray-2 rounded-full size-11">
-        <span class="size-5 text-ink-gray-5 lucide-shield"></span>
-      </div>
-      <p class="font-medium text-ink-gray-7 text-sm">No devices enrolled</p>
-      <p class="max-w-xs text-ink-gray-5 text-xs">
-        Sign-in needs only the admin password. Add a device to require a code from an
-        authenticator app as well.
-      </p>
-    </div>
+      icon="lucide-shield"
+      title="No devices enrolled"
+      description="Sign-in needs only the admin password. Add a device to require a code from an authenticator app as well."
+    />
 
     <ListView
       v-else
@@ -51,19 +44,27 @@
       <template #cell="{ column, row, item }">
         <span
           v-if="column.key === 'name'"
-          class="block min-w-0 max-w-full text-ink-gray-7 text-sm truncate"
+          class="block min-w-0 max-w-full text-ink-gray-7 text-base truncate"
           :title="row.name"
         >
           {{ row.name }}
         </span>
-        <span v-else-if="column.key === 'confirmed_at'" class="text-ink-gray-6 text-xs">
+        <span v-else-if="column.key === 'confirmed_at'" class="text-ink-gray-6 text-sm">
           {{ fmtTimestamp(row.confirmed_at) }}
         </span>
-        <span v-else-if="column.key === 'last_used_at'" class="text-ink-gray-6 text-xs">
+        <span v-else-if="column.key === 'last_used_at'" class="text-ink-gray-6 text-sm">
           {{ fmtTimestamp(row.last_used_at) }}
         </span>
         <div v-else-if="column.key === 'actions'" class="flex justify-end">
-          <Button variant="ghost" size="sm" theme="red" icon="lucide-trash-2" @click="promptRemove(row)" />
+          <Button
+            variant="ghost"
+            size="sm"
+            theme="red"
+            icon="lucide-trash-2"
+            label="Remove device"
+            tooltip="Remove device"
+            @click="promptRemove(row)"
+          />
         </div>
         <ListRowItem v-else :column="column" :row="row" :item="item" :align="column.align" />
       </template>
@@ -92,7 +93,7 @@
         />
 
         <template v-if="enrollment">
-          <p class="text-ink-gray-6 text-p-sm">
+          <p class="text-ink-gray-6 text-p-base">
             Scan with Authy, Bitwarden, Microsoft Authenticator or any TOTP app.
           </p>
           <div class="flex justify-center bg-surface-white p-4 rounded-lg">
@@ -100,7 +101,7 @@
           </div>
           <details class="group">
             <summary
-              class="flex items-center gap-1.5 text-ink-gray-6 text-sm cursor-pointer select-none"
+              class="flex items-center gap-1.5 text-ink-gray-6 text-base cursor-pointer select-none"
             >
               <span
                 class="size-4 transition-transform group-open:rotate-90 lucide-chevron-right"
@@ -108,8 +109,8 @@
               Can't scan? Enter the key by hand
             </summary>
             <div class="bg-surface-gray-2 mt-2 p-3 rounded-lg">
-              <p class="font-mono text-ink-gray-8 text-sm break-all">{{ enrollment.secret }}</p>
-              <button class="mt-1 text-ink-blue-3 text-xs" @click="copy(enrollment.secret)">
+              <p class="font-mono text-ink-gray-8 text-base break-all">{{ enrollment.secret }}</p>
+              <button class="mt-1 text-ink-blue-3 text-sm" @click="copy(enrollment.secret)">
                 Copy key
               </button>
             </div>
@@ -138,7 +139,7 @@
 
   <Dialog v-model="showCodes" :options="{ title: 'Save your recovery codes', size: 'md' }">
     <template #body-content>
-      <p class="text-ink-gray-7 text-p-sm">
+      <p class="text-ink-gray-7 text-p-base">
         These are shown once. Store them somewhere safe — each one signs you in when no device
         is available, and works only once.
       </p>
@@ -146,7 +147,7 @@
         <span
           v-for="code in codes"
           :key="code"
-          class="font-mono text-ink-gray-8 text-xs text-center"
+          class="font-mono text-ink-gray-8 text-sm text-center"
         >
           {{ code }}
         </span>
@@ -162,7 +163,7 @@
 
   <Dialog v-model="showRemove" :options="{ title: 'Remove device', size: 'md' }">
     <template #body-content>
-      <p class="text-ink-gray-7 text-p-sm">
+      <p class="text-ink-gray-7 text-p-base">
         Remove <strong>{{ removing?.name }}</strong
         >? Its codes stop working. Removing the last device turns two-factor off.
       </p>
@@ -176,7 +177,7 @@
 
   <Dialog v-model="showRegenerate" :options="{ title: 'Regenerate recovery codes', size: 'md' }">
     <template #body-content>
-      <p class="text-ink-gray-7 text-p-sm">
+      <p class="text-ink-gray-7 text-p-base">
         This replaces all existing codes, including unused ones. Anything you saved earlier stops
         working.
       </p>
@@ -193,6 +194,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { Button, Dialog, ErrorMessage, FormControl, ListRowItem, ListView, Spinner, toast } from 'frappe-ui'
 import QrcodeVue from 'qrcode.vue'
+import EmptyState from '@/components/common/EmptyState.vue'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
 import { twoFactorApi } from '@/api/twoFactor'
 import { fmtDateTime } from '@/utils/taskFormat'

--- a/admin/frontend/dashboard/src/components/settings/TwoFactor.vue
+++ b/admin/frontend/dashboard/src/components/settings/TwoFactor.vue
@@ -28,6 +28,7 @@
     </div>
 
     <EmptyState
+      compact
       v-if="!devices.length"
       icon="lucide-shield"
       title="No devices enrolled"

--- a/admin/frontend/dashboard/src/components/settings/TwoFactor.vue
+++ b/admin/frontend/dashboard/src/components/settings/TwoFactor.vue
@@ -72,12 +72,16 @@
     </ListView>
 
     <div v-if="status.enabled" class="pt-2 border-t border-outline-gray-1">
-      <SettingsRow
-        label="Recovery codes"
-        :description="`${status.recovery_codes_remaining} unused. Use one when no device is available.`"
-      >
-        <Button size="sm" variant="subtle" @click="showRegenerate = true">Regenerate</Button>
-      </SettingsRow>
+      <!-- -mx on the row alone: on the rule above it the border would overhang
+           the list it divides. -->
+      <div class="-mx-2.5">
+        <SettingsRow
+          label="Recovery codes"
+          :description="`${status.recovery_codes_remaining} unused. Use one when no device is available.`"
+        >
+          <Button size="sm" variant="subtle" @click="showRegenerate = true">Regenerate</Button>
+        </SettingsRow>
+      </div>
     </div>
   </div>
 

--- a/admin/frontend/dashboard/src/components/settings/Version.vue
+++ b/admin/frontend/dashboard/src/components/settings/Version.vue
@@ -6,28 +6,28 @@
 
   <Dialog v-model="dialogOpen" :options="{ title: 'Update', size: 'md' }">
     <div v-if="isDev" class="flex flex-col gap-3">
-      <p class="text-ink-gray-7 text-sm">
+      <p class="text-ink-gray-7 text-p-base">
         This is a development install. Update it from a terminal:
       </p>
-      <pre class="p-3 bg-surface-gray-2 rounded overflow-x-auto text-ink-gray-8 text-xs">git pull
+      <pre class="p-3 bg-surface-gray-2 rounded overflow-x-auto text-ink-gray-8 text-sm">git pull
 pilot admin build
 pilot admin upgrade</pre>
       <p class="text-ink-gray-5 text-p-sm">The last step restarts the admin service.</p>
     </div>
 
     <div v-else-if="updating" class="flex flex-col gap-3">
-      <p class="text-ink-gray-7 text-sm">Updating to {{ latestVersion }}…</p>
+      <p class="text-ink-gray-7 text-base">Updating to {{ latestVersion }}…</p>
       <div v-if="!log" class="flex justify-center items-center py-8">
         <Spinner size="lg" class="text-ink-gray-4" />
       </div>
       <pre
         v-else
-        class="p-3 bg-surface-gray-2 rounded max-h-64 overflow-auto text-ink-gray-7 text-xs whitespace-pre-wrap"
+        class="p-3 bg-surface-gray-2 rounded max-h-64 overflow-auto text-ink-gray-7 text-sm whitespace-pre-wrap"
       >{{ log }}</pre>
     </div>
 
     <div v-else-if="updateAvailable" class="flex flex-col gap-3">
-      <p class="text-ink-gray-7 text-sm">
+      <p class="text-ink-gray-7 text-p-base">
         Version <strong>{{ latestVersion }}</strong> is available. You are on
         {{ status.current_version || 'an unknown version' }}.
       </p>

--- a/admin/frontend/dashboard/src/components/settings/Waf.vue
+++ b/admin/frontend/dashboard/src/components/settings/Waf.vue
@@ -2,8 +2,12 @@
   <div v-if="loading" class="flex justify-center items-center h-40">
     <Spinner size="lg" class="text-ink-gray-4" />
   </div>
-  <div v-else class="space-y-6">
-    <div class="space-y-6">
+  <div v-else class="space-y-12">
+    <!-- Two groups - protection, then custom rules - carried by spacing
+         (space-y-12 between, space-y-4 within) rather than headings. The 3x
+         ratio against the in-group rhythm is what makes a seam read as a
+         section break rather than a wide row. -->
+    <div class="space-y-4">
       <SettingsSwitch
         label="Enable WAF"
         description="Inspects request contents for SQLi, XSS and path traversal, across all sites and the admin."
@@ -11,70 +15,44 @@
         @update:model-value="(v) => (enabled = v)"
       />
 
-      <Alert v-if="!production" title="Not enforced yet" theme="yellow" :dismissible="false">
-        <template #description>
-          <span class="text-ink-gray-6 text-p-sm"
-            >The WAF takes effect only in production (it's applied by nginx). This bench isn't
-            deployed, so nothing is enforced until you run
-            <span class="font-mono text-xs">pilot setup production</span>.</span
-          >
-        </template>
-      </Alert>
+      <!-- One inline line for the single most urgent deployment gap, replacing
+           two stacked Alert boxes. Only shown while the WAF is on - off, there
+           is nothing to enforce and nothing to warn about. -->
+      <p v-if="setupNote" class="flex items-start gap-1.5 text-ink-amber-7 text-p-sm">
+        <span class="shrink-0 mt-0.5 size-3.5 lucide-triangle-alert" />
+        <span>{{ setupNote }}</span>
+      </p>
 
-      <Alert
-        v-if="production && enabled && !installed"
-        title="ModSecurity not installed"
-        theme="yellow"
-        :dismissible="false"
-      >
-        <template #description>
-          <span class="text-ink-gray-6 text-p-sm"
-            >The ModSecurity module isn't installed on this host, so the WAF stays inactive even
-            when enabled. Redeploy production (<span class="font-mono text-xs"
-              >pilot setup production</span
-            >) to install it, then it takes effect.</span
-          >
-        </template>
-      </Alert>
-
-      <div>
-        <p class="font-medium text-ink-gray-8 text-base">Managed ruleset (OWASP CRS)</p>
-        <div class="gap-4 grid grid-cols-1 sm:grid-cols-2 mt-3">
+      <div class="items-start gap-4 grid grid-cols-1 sm:grid-cols-2">
+        <div class="space-y-1.5">
           <FormControl type="select" label="Action" :options="ACTION_OPTIONS" v-model="mode" />
-          <div class="space-y-1.5">
-            <FormControl
-              type="select"
-              label="Sensitivity"
-              :options="SENSITIVITY_OPTIONS"
-              v-model="paranoia"
-            />
-            <!-- The consequential knob on this page, and it used to be four bare
-                 words. Each step up trades false positives for coverage, which is
-                 the whole decision. -->
-            <p class="text-ink-gray-5 text-p-sm">{{ sensitivityHint }}</p>
-          </div>
-        </div>
-      </div>
-
-      <Alert
-        v-if="enabled && mode === 'DetectionOnly'"
-        title="Log only"
-        theme="yellow"
-        :dismissible="false"
-      >
-        <template #description>
-          <span class="text-ink-gray-6 text-p-sm"
-            >Matches (managed <b>and</b> custom rules) are <b>logged, not blocked</b>. Review
+          <!-- Each mode's consequence as a field hint, where the choice is made -
+               the Log-only case used to be a full Alert further down the page. -->
+          <p v-if="mode === 'DetectionOnly'" class="text-ink-gray-5 text-p-sm">
+            Matches are logged, not blocked. Review
             <RouterLink
-              class="underline underline-offset-2"
+              class="text-ink-gray-7 hover:text-ink-gray-8"
               :to="{ name: 'Analytics', query: { view: 'system', window: '1h' } }"
               >the WAF analytics</RouterLink
-            >, then switch Action to <b>Block</b> to enforce.</span
-          >
-        </template>
-      </Alert>
+            >, then switch to Block.
+          </p>
+          <p v-else class="text-ink-gray-5 text-p-sm">{{ ACTION_HINTS[mode] }}</p>
+        </div>
+        <div class="space-y-1.5">
+          <!-- Four fixed, ordered options: a segmented control shows the scale a
+               select was hiding. Label markup matches frappe-ui's InputLabel. -->
+          <span class="block text-ink-gray-5 text-base">Sensitivity</span>
+          <TabButtons :options="SENSITIVITY_OPTIONS" v-model="paranoia" />
+          <!-- Each step up trades false positives for coverage, which is the
+               whole decision. -->
+          <p class="text-ink-gray-5 text-p-sm">{{ sensitivityHint }}</p>
+        </div>
+      </div>
     </div>
 
+    <!-- Stays visible with the WAF off: staging rules first and flipping the
+         switch last is the safe rollout order, and rules save independently of
+         `enabled`. The switch and the absent setup note carry the off state. -->
     <WafCustomRules
       v-model="customRules"
       :fields="ruleFields"
@@ -83,11 +61,21 @@
     />
 
     <details class="group">
-      <summary class="flex items-center gap-1.5 text-ink-gray-6 text-base cursor-pointer select-none">
+      <!-- Chrome marks a *clicked* summary :focus-visible, so the tab-focus ring
+           was appearing on every pointer toggle - blur drops it for mouse users
+           while tabbing still shows the global ring. w-fit + rounded so that
+           ring hugs the word instead of drawing a panel-wide rectangle. -->
+      <summary
+        class="flex items-center gap-1.5 pr-1.5 rounded-sm w-fit text-ink-gray-6 text-base cursor-pointer select-none"
+        @click="(e) => e.currentTarget.blur()"
+      >
         <span
           class="size-4 transition-transform group-open:rotate-90 lucide-chevron-right"
         ></span>Advanced
       </summary>
+      <!-- Ordered tuning -> scope -> responses; the one thing that adds
+           inspection goes last. Examples live in hints, not placeholders -
+           a placeholder is gone at the first keystroke. -->
       <div class="space-y-4 mt-4">
         <div class="gap-4 grid grid-cols-1 sm:grid-cols-2 items-start">
           <div class="space-y-1.5">
@@ -97,20 +85,46 @@
               min="1"
               v-model="inboundThreshold"
             />
+            <p v-if="thresholdError" class="text-ink-red-6 text-p-sm">{{ thresholdError }}</p>
             <!-- These two knobs multiply, and nothing said so: Sensitivity sets
                  how much score a request accrues, this sets how much it takes to
                  act. High sensitivity with a low threshold blocks ordinary
                  traffic. -->
-            <p class="text-ink-gray-5 text-p-sm">
+            <p v-else class="text-ink-gray-5 text-p-sm">
               Score needed before Action applies. Sensitivity raises scores, so the two compound.
             </p>
           </div>
+          <div class="space-y-1.5">
+            <FormControl type="text" label="Max inspected body size" v-model="bodyLimit" />
+            <p class="text-ink-gray-5 text-p-sm">Number with a k, m or g suffix, e.g. 50m.</p>
+          </div>
+        </div>
+        <!-- Path-level scope before rule-level: plain English before SecLang.
+             Each hint names its level, since both fields read as "don't
+             inspect X" until you know the difference. -->
+        <div class="space-y-1.5">
           <FormControl
-            type="text"
-            label="Max inspected body size"
-            placeholder="50m"
-            v-model="bodyLimit"
+            type="textarea"
+            label="Exempt paths"
+            :rows="3"
+            placeholder="/api/method/frappe.ping"
+            v-model="exemptPathsText"
           />
+          <p class="text-ink-gray-5 text-p-sm">
+            One path prefix per line. Requests under these skip the WAF entirely.
+          </p>
+        </div>
+        <div class="space-y-1.5">
+          <FormControl
+            type="textarea"
+            label="Rule exclusions (SecLang)"
+            :rows="3"
+            placeholder="SecRuleRemoveById 942100"
+            v-model="exclusionsText"
+          />
+          <p class="text-ink-gray-5 text-p-sm">
+            One SecLang directive per line. Turns a managed rule off everywhere.
+          </p>
         </div>
         <SettingsSwitch
           label="Inspect responses"
@@ -118,27 +132,17 @@
           :model-value="inspectResponses"
           @update:model-value="(v) => (inspectResponses = v)"
         />
-        <FormControl
-          type="textarea"
-          label="Exclusions"
-          :rows="3"
-          v-model="exclusionsText"
-          placeholder="One SecLang rule per line, e.g. SecRuleRemoveById 942100"
-        />
-        <FormControl
-          type="textarea"
-          label="Exempt paths"
-          :rows="2"
-          v-model="exemptPathsText"
-          placeholder="One path prefix per line, e.g. /api/method/frappe.ping"
-        />
       </div>
     </details>
 
+    <!-- Server failures only - field problems show at their fields (threshold
+         hint, Incomplete badges) and disable the button instead. -->
     <ErrorMessage v-if="error" :message="error" />
 
-    <div class="flex justify-end">
-      <Button variant="solid" :loading="saving" :disabled="!dirty" @click="save">
+    <!-- Surfaces only once something changed: a permanently visible disabled
+         button is chrome with nothing to say. -->
+    <div v-if="dirty" class="flex justify-end">
+      <Button variant="solid" :loading="saving" :disabled="!canSave" @click="save">
         Save changes
       </Button>
     </div>
@@ -148,11 +152,11 @@
 <script setup>
 import { computed, ref, onMounted, onUnmounted } from 'vue'
 import { RouterLink } from 'vue-router'
-import { Alert, Button, ErrorMessage, FormControl, Spinner, toast } from 'frappe-ui'
+import { Button, ErrorMessage, FormControl, Spinner, TabButtons, toast } from 'frappe-ui'
 import SettingsSwitch from '@/components/settings/SettingsSwitch.vue'
 import WafCustomRules from '@/components/settings/WafCustomRules.vue'
 import { settingsApi } from '@/api/settings'
-import { ruleLabel, ruleProblem } from '@/utils/wafRules'
+import { ruleProblem } from '@/utils/wafRules'
 import { useUnsavedChanges } from '@/composables/common/useUnsavedChanges'
 
 // "Paused", not "Off": this and the Enable switch both read as off but do
@@ -179,6 +183,11 @@ const SENSITIVITY_HINTS = {
   3: 'Expect to add exclusions.',
   4: 'Most coverage, most false positives.',
 }
+// DetectionOnly's hint lives in the template - it carries a link.
+const ACTION_HINTS = {
+  Off: 'Loaded but idle. Nothing is inspected.',
+  On: 'Matching requests are rejected.',
+}
 
 const loading = ref(true)
 const saving = ref(false)
@@ -200,6 +209,17 @@ const ruleOperators = ref([])
 const ruleActions = ref([])
 
 const sensitivityHint = computed(() => SENSITIVITY_HINTS[Number(paranoia.value)] || '')
+
+// The single most urgent deployment gap, or nothing. `installed` only means
+// anything in production, so these can't both apply at once.
+const setupNote = computed(() => {
+  if (!enabled.value) return ''
+  if (!production.value)
+    return "Enforced in production only. This bench isn't deployed - run pilot setup production first."
+  if (!installed.value)
+    return 'ModSecurity is not installed on this host. Redeploy production to install it.'
+  return ''
+})
 
 function linesToArray(text) {
   return text
@@ -246,26 +266,21 @@ function warnIfDirty(event) {
 onMounted(() => window.addEventListener('beforeunload', warnIfDirty))
 onUnmounted(() => window.removeEventListener('beforeunload', warnIfDirty))
 
-function validateRules() {
-  for (const [index, rule] of customRules.value.entries()) {
-    const problem = ruleProblem(rule)
-    if (problem) return `${ruleLabel(rule, index)} ${problem}.`
-  }
-  return ''
-}
-
-function validate() {
+// A wrong fill gets a red hint at the field; an empty required field or an
+// incomplete rule (already badged on its card) just holds the button.
+const thresholdError = computed(() => {
   const threshold = Number(inboundThreshold.value)
-  if (!Number.isInteger(threshold) || threshold < 1)
-    return 'Anomaly threshold must be a positive whole number.'
-  if (!bodyLimit.value.trim()) return 'Max inspected body size is required (e.g. 50m).'
-  return validateRules()
-}
+  if (Number.isInteger(threshold) && threshold >= 1) return ''
+  return 'Must be a positive whole number.'
+})
+const canSave = computed(
+  () =>
+    !thresholdError.value &&
+    Boolean(bodyLimit.value.trim()) &&
+    !customRules.value.some((rule) => ruleProblem(rule)),
+)
 
 async function save() {
-  error.value = validate()
-  if (error.value) return
-
   saving.value = true
   try {
     const payload = buildPayload()
@@ -292,7 +307,9 @@ onMounted(async () => {
     enabled.value = !!waf.enabled
     installed.value = !!waf.installed
     mode.value = waf.mode || 'DetectionOnly'
-    paranoia.value = waf.paranoia || 1
+    // Cast: TabButtons matches by Object.is, so a stringy "2" would silently
+    // fall back to Low and emit a change - making the form dirty on open.
+    paranoia.value = Number(waf.paranoia) || 1
     inboundThreshold.value = waf.inbound_threshold ?? 5
     bodyLimit.value = waf.body_limit || '50m'
     inspectResponses.value = !!waf.inspect_responses

--- a/admin/frontend/dashboard/src/components/settings/Waf.vue
+++ b/admin/frontend/dashboard/src/components/settings/Waf.vue
@@ -3,10 +3,6 @@
     <Spinner size="lg" class="text-ink-gray-4" />
   </div>
   <div v-else class="space-y-12">
-    <!-- Two groups - protection, then custom rules - carried by spacing
-         (space-y-12 between, space-y-4 within) rather than headings. The 3x
-         ratio against the in-group rhythm is what makes a seam read as a
-         section break rather than a wide row. -->
     <div class="space-y-4">
       <SettingsSwitch
         label="Enable WAF"
@@ -15,9 +11,6 @@
         @update:model-value="(v) => (enabled = v)"
       />
 
-      <!-- One inline line for the single most urgent deployment gap, replacing
-           two stacked Alert boxes. Only shown while the WAF is on - off, there
-           is nothing to enforce and nothing to warn about. -->
       <p v-if="setupNote" class="flex items-start gap-1.5 text-ink-amber-7 text-p-sm">
         <span class="shrink-0 mt-0.5 size-3.5 lucide-triangle-alert" />
         <span>{{ setupNote }}</span>
@@ -26,8 +19,6 @@
       <div class="items-start gap-4 grid grid-cols-1 sm:grid-cols-2">
         <div class="space-y-1.5">
           <FormControl type="select" label="Action" :options="ACTION_OPTIONS" v-model="mode" />
-          <!-- Each mode's consequence as a field hint, where the choice is made -
-               the Log-only case used to be a full Alert further down the page. -->
           <p v-if="mode === 'DetectionOnly'" class="text-ink-gray-5 text-p-sm">
             Matches are logged, not blocked. Review
             <RouterLink
@@ -39,20 +30,16 @@
           <p v-else class="text-ink-gray-5 text-p-sm">{{ ACTION_HINTS[mode] }}</p>
         </div>
         <div class="space-y-1.5">
-          <!-- Four fixed, ordered options: a segmented control shows the scale a
-               select was hiding. Label markup matches frappe-ui's InputLabel. -->
+          <!-- Label markup matches frappe-ui's InputLabel. -->
           <span class="block text-ink-gray-5 text-base">Sensitivity</span>
           <TabButtons :options="SENSITIVITY_OPTIONS" v-model="paranoia" />
-          <!-- Each step up trades false positives for coverage, which is the
-               whole decision. -->
           <p class="text-ink-gray-5 text-p-sm">{{ sensitivityHint }}</p>
         </div>
       </div>
     </div>
 
-    <!-- Stays visible with the WAF off: staging rules first and flipping the
-         switch last is the safe rollout order, and rules save independently of
-         `enabled`. The switch and the absent setup note carry the off state. -->
+    <!-- Visible with the WAF off: rules are staged first and save independently
+         of `enabled`. -->
     <WafCustomRules
       v-model="customRules"
       :fields="ruleFields"
@@ -61,10 +48,8 @@
     />
 
     <details class="group">
-      <!-- Chrome marks a *clicked* summary :focus-visible, so the tab-focus ring
-           was appearing on every pointer toggle - blur drops it for mouse users
-           while tabbing still shows the global ring. w-fit + rounded so that
-           ring hugs the word instead of drawing a panel-wide rectangle. -->
+      <!-- Chrome marks a clicked summary :focus-visible; blur keeps the focus
+           ring for keyboard only. w-fit so the ring hugs the word. -->
       <summary
         class="flex items-center gap-1.5 pr-1.5 rounded-sm w-fit text-ink-gray-6 text-base cursor-pointer select-none"
         @click="(e) => e.currentTarget.blur()"
@@ -73,9 +58,6 @@
           class="size-4 transition-transform group-open:rotate-90 lucide-chevron-right"
         ></span>Advanced
       </summary>
-      <!-- Ordered tuning -> scope -> responses; the one thing that adds
-           inspection goes last. Examples live in hints, not placeholders -
-           a placeholder is gone at the first keystroke. -->
       <div class="space-y-4 mt-4">
         <div class="gap-4 grid grid-cols-1 sm:grid-cols-2 items-start">
           <div class="space-y-1.5">
@@ -86,10 +68,6 @@
               v-model="inboundThreshold"
             />
             <p v-if="thresholdError" class="text-ink-red-6 text-p-sm">{{ thresholdError }}</p>
-            <!-- These two knobs multiply, and nothing said so: Sensitivity sets
-                 how much score a request accrues, this sets how much it takes to
-                 act. High sensitivity with a low threshold blocks ordinary
-                 traffic. -->
             <p v-else class="text-ink-gray-5 text-p-sm">
               Score needed before Action applies. Sensitivity raises scores, so the two compound.
             </p>
@@ -99,9 +77,6 @@
             <p class="text-ink-gray-5 text-p-sm">Number with a k, m or g suffix, e.g. 50m.</p>
           </div>
         </div>
-        <!-- Path-level scope before rule-level: plain English before SecLang.
-             Each hint names its level, since both fields read as "don't
-             inspect X" until you know the difference. -->
         <div class="space-y-1.5">
           <FormControl
             type="textarea"
@@ -135,12 +110,8 @@
       </div>
     </details>
 
-    <!-- Server failures only - field problems show at their fields (threshold
-         hint, Incomplete badges) and disable the button instead. -->
     <ErrorMessage v-if="error" :message="error" />
 
-    <!-- Surfaces only once something changed: a permanently visible disabled
-         button is chrome with nothing to say. -->
     <div v-if="dirty" class="flex justify-end">
       <Button variant="solid" :loading="saving" :disabled="!canSave" @click="save">
         Save changes
@@ -159,11 +130,8 @@ import { settingsApi } from '@/api/settings'
 import { ruleProblem } from '@/utils/wafRules'
 import { useUnsavedChanges } from '@/composables/common/useUnsavedChanges'
 
-// "Paused", not "Off": this and the Enable switch both read as off but do
-// different things. The switch drops the module from the server config and
-// coming back costs a rebuild; this leaves it loaded with the engine idle, which
-// is the state you want when checking whether the WAF is behind a broken site.
-// The stored value stays "Off" - only the word the user reads changes.
+// "Paused" leaves the module loaded and idle; the Enable switch drops it from
+// the server config. The stored value stays "Off" - only the label differs.
 const ACTION_OPTIONS = [
   { label: 'Paused', value: 'Off' },
   { label: 'Log only', value: 'DetectionOnly' },
@@ -175,8 +143,7 @@ const SENSITIVITY_OPTIONS = [
   { label: 'High', value: 3 },
   { label: 'Very High', value: 4 },
 ]
-// CRS paranoia levels. Every step up widens coverage and widens false positives
-// with it - the tradeoff is the whole decision, so it is stated per level.
+// CRS paranoia levels.
 const SENSITIVITY_HINTS = {
   1: 'Very few false positives. Start here.',
   2: 'Admin tooling may start tripping it.',
@@ -210,8 +177,7 @@ const ruleActions = ref([])
 
 const sensitivityHint = computed(() => SENSITIVITY_HINTS[Number(paranoia.value)] || '')
 
-// The single most urgent deployment gap, or nothing. `installed` only means
-// anything in production, so these can't both apply at once.
+// `installed` only means anything in production, so at most one applies.
 const setupNote = computed(() => {
   if (!enabled.value) return ''
   if (!production.value)
@@ -242,22 +208,13 @@ function buildPayload() {
   }
 }
 
-// Compared against what the server last gave us, so Save is dead until something
-// actually changed - and so leaving with unsaved rules is something we can warn
-// about rather than discard silently.
 const savedPayload = ref('')
 const dirty = computed(() => JSON.stringify(buildPayload()) !== savedPayload.value)
 
-// Both of these read `dirty`, so they have to be declared after it - a const is
-// in its temporal dead zone until then, and useUnsavedChanges() evaluates its
-// argument straight away.
-//
-// A half-built ruleset is real work. The Settings shell asks this before it
-// swaps the panel out: moving between panels is a route param change on the one
-// Settings record, so a component-level route guard here would never see it.
+// After `dirty`: useUnsavedChanges evaluates its argument immediately, and a
+// route-level guard never fires for the shell's param-only navigation.
 useUnsavedChanges(dirty)
 
-// Leaving the tab entirely is the browser's to warn about, not the shell's.
 function warnIfDirty(event) {
   if (!dirty.value) return
   event.preventDefault()
@@ -266,8 +223,6 @@ function warnIfDirty(event) {
 onMounted(() => window.addEventListener('beforeunload', warnIfDirty))
 onUnmounted(() => window.removeEventListener('beforeunload', warnIfDirty))
 
-// A wrong fill gets a red hint at the field; an empty required field or an
-// incomplete rule (already badged on its card) just holds the button.
 const thresholdError = computed(() => {
   const threshold = Number(inboundThreshold.value)
   if (Number.isInteger(threshold) && threshold >= 1) return ''
@@ -307,8 +262,7 @@ onMounted(async () => {
     enabled.value = !!waf.enabled
     installed.value = !!waf.installed
     mode.value = waf.mode || 'DetectionOnly'
-    // Cast: TabButtons matches by Object.is, so a stringy "2" would silently
-    // fall back to Low and emit a change - making the form dirty on open.
+    // TabButtons matches by Object.is; a stringy "2" would fall back to Low.
     paranoia.value = Number(waf.paranoia) || 1
     inboundThreshold.value = waf.inbound_threshold ?? 5
     bodyLimit.value = waf.body_limit || '50m'
@@ -319,9 +273,7 @@ onMounted(async () => {
     ruleFields.value = waf.rule_fields || []
     ruleOperators.value = waf.rule_operators || []
     ruleActions.value = waf.rule_actions || []
-    // The baseline `dirty` measures against. Built from the same function as the
-    // save payload so a normalisation (trimmed body limit, blank lines dropped
-    // from the textareas) does not read as an edit the moment the page loads.
+    // Same builder as the save payload, so normalisation is not an edit.
     savedPayload.value = JSON.stringify(buildPayload())
   } catch (e) {
     error.value = e.message || 'Could not load settings.'

--- a/admin/frontend/dashboard/src/components/settings/Waf.vue
+++ b/admin/frontend/dashboard/src/components/settings/Waf.vue
@@ -5,11 +5,23 @@
   <div v-else class="space-y-12">
     <div class="space-y-4">
       <SettingsSwitch
-        label="Enable WAF"
+        label="Enable web application firewall"
         description="Inspects request contents for SQLi, XSS and path traversal, across all sites and the admin."
         :model-value="enabled"
         @update:model-value="(v) => (enabled = v)"
       />
+
+      <p class="text-ink-gray-5 text-p-sm">
+        Runs ModSecurity with the OWASP Core Rule Set.
+        <a
+          href="https://coreruleset.org/docs/"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-ink-gray-7 hover:text-ink-gray-8"
+        >
+          Read what the rules cover
+        </a>
+      </p>
 
       <p v-if="setupNote" class="flex items-start gap-1.5 text-ink-amber-7 text-p-sm">
         <span class="shrink-0 mt-0.5 size-3.5 lucide-triangle-alert" />
@@ -24,7 +36,7 @@
             <RouterLink
               class="text-ink-gray-7 hover:text-ink-gray-8"
               :to="{ name: 'Analytics', query: { view: 'system', window: '1h' } }"
-              >the WAF analytics</RouterLink
+              >the firewall analytics</RouterLink
             >, then switch to Block.
           </p>
           <p v-else class="text-ink-gray-5 text-p-sm">{{ ACTION_HINTS[mode] }}</p>
@@ -86,7 +98,7 @@
             v-model="exemptPathsText"
           />
           <p class="text-ink-gray-5 text-p-sm">
-            One path prefix per line. Requests under these skip the WAF entirely.
+            One path prefix per line. Requests under these skip the firewall entirely.
           </p>
         </div>
         <div class="space-y-1.5">
@@ -245,7 +257,7 @@ async function save() {
       return
     }
     savedPayload.value = JSON.stringify(payload)
-    toast.success('WAF updated')
+    toast.success('Web application firewall updated')
     if (result.nginx_error) toast.error(result.nginx_error)
   } catch (e) {
     error.value = e.message || 'Failed to save.'

--- a/admin/frontend/dashboard/src/components/settings/Waf.vue
+++ b/admin/frontend/dashboard/src/components/settings/Waf.vue
@@ -11,18 +11,6 @@
         @update:model-value="(v) => (enabled = v)"
       />
 
-      <p class="text-ink-gray-5 text-p-sm">
-        Runs ModSecurity with the OWASP Core Rule Set.
-        <a
-          href="https://coreruleset.org/docs/"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="text-ink-gray-7 hover:text-ink-gray-8"
-        >
-          Read what the rules cover
-        </a>
-      </p>
-
       <p v-if="setupNote" class="flex items-start gap-1.5 text-ink-amber-7 text-p-sm">
         <span class="shrink-0 mt-0.5 size-3.5 lucide-triangle-alert" />
         <span>{{ setupNote }}</span>

--- a/admin/frontend/dashboard/src/components/settings/Waf.vue
+++ b/admin/frontend/dashboard/src/components/settings/Waf.vue
@@ -4,9 +4,9 @@
   </div>
   <div v-else class="space-y-6">
     <div class="space-y-6">
-      <Switch
+      <SettingsSwitch
         label="Enable WAF"
-        description="ModSecurity + OWASP Core Rule Set inspects request contents (SQLi, XSS, path traversal) for all sites and the admin."
+        description="Inspects request contents for SQLi, XSS and path traversal, across all sites and the admin."
         :model-value="enabled"
         @update:model-value="(v) => (enabled = v)"
       />
@@ -38,17 +38,21 @@
       </Alert>
 
       <div>
-        <p class="mb-3 font-medium text-ink-gray-8 text-base leading-normal">
-          Managed ruleset (OWASP CRS)
-        </p>
-        <div class="gap-4 grid grid-cols-2">
+        <p class="font-medium text-ink-gray-8 text-base">Managed ruleset (OWASP CRS)</p>
+        <div class="gap-4 grid grid-cols-1 sm:grid-cols-2 mt-3">
           <FormControl type="select" label="Action" :options="ACTION_OPTIONS" v-model="mode" />
-          <FormControl
-            type="select"
-            label="Sensitivity"
-            :options="SENSITIVITY_OPTIONS"
-            v-model="paranoia"
-          />
+          <div class="space-y-1.5">
+            <FormControl
+              type="select"
+              label="Sensitivity"
+              :options="SENSITIVITY_OPTIONS"
+              v-model="paranoia"
+            />
+            <!-- The consequential knob on this page, and it used to be four bare
+                 words. Each step up trades false positives for coverage, which is
+                 the whole decision. -->
+            <p class="text-ink-gray-5 text-p-sm">{{ sensitivityHint }}</p>
+          </div>
         </div>
       </div>
 
@@ -60,8 +64,12 @@
       >
         <template #description>
           <span class="text-ink-gray-6 text-p-sm"
-            >Matches (managed <b>and</b> custom rules) are <b>logged, not blocked</b>. Review the
-            WAF analytics, then switch Action to <b>Block</b> to enforce.</span
+            >Matches (managed <b>and</b> custom rules) are <b>logged, not blocked</b>. Review
+            <RouterLink
+              class="underline underline-offset-2"
+              :to="{ name: 'Analytics', query: { view: 'system', window: '1h' } }"
+              >the WAF analytics</RouterLink
+            >, then switch Action to <b>Block</b> to enforce.</span
           >
         </template>
       </Alert>
@@ -75,14 +83,28 @@
     />
 
     <details class="group">
-      <summary class="flex items-center gap-1.5 text-ink-gray-6 text-sm cursor-pointer select-none">
+      <summary class="flex items-center gap-1.5 text-ink-gray-6 text-base cursor-pointer select-none">
         <span
           class="size-4 transition-transform group-open:rotate-90 lucide-chevron-right"
         ></span>Advanced
       </summary>
       <div class="space-y-4 mt-4">
-        <div class="gap-4 grid grid-cols-2 items-start">
-          <FormControl type="number" label="Anomaly threshold" min="1" v-model="inboundThreshold" />
+        <div class="gap-4 grid grid-cols-1 sm:grid-cols-2 items-start">
+          <div class="space-y-1.5">
+            <FormControl
+              type="number"
+              label="Anomaly threshold"
+              min="1"
+              v-model="inboundThreshold"
+            />
+            <!-- These two knobs multiply, and nothing said so: Sensitivity sets
+                 how much score a request accrues, this sets how much it takes to
+                 act. High sensitivity with a low threshold blocks ordinary
+                 traffic. -->
+            <p class="text-ink-gray-5 text-p-sm">
+              Score needed before Action applies. Sensitivity raises scores, so the two compound.
+            </p>
+          </div>
           <FormControl
             type="text"
             label="Max inspected body size"
@@ -90,7 +112,7 @@
             v-model="bodyLimit"
           />
         </div>
-        <Switch
+        <SettingsSwitch
           label="Inspect responses"
           description="Scan outbound responses for leaks. Adds latency."
           :model-value="inspectResponses"
@@ -116,19 +138,30 @@
     <ErrorMessage v-if="error" :message="error" />
 
     <div class="flex justify-end">
-      <Button variant="solid" :loading="saving" @click="save">Save changes</Button>
+      <Button variant="solid" :loading="saving" :disabled="!dirty" @click="save">
+        Save changes
+      </Button>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, onMounted } from 'vue'
-import { Alert, Button, ErrorMessage, FormControl, Spinner, Switch, toast } from 'frappe-ui'
+import { computed, ref, onMounted, onUnmounted } from 'vue'
+import { RouterLink } from 'vue-router'
+import { Alert, Button, ErrorMessage, FormControl, Spinner, toast } from 'frappe-ui'
+import SettingsSwitch from '@/components/settings/SettingsSwitch.vue'
 import WafCustomRules from '@/components/settings/WafCustomRules.vue'
 import { settingsApi } from '@/api/settings'
+import { ruleLabel, ruleProblem } from '@/utils/wafRules'
+import { useUnsavedChanges } from '@/composables/common/useUnsavedChanges'
 
+// "Paused", not "Off": this and the Enable switch both read as off but do
+// different things. The switch drops the module from the server config and
+// coming back costs a rebuild; this leaves it loaded with the engine idle, which
+// is the state you want when checking whether the WAF is behind a broken site.
+// The stored value stays "Off" - only the word the user reads changes.
 const ACTION_OPTIONS = [
-  { label: 'Off', value: 'Off' },
+  { label: 'Paused', value: 'Off' },
   { label: 'Log only', value: 'DetectionOnly' },
   { label: 'Block', value: 'On' },
 ]
@@ -138,6 +171,14 @@ const SENSITIVITY_OPTIONS = [
   { label: 'High', value: 3 },
   { label: 'Very High', value: 4 },
 ]
+// CRS paranoia levels. Every step up widens coverage and widens false positives
+// with it - the tradeoff is the whole decision, so it is stated per level.
+const SENSITIVITY_HINTS = {
+  1: 'Very few false positives. Start here.',
+  2: 'Admin tooling may start tripping it.',
+  3: 'Expect to add exclusions.',
+  4: 'Most coverage, most false positives.',
+}
 
 const loading = ref(true)
 const saving = ref(false)
@@ -158,6 +199,8 @@ const ruleFields = ref([])
 const ruleOperators = ref([])
 const ruleActions = ref([])
 
+const sensitivityHint = computed(() => SENSITIVITY_HINTS[Number(paranoia.value)] || '')
+
 function linesToArray(text) {
   return text
     .split('\n')
@@ -165,12 +208,58 @@ function linesToArray(text) {
     .filter(Boolean)
 }
 
+function buildPayload() {
+  return {
+    enabled: enabled.value,
+    mode: mode.value,
+    paranoia: Number(paranoia.value),
+    inbound_threshold: Number(inboundThreshold.value),
+    body_limit: bodyLimit.value.trim(),
+    inspect_responses: inspectResponses.value,
+    exclusions: linesToArray(exclusionsText.value),
+    exempt_paths: linesToArray(exemptPathsText.value),
+    custom_rules: customRules.value,
+  }
+}
+
+// Compared against what the server last gave us, so Save is dead until something
+// actually changed - and so leaving with unsaved rules is something we can warn
+// about rather than discard silently.
+const savedPayload = ref('')
+const dirty = computed(() => JSON.stringify(buildPayload()) !== savedPayload.value)
+
+// Both of these read `dirty`, so they have to be declared after it - a const is
+// in its temporal dead zone until then, and useUnsavedChanges() evaluates its
+// argument straight away.
+//
+// A half-built ruleset is real work. The Settings shell asks this before it
+// swaps the panel out: moving between panels is a route param change on the one
+// Settings record, so a component-level route guard here would never see it.
+useUnsavedChanges(dirty)
+
+// Leaving the tab entirely is the browser's to warn about, not the shell's.
+function warnIfDirty(event) {
+  if (!dirty.value) return
+  event.preventDefault()
+  event.returnValue = ''
+}
+onMounted(() => window.addEventListener('beforeunload', warnIfDirty))
+onUnmounted(() => window.removeEventListener('beforeunload', warnIfDirty))
+
+function validateRules() {
+  for (const [index, rule] of customRules.value.entries()) {
+    const problem = ruleProblem(rule)
+    if (problem) return `${ruleLabel(rule, index)} ${problem}.`
+  }
+  return ''
+}
+
 function validate() {
   const threshold = Number(inboundThreshold.value)
   if (!Number.isInteger(threshold) || threshold < 1)
     return 'Anomaly threshold must be a positive whole number.'
   if (!bodyLimit.value.trim()) return 'Max inspected body size is required (e.g. 50m).'
-  return ''
+  return validateRules()
 }
 
 async function save() {
@@ -179,22 +268,13 @@ async function save() {
 
   saving.value = true
   try {
-    const payload = {
-      enabled: enabled.value,
-      mode: mode.value,
-      paranoia: Number(paranoia.value),
-      inbound_threshold: Number(inboundThreshold.value),
-      body_limit: bodyLimit.value.trim(),
-      inspect_responses: inspectResponses.value,
-      exclusions: linesToArray(exclusionsText.value),
-      exempt_paths: linesToArray(exemptPathsText.value),
-      custom_rules: customRules.value,
-    }
+    const payload = buildPayload()
     const result = await settingsApi.update({ waf: payload })
     if (!result.ok) {
       error.value = result.error || 'Failed to save.'
       return
     }
+    savedPayload.value = JSON.stringify(payload)
     toast.success('WAF updated')
     if (result.nginx_error) toast.error(result.nginx_error)
   } catch (e) {
@@ -222,6 +302,10 @@ onMounted(async () => {
     ruleFields.value = waf.rule_fields || []
     ruleOperators.value = waf.rule_operators || []
     ruleActions.value = waf.rule_actions || []
+    // The baseline `dirty` measures against. Built from the same function as the
+    // save payload so a normalisation (trimmed body limit, blank lines dropped
+    // from the textareas) does not read as an edit the moment the page loads.
+    savedPayload.value = JSON.stringify(buildPayload())
   } catch (e) {
     error.value = e.message || 'Could not load settings.'
   } finally {

--- a/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
+++ b/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
@@ -1,81 +1,207 @@
 <template>
-  <div class="space-y-4">
-    <div class="flex justify-between items-center">
-      <div>
-        <p class="font-medium text-ink-gray-8 text-base leading-normal">Custom rules</p>
-        <p class="text-ink-gray-5 text-xs">
-          Match requests and block, log, or skip the WAF. Evaluated before the managed rules, top to
-          bottom.
+  <div class="space-y-3" ref="root">
+    <div class="flex justify-between items-start gap-4">
+      <div class="min-w-0">
+        <p class="font-medium text-ink-gray-8 text-base">Custom rules</p>
+        <!-- max-w here and shrink-0 on the button: with neither, this paragraph
+             ran to the button's exact left edge and wrapped into it. -->
+        <p class="mt-0.5 max-w-md text-ink-gray-5 text-p-sm">
+          Checked before the managed rules, top to bottom.
         </p>
       </div>
-      <Button variant="subtle" icon-left="plus" @click="addRule">Add rule</Button>
+      <!-- Stays live while a rule is unfinished, and points at the offender
+           instead: a disabled button with no target leaves you hunting for which
+           card it meant. -->
+      <Button class="shrink-0" variant="subtle" icon-left="lucide-plus" @click="addRule">
+        Add rule
+      </Button>
     </div>
 
-    <div
+    <EmptyState
       v-if="!rules.length"
-      class="flex flex-col items-center gap-2.5 py-10 border border-dashed rounded-lg border-outline-gray-2 text-center"
-    >
-      <div class="flex justify-center items-center bg-surface-gray-2 rounded-full size-11">
-        <span class="size-5 text-ink-gray-5 lucide-list-filter"></span>
-      </div>
-      <p class="font-medium text-ink-gray-7 text-sm">No custom rules</p>
-      <p class="max-w-xs text-ink-gray-5 text-xs">
-        Add a rule to block or log requests by path, IP, method, header, and more.
-      </p>
-    </div>
+      icon="lucide-list-filter"
+      title="No custom rules"
+      description="Add a rule to block or log requests by path, IP, method, header, and more."
+    />
 
+    <!-- Two durations, not one: the flag has to arrive fast enough to read as a
+         response to the click, and leave slowly enough to be watched rather than
+         blink. Same class toggle, different transition on each side. -->
     <div
       v-for="(rule, ri) in rules"
-      :key="ri"
-      class="space-y-3 bg-surface-gray-1 p-4 border rounded-lg border-outline-gray-2"
+      :key="keyOf(rule)"
+      :data-rule-key="keyOf(rule)"
+      class="bg-surface-elevation-1 border rounded-lg transition-colors"
+      :class="
+        flaggedKey === keyOf(rule)
+          ? 'border-outline-red-3 duration-75'
+          : 'border-outline-gray-2 duration-1000'
+      "
     >
-      <div class="flex items-center gap-2">
-        <TextInput v-model="rule.name" placeholder="Rule name" class="flex-1" />
-        <Switch :model-value="rule.enabled" @update:model-value="(v) => (rule.enabled = v)" />
-        <Button variant="ghost" icon="lucide-trash-2" @click="removeRule(ri)" />
-      </div>
-
-      <div class="flex flex-wrap items-center gap-2 text-ink-gray-7 text-sm">
-        <span>When</span>
-        <Select v-model="rule.match" :options="MATCH_OPTIONS" class="w-24" />
-        <span>of the following match:</span>
-      </div>
-
-      <div
-        v-for="(cond, ci) in rule.conditions"
-        :key="ci"
-        class="flex flex-wrap items-center gap-2"
-      >
-        <Select v-model="cond.field" :options="fieldOptions" class="w-40" />
-        <TextInput
-          v-if="cond.field === 'header'"
-          v-model="cond.header_name"
-          placeholder="Header name"
-          class="w-36"
+      <!-- Summary: what the rule is, always visible. The builder below is the
+           editor for it, which is why it collapses and this does not. -->
+      <div class="flex items-start gap-3 p-3">
+        <!-- Labelled, then the label is hidden: a bare Switch has no accessible
+             name at all (attrs land on the wrapper, not the control), while
+             `label` gives the real <label for> association. sr-only keeps it out
+             of a header row that has no space for the word, and the gap override
+             stops the hidden node from reserving one. -->
+        <Switch
+          class="shrink-0 mt-0.5 [&_[data-slot='label']]:sr-only [&>div]:!gap-x-0 [&>div]:!py-0"
+          label="Rule enabled"
+          :model-value="rule.enabled"
+          @update:model-value="(v) => (rule.enabled = v)"
         />
-        <Select v-model="cond.operator" :options="operatorOptions" class="w-44" />
-        <TextInput
-          v-model="cond.value"
-          :placeholder="placeholder(cond.field)"
-          class="flex-1 min-w-40"
+        <button
+          type="button"
+          class="flex-1 min-w-0 text-left"
+          :aria-expanded="isOpen(rule)"
+          @click="toggleOpen(rule)"
+        >
+          <p
+            class="font-medium text-base truncate"
+            :class="rule.enabled ? 'text-ink-gray-8' : 'text-ink-gray-5'"
+          >
+            {{ rule.name || 'Untitled rule' }}
+          </p>
+          <!-- The rule in plain English, promoted out of the card's footer. It
+               was the smallest, faintest line on the card while being the one
+               you actually read when auditing a list of them. -->
+          <p class="mt-0.5 text-ink-gray-6 text-p-sm">{{ preview(rule) }}</p>
+        </button>
+        <Button
+          class="shrink-0"
+          variant="ghost"
+          icon="lucide-chevron-down"
+          :label="isOpen(rule) ? 'Collapse rule' : 'Edit rule'"
+          :tooltip="isOpen(rule) ? 'Collapse' : 'Edit'"
+          :class="isOpen(rule) ? 'rotate-180' : ''"
+          @click="toggleOpen(rule)"
         />
-        <Button variant="ghost" icon="lucide-x" @click="removeCondition(rule, ci)" />
+        <Button
+          class="shrink-0"
+          variant="ghost"
+          theme="red"
+          icon="lucide-trash-2"
+          label="Delete rule"
+          tooltip="Delete rule"
+          @click="promptRemove(ri)"
+        />
       </div>
-      <Button variant="ghost" icon-left="plus" @click="addCondition(rule)">Add condition</Button>
 
-      <div class="flex items-center gap-2 text-ink-gray-7 text-sm">
-        <span>Then</span>
-        <Select v-model="rule.action" :options="actionOptions" class="w-48" />
+      <!-- No rule between the summary and the builder: only one rule can be open
+           at a time, so the card's own border already bounds it and the line was
+           just cutting a single object in half. -->
+      <div v-if="isOpen(rule)" class="space-y-4 mx-3 mb-3">
+        <FormControl
+          type="text"
+          label="Rule name"
+          v-model="rule.name"
+          placeholder="Block /admin from outside the office"
+        />
+
+        <div class="space-y-2">
+          <!-- All/Any only once there is something to combine: with a single
+               condition the choice has no meaning. -->
+          <div class="flex flex-wrap items-center gap-2 text-ink-gray-7 text-base">
+            <span>When</span>
+            <Select
+              v-if="rule.conditions.length > 1"
+              v-model="rule.match"
+              :options="MATCH_OPTIONS"
+              class="w-24"
+            />
+            <span>{{ rule.conditions.length > 1 ? 'of the following match:' : 'this matches:' }}</span>
+          </div>
+
+          <div
+            v-if="rule.conditions.length > 1"
+            class="hidden sm:grid grid-cols-[10rem_11rem_minmax(0,1fr)_2rem] gap-2 text-ink-gray-5 text-sm"
+          >
+            <span>Field</span>
+            <span>Condition</span>
+            <span>Value</span>
+            <span />
+          </div>
+
+          <div
+            v-for="(cond, ci) in rule.conditions"
+            :key="keyOf(cond)"
+            class="gap-2 grid grid-cols-1 sm:grid-cols-[10rem_11rem_minmax(0,1fr)_2rem] items-start"
+          >
+            <!-- The header-name input stacks inside the field column rather than
+                 taking a column of its own: as a sibling it shoved this row's
+                 operator and value out of line with every other row. -->
+            <div class="space-y-1.5 min-w-0">
+              <Select v-model="cond.field" :options="fieldOptions" class="w-full" />
+              <TextInput
+                v-if="cond.field === 'header'"
+                v-model="cond.header_name"
+                placeholder="Header name"
+                class="w-full"
+              />
+            </div>
+            <Select v-model="cond.operator" :options="operatorOptions" class="w-full" />
+            <TextInput
+              v-model="cond.value"
+              :placeholder="placeholder(cond.field)"
+              class="w-full"
+            />
+            <!-- A rule with no conditions is dropped silently by the renderer,
+                 so the last one cannot go. -->
+            <Button
+              variant="ghost"
+              icon="lucide-x"
+              label="Remove condition"
+              tooltip="Remove condition"
+              :disabled="rule.conditions.length === 1"
+              @click="removeCondition(rule, ci)"
+            />
+          </div>
+
+          <Button variant="ghost" icon-left="lucide-plus" @click="addCondition(rule)">
+            Add condition
+          </Button>
+        </div>
+
+        <div class="space-y-1.5">
+          <div class="flex flex-wrap items-center gap-2 text-ink-gray-7 text-base">
+            <span>Then</span>
+            <Select v-model="rule.action" :options="actionOptions" class="w-48" />
+          </div>
+          <!-- Skip is the one action that removes protection rather than adding
+               it, and as a plain option it looked like a peer of Block and Log. -->
+          <p
+            v-if="rule.action === 'skip'"
+            class="flex items-start gap-1.5 text-ink-amber-7 text-p-sm"
+          >
+            <span class="shrink-0 mt-0.5 size-3.5 lucide-triangle-alert" />
+            Matching requests bypass the WAF entirely - no managed rules, no inspection.
+          </p>
+        </div>
       </div>
-
-      <p class="text-ink-gray-5 text-xs">{{ preview(rule) }}</p>
     </div>
+
+    <Dialog v-model="showRemove" :options="{ title: 'Delete rule', size: 'md' }">
+      <template #body-content>
+        <p class="text-ink-gray-7 text-p-base">
+          Delete <strong>{{ removingLabel }}</strong
+          >? Requests it was matching fall through to the managed ruleset.
+        </p>
+        <div class="flex justify-end gap-2 mt-4">
+          <Button variant="ghost" @click="showRemove = false">Cancel</Button>
+          <Button variant="solid" theme="red" @click="confirmRemove">Delete</Button>
+        </div>
+      </template>
+    </Dialog>
   </div>
 </template>
 
 <script setup>
-import { computed } from 'vue'
-import { Button, Select, Switch, TextInput } from 'frappe-ui'
+import { computed, onUnmounted, ref } from 'vue'
+import { Button, Dialog, FormControl, Select, Switch, TextInput } from 'frappe-ui'
+import EmptyState from '@/components/common/EmptyState.vue'
+import { ruleProblem } from '@/utils/wafRules'
 
 // Two-way bound so the child owns list edits without mutating a prop.
 const rules = defineModel({ type: Array, default: () => [] })
@@ -103,7 +229,7 @@ const OPERATOR_LABELS = {
   starts_with: 'starts with',
   matches: 'matches regex',
 }
-const ACTION_LABELS = { block: 'Block', log: 'Log', skip: 'Skip (bypass WAF)' }
+const ACTION_LABELS = { block: 'Block', log: 'Log', skip: 'Skip' }
 const PLACEHOLDERS = {
   source_ip: '10.0.0.0/8, 203.0.113.4',
   method: 'POST',
@@ -129,26 +255,98 @@ function placeholder(field) {
   return PLACEHOLDERS[field] || 'value'
 }
 
+// Stable identity for :key. Rules and conditions arrive from the API with no id
+// of their own, and an index key means deleting the first of three re-keys the
+// rest - Vue then patches the inputs in place and a focused caret jumps to the
+// wrong row. Keyed off object identity so it survives a splice without adding a
+// field the API payload would have to carry.
+const keys = new WeakMap()
+let nextKey = 0
+function keyOf(object) {
+  if (!keys.has(object)) keys.set(object, `k${(nextKey += 1)}`)
+  return keys.get(object)
+}
+
+// Collapsed by default: the summary line is the rule, and the builder is the
+// editor for it. A rule added here is empty, so there is nothing to summarise
+// and it opens straight away.
+//
+// One key, not a set: opening a rule closes the one before it. Editing is a
+// one-at-a-time job here, and a column of open builders is the wall of controls
+// collapsing was meant to get rid of.
+const openKey = ref('')
+const isOpen = (rule) => openKey.value === keyOf(rule)
+function toggleOpen(rule) {
+  const key = keyOf(rule)
+  openKey.value = openKey.value === key ? '' : key
+}
+
+// Flashing the unfinished rule rather than blocking the button. Same predicate
+// the save path uses, so what stops you adding and what stops you saving can
+// never disagree.
+const flaggedKey = ref('')
+const root = ref(null)
+let flagTimer = null
+
+function flagUnfinished() {
+  const rule = rules.value.find((candidate) => ruleProblem(candidate))
+  if (!rule) return false
+  const key = keyOf(rule)
+  openKey.value = key
+  flaggedKey.value = key
+  clearTimeout(flagTimer)
+  // Held just under a second, then the class flips and the 1s transition takes
+  // the outline back to gray on its own.
+  flagTimer = setTimeout(() => (flaggedKey.value = ''), 900)
+  // Looked up rather than held in a ref map: this is a one-off nudge, and the
+  // card carries its key already.
+  root.value?.querySelector(`[data-rule-key="${key}"]`)?.scrollIntoView({
+    block: 'nearest',
+    behavior: 'smooth',
+  })
+  return true
+}
+
+onUnmounted(() => clearTimeout(flagTimer))
+
 function newCondition() {
   return { field: 'uri_path', operator: 'contains', value: '', header_name: '' }
 }
 function addRule() {
-  rules.value.push({
+  if (flagUnfinished()) return
+  const rule = {
     name: '',
     action: 'block',
     match: 'all',
     enabled: true,
     conditions: [newCondition()],
-  })
-}
-function removeRule(index) {
-  rules.value.splice(index, 1)
+  }
+  rules.value.push(rule)
+  // Read the pushed item back rather than keying off the local: `rules` is a
+  // reactive array, so what the template iterates is a proxy of this object, not
+  // this object. keyOf() is identity-based, so keying the raw one here would
+  // register a key the template never asks for and the card would open closed.
+  openKey.value = keyOf(rules.value[rules.value.length - 1])
 }
 function addCondition(rule) {
   rule.conditions.push(newCondition())
 }
 function removeCondition(rule, index) {
   rule.conditions.splice(index, 1)
+}
+
+// Confirmed, like every other destructive action in Settings - a WAF rule is at
+// least as consequential as an SSH key, and this used to delete on one click.
+const showRemove = ref(false)
+const removingIndex = ref(-1)
+const removingLabel = computed(() => rules.value[removingIndex.value]?.name || 'this rule')
+function promptRemove(index) {
+  removingIndex.value = index
+  showRemove.value = true
+}
+function confirmRemove() {
+  rules.value.splice(removingIndex.value, 1)
+  showRemove.value = false
 }
 
 function preview(rule) {

--- a/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
+++ b/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
@@ -22,22 +22,28 @@
 
     <div
       v-if="rules.length"
-      class="bg-surface-elevation-1 border border-outline-gray-2 rounded-lg divide-y divide-outline-gray-1"
+      class="bg-surface-elevation-1 p-1 border border-outline-gray-2 rounded-lg"
     >
       <div
         v-for="rule in rules"
         :key="keyOf(rule)"
         :data-rule-key="keyOf(rule)"
-        class="first:rounded-t-lg last:rounded-b-lg ring-1 ring-inset transition-shadow"
+        class="rounded ring-1 ring-inset transition-shadow"
         :class="[
           // Fast in, slow out. transition-shadow: a ring is box-shadow underneath.
           flaggedKey === keyOf(rule) ? 'ring-outline-red-3 duration-75' : 'ring-transparent duration-1000',
           dragKey === keyOf(rule) ? 'opacity-50' : '',
+          // No dividers, so air below an open rule marks where its fields stop.
+          // Below only: a top margin would shove the header down as it opens.
+          isOpen(rule) ? 'mb-1 last:mb-0' : '',
         ]"
         @dragover.prevent="onDragOver(rule)"
       >
         <!-- The whole row toggles; interactive children stop the click. -->
-        <div class="flex items-center gap-3 px-3 py-2.5 cursor-pointer" @click="toggleOpen(rule)">
+        <div
+          class="flex items-center gap-3 px-2.5 h-10 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
+          @click="toggleOpen(rule)"
+        >
           <button
             type="button"
             draggable="true"
@@ -51,17 +57,21 @@
           </button>
           <button
             type="button"
-            class="flex-1 min-w-0 text-left"
+            class="flex flex-1 items-baseline gap-2 min-w-0 text-left"
             :aria-expanded="isOpen(rule)"
             @click.stop="toggleOpen(rule)"
           >
-            <p
-              class="font-medium text-base truncate"
+            <span
+              class="min-w-0 font-medium text-base truncate"
               :class="rule.enabled ? 'text-ink-gray-8' : 'text-ink-gray-5'"
             >
               {{ rule.name || 'Untitled rule' }}
-            </p>
-            <p class="mt-0.5 text-ink-gray-6 text-p-sm">{{ preview(rule) }}</p>
+            </span>
+            <span class="min-w-0 text-ink-gray-6 text-p-sm truncate">
+              {{ ruleSummary(rule) }}
+            </span>
+            <!-- What the rule does outranks what it matches on: never truncate it. -->
+            <span class="shrink-0 text-ink-gray-6 text-p-sm">→ {{ actionLabel(rule) }}</span>
           </button>
           <!-- The nginx renderer silently drops broken rules. -->
           <Badge v-if="ruleProblem(rule)" class="shrink-0" theme="amber">Incomplete</Badge>
@@ -75,18 +85,11 @@
             @click.stop
             @update:model-value="(v) => (rule.enabled = v)"
           />
-          <Button
-            class="shrink-0"
-            variant="ghost"
-            icon="lucide-chevron-down"
-            :label="isOpen(rule) ? 'Collapse rule' : 'Edit rule'"
-            :tooltip="isOpen(rule) ? 'Collapse' : 'Edit'"
-            :class="isOpen(rule) ? 'rotate-180' : ''"
-            @click.stop="toggleOpen(rule)"
-          />
         </div>
 
-        <div v-if="isOpen(rule)" class="space-y-4 px-3 pb-3">
+        <!-- Indent on the left only: the fields keep the header's right edge.
+             pl clears the drag handle so the fields line up under the rule name. -->
+        <div v-if="isOpen(rule)" class="space-y-4 pt-1 pr-2.5 pb-5 pl-[2.375rem]">
         <FormControl
           type="text"
           label="Rule name"
@@ -97,56 +100,66 @@
         <div class="space-y-2">
           <!-- All/Any only once there is something to combine. -->
           <div class="flex flex-wrap items-center gap-2 text-ink-gray-7 text-base">
-            <span>When</span>
-            <Select
-              v-if="rule.conditions.length > 1"
-              v-model="rule.match"
-              :options="MATCH_OPTIONS"
-              class="w-24"
+            <!-- One phrase when there is no Select between the words, or the flex
+                 gap reads as a double space. -->
+            <template v-if="rule.conditions.length > 1">
+              <span>When</span>
+              <Select v-model="rule.match" :options="MATCH_OPTIONS" class="w-24" />
+              <span>of the following match:</span>
+            </template>
+            <span v-else>When this matches:</span>
+          </div>
+
+          <div class="relative space-y-2 pl-5">
+            <!-- One condition bends into its row, several run straight past them
+                 all. -top-2 spans the space-y gap so the line meets "When". -->
+            <span
+              aria-hidden="true"
+              class="absolute left-1 -top-2 border-outline-gray-3"
+              :class="
+                rule.conditions.length > 1
+                  ? 'bottom-1 border-l'
+                  : 'h-[1.625rem] w-2.5 border-l border-b rounded-bl-lg'
+              "
             />
-            <span>{{ rule.conditions.length > 1 ? 'of the following match:' : 'this matches:' }}</span>
-          </div>
 
-          <div
-            v-if="rule.conditions.length > 1"
-            class="hidden sm:grid grid-cols-[10rem_11rem_minmax(0,1fr)_2rem] gap-2 text-ink-gray-5 text-sm"
-          >
-            <span>Field</span>
-            <span>Condition</span>
-            <span>Value</span>
-            <span />
-          </div>
+            <div
+              v-if="rule.conditions.length > 1"
+              class="hidden sm:grid grid-cols-[10rem_11rem_minmax(0,1fr)_2rem] gap-2 text-ink-gray-5 text-sm"
+            >
+              <span>Field</span>
+              <span>Condition</span>
+              <span>Value</span>
+              <span />
+            </div>
 
-          <div
-            v-for="(cond, ci) in rule.conditions"
-            :key="keyOf(cond)"
-            class="gap-2 grid grid-cols-1 sm:grid-cols-[10rem_11rem_minmax(0,1fr)_2rem] items-start"
-          >
-            <!-- Stacked inside the field column to keep rows aligned. -->
-            <div class="space-y-1.5 min-w-0">
-              <Select v-model="cond.field" :options="fieldOptions" class="w-full" />
-              <TextInput
-                v-if="cond.field === 'header'"
-                v-model="cond.header_name"
-                placeholder="Header name"
-                class="w-full"
+            <div
+              v-for="(cond, ci) in rule.conditions"
+              :key="keyOf(cond)"
+              class="gap-2 grid grid-cols-1 sm:grid-cols-[10rem_11rem_minmax(0,1fr)_2rem] items-start"
+            >
+              <!-- Stacked inside the field column to keep rows aligned. -->
+              <div class="space-y-1.5 min-w-0">
+                <Select v-model="cond.field" :options="fieldOptions" class="w-full" />
+                <TextInput
+                  v-if="cond.field === 'header'"
+                  v-model="cond.header_name"
+                  placeholder="Header name"
+                  class="w-full"
+                />
+              </div>
+              <Select v-model="cond.operator" :options="operatorOptions" class="w-full" />
+              <TextInput v-model="cond.value" :placeholder="placeholder(cond.field)" class="w-full" />
+              <!-- Conditionless rules are dropped silently; the last one cannot go. -->
+              <Button
+                variant="ghost"
+                icon="lucide-x"
+                label="Remove condition"
+                tooltip="Remove condition"
+                :disabled="rule.conditions.length === 1"
+                @click="removeCondition(rule, ci)"
               />
             </div>
-            <Select v-model="cond.operator" :options="operatorOptions" class="w-full" />
-            <TextInput
-              v-model="cond.value"
-              :placeholder="placeholder(cond.field)"
-              class="w-full"
-            />
-            <!-- Conditionless rules are dropped silently; the last one cannot go. -->
-            <Button
-              variant="ghost"
-              icon="lucide-x"
-              label="Remove condition"
-              tooltip="Remove condition"
-              :disabled="rule.conditions.length === 1"
-              @click="removeCondition(rule, ci)"
-            />
           </div>
 
           <Button variant="ghost" icon-left="lucide-plus" @click="addCondition(rule)">
@@ -158,6 +171,15 @@
           <div class="flex flex-wrap items-center gap-2 text-ink-gray-7 text-base">
             <span>Then</span>
             <Select v-model="rule.action" :options="actionOptions" class="w-48" />
+            <Button
+              class="ml-auto"
+              variant="ghost"
+              theme="red"
+              icon-left="lucide-trash-2"
+              @click="promptRemove(rule)"
+            >
+              Delete rule
+            </Button>
           </div>
           <p
             v-if="rule.action === 'skip'"
@@ -166,12 +188,6 @@
             <span class="shrink-0 mt-0.5 size-3.5 lucide-triangle-alert" />
             Matching requests bypass the WAF entirely - no managed rules, no inspection.
           </p>
-        </div>
-
-        <div class="flex justify-end">
-          <Button variant="ghost" theme="red" icon-left="lucide-trash-2" @click="promptRemove(rule)">
-            Delete rule
-          </Button>
         </div>
         </div>
       </div>
@@ -196,7 +212,14 @@
 import { computed, onUnmounted, ref } from 'vue'
 import { Badge, Button, Dialog, FormControl, Select, Switch, TextInput } from 'frappe-ui'
 import EmptyState from '@/components/common/EmptyState.vue'
-import { ruleProblem } from '@/utils/wafRules'
+import {
+  ACTION_LABELS,
+  FIELD_LABELS,
+  OPERATOR_LABELS,
+  actionLabel,
+  ruleProblem,
+  ruleSummary,
+} from '@/utils/wafRules'
 
 // Two-way bound so the child owns list edits without mutating a prop.
 const rules = defineModel({ type: Array, default: () => [] })
@@ -206,25 +229,6 @@ const props = defineProps({
   actions: { type: Array, default: () => [] },
 })
 
-const FIELD_LABELS = {
-  uri_path: 'URI Path',
-  uri_full: 'Full URI',
-  query: 'Query String',
-  method: 'HTTP Method',
-  source_ip: 'Source IP',
-  user_agent: 'User Agent',
-  header: 'Request Header',
-  host: 'Host',
-}
-const OPERATOR_LABELS = {
-  is: 'is',
-  is_not: 'is not',
-  contains: 'contains',
-  not_contains: 'does not contain',
-  starts_with: 'starts with',
-  matches: 'matches regex',
-}
-const ACTION_LABELS = { block: 'Block', log: 'Log', skip: 'Skip' }
 const PLACEHOLDERS = {
   source_ip: '10.0.0.0/8, 203.0.113.4',
   method: 'POST',
@@ -345,13 +349,4 @@ function confirmRemove() {
   removingRule.value = null
 }
 
-function preview(rule) {
-  const joiner = rule.match === 'any' ? ' OR ' : ' AND '
-  const parts = rule.conditions.map((c) => {
-    const field =
-      c.field === 'header' ? `Header ${c.header_name || '?'}` : FIELD_LABELS[c.field] || c.field
-    return `${field} ${OPERATOR_LABELS[c.operator] || c.operator} "${c.value || '…'}"`
-  })
-  return `When ${parts.join(joiner) || '…'} → ${ACTION_LABELS[rule.action] || rule.action}`
-}
 </script>

--- a/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
+++ b/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
@@ -19,80 +19,95 @@
 
     <EmptyState
       v-if="!rules.length"
+      compact
       icon="lucide-list-filter"
       title="No custom rules"
       description="Add a rule to block or log requests by path, IP, method, header, and more."
     />
 
-    <!-- Two durations, not one: the flag has to arrive fast enough to read as a
-         response to the click, and leave slowly enough to be watched rather than
-         blink. Same class toggle, different transition on each side. -->
+    <!-- One bordered list, not floating cards: quieter, and "checked top to
+         bottom" reads as an actual ordered list. -->
     <div
-      v-for="(rule, ri) in rules"
-      :key="keyOf(rule)"
-      :data-rule-key="keyOf(rule)"
-      class="bg-surface-elevation-1 border rounded-lg transition-colors"
-      :class="
-        flaggedKey === keyOf(rule)
-          ? 'border-outline-red-3 duration-75'
-          : 'border-outline-gray-2 duration-1000'
-      "
+      v-if="rules.length"
+      class="bg-surface-elevation-1 border border-outline-gray-2 rounded-lg divide-y divide-outline-gray-1"
     >
-      <!-- Summary: what the rule is, always visible. The builder below is the
-           editor for it, which is why it collapses and this does not. -->
-      <div class="flex items-start gap-3 p-3">
-        <!-- Labelled, then the label is hidden: a bare Switch has no accessible
-             name at all (attrs land on the wrapper, not the control), while
-             `label` gives the real <label for> association. sr-only keeps it out
-             of a header row that has no space for the word, and the gap override
-             stops the hidden node from reserving one. -->
-        <Switch
-          class="shrink-0 mt-0.5 [&_[data-slot='label']]:sr-only [&>div]:!gap-x-0 [&>div]:!py-0"
-          label="Rule enabled"
-          :model-value="rule.enabled"
-          @update:model-value="(v) => (rule.enabled = v)"
-        />
-        <button
-          type="button"
-          class="flex-1 min-w-0 text-left"
-          :aria-expanded="isOpen(rule)"
-          @click="toggleOpen(rule)"
-        >
-          <p
-            class="font-medium text-base truncate"
-            :class="rule.enabled ? 'text-ink-gray-8' : 'text-ink-gray-5'"
+      <div
+        v-for="(rule, ri) in rules"
+        :key="keyOf(rule)"
+        :data-rule-key="keyOf(rule)"
+        class="first:rounded-t-lg last:rounded-b-lg ring-1 ring-inset transition-shadow"
+        :class="[
+          // Two durations, not one: the flag has to arrive fast enough to read
+          // as a response to the click, and leave slowly enough to be watched
+          // rather than blink. An inset ring, since rows share the list's
+          // border - transition-shadow because a ring is box-shadow underneath.
+          flaggedKey === keyOf(rule) ? 'ring-outline-red-3 duration-75' : 'ring-transparent duration-1000',
+          dragKey === keyOf(rule) ? 'opacity-50' : '',
+        ]"
+        @dragover.prevent="onDragOver(rule)"
+      >
+        <!-- Summary: what the rule is, always visible. The builder below is the
+             editor for it, which is why it collapses and this does not. The
+             whole row toggles; interactive children stop the click so it only
+             lands on dead space. -->
+        <div class="flex items-center gap-3 px-3 py-2.5 cursor-pointer" @click="toggleOpen(rule)">
+          <button
+            type="button"
+            draggable="true"
+            class="text-ink-gray-4 hover:text-ink-gray-6 cursor-grab shrink-0"
+            aria-label="Drag to reorder"
+            @click.stop
+            @dragstart="onDragStart(rule, $event)"
+            @dragend="onDragEnd"
           >
-            {{ rule.name || 'Untitled rule' }}
-          </p>
-          <!-- The rule in plain English, promoted out of the card's footer. It
-               was the smallest, faintest line on the card while being the one
-               you actually read when auditing a list of them. -->
-          <p class="mt-0.5 text-ink-gray-6 text-p-sm">{{ preview(rule) }}</p>
-        </button>
-        <Button
-          class="shrink-0"
-          variant="ghost"
-          icon="lucide-chevron-down"
-          :label="isOpen(rule) ? 'Collapse rule' : 'Edit rule'"
-          :tooltip="isOpen(rule) ? 'Collapse' : 'Edit'"
-          :class="isOpen(rule) ? 'rotate-180' : ''"
-          @click="toggleOpen(rule)"
-        />
-        <Button
-          class="shrink-0"
-          variant="ghost"
-          theme="red"
-          icon="lucide-trash-2"
-          label="Delete rule"
-          tooltip="Delete rule"
-          @click="promptRemove(ri)"
-        />
-      </div>
+            <span class="block size-4 lucide-grip-vertical" />
+          </button>
+          <button
+            type="button"
+            class="flex-1 min-w-0 text-left"
+            :aria-expanded="isOpen(rule)"
+            @click.stop="toggleOpen(rule)"
+          >
+            <p
+              class="font-medium text-base truncate"
+              :class="rule.enabled ? 'text-ink-gray-8' : 'text-ink-gray-5'"
+            >
+              {{ rule.name || 'Untitled rule' }}
+            </p>
+            <p class="mt-0.5 text-ink-gray-6 text-p-sm">{{ preview(rule) }}</p>
+          </button>
+          <!-- A broken rule is silently dropped by the renderer - it must not
+               look as confident as a working one. -->
+          <Badge v-if="ruleProblem(rule)" class="shrink-0" theme="amber">Incomplete</Badge>
+          <!-- Labelled, then the label is hidden: a bare Switch has no accessible
+               name at all (attrs land on the wrapper, not the control), while
+               `label` gives the real <label for> association. sr-only keeps it
+               out of a header row that has no space for the word, and the gap
+               override stops the hidden node from reserving one. Small and on
+               the right: enabled is the norm, so it shouldn't lead the row. -->
+          <Switch
+            size="sm"
+            class="shrink-0 [&_[data-slot='label']]:sr-only [&>div]:!gap-x-0 [&>div]:!py-0"
+            label="Rule enabled"
+            :model-value="rule.enabled"
+            @click.stop
+            @update:model-value="(v) => (rule.enabled = v)"
+          />
+          <Button
+            class="shrink-0"
+            variant="ghost"
+            icon="lucide-chevron-down"
+            :label="isOpen(rule) ? 'Collapse rule' : 'Edit rule'"
+            :tooltip="isOpen(rule) ? 'Collapse' : 'Edit'"
+            :class="isOpen(rule) ? 'rotate-180' : ''"
+            @click.stop="toggleOpen(rule)"
+          />
+        </div>
 
-      <!-- No rule between the summary and the builder: only one rule can be open
-           at a time, so the card's own border already bounds it and the line was
-           just cutting a single object in half. -->
-      <div v-if="isOpen(rule)" class="space-y-4 mx-3 mb-3">
+        <!-- No rule between the summary and the builder: only one rule can be
+             open at a time, so the row's own bounds already frame it and a line
+             was just cutting a single object in half. -->
+        <div v-if="isOpen(rule)" class="space-y-4 px-3 pb-3">
         <FormControl
           type="text"
           label="Rule name"
@@ -179,6 +194,15 @@
             Matching requests bypass the WAF entirely - no managed rules, no inspection.
           </p>
         </div>
+
+        <!-- In the editor, not the row: delete is rare and destructive, and it
+             was a red icon on every row for the sake of the odd occasion. -->
+        <div class="flex justify-end">
+          <Button variant="ghost" theme="red" icon-left="lucide-trash-2" @click="promptRemove(ri)">
+            Delete rule
+          </Button>
+        </div>
+        </div>
       </div>
     </div>
 
@@ -199,7 +223,7 @@
 
 <script setup>
 import { computed, onUnmounted, ref } from 'vue'
-import { Button, Dialog, FormControl, Select, Switch, TextInput } from 'frappe-ui'
+import { Badge, Button, Dialog, FormControl, Select, Switch, TextInput } from 'frappe-ui'
 import EmptyState from '@/components/common/EmptyState.vue'
 import { ruleProblem } from '@/utils/wafRules'
 
@@ -308,6 +332,29 @@ function flagUnfinished() {
 }
 
 onUnmounted(() => clearTimeout(flagTimer))
+
+// Reorder by dragging the grip. Rules are checked top to bottom, so order is a
+// real setting - the move is done live on dragover (the list re-sorts under the
+// cursor) and identity keys keep every row's state attached through the splice.
+const dragKey = ref('')
+function onDragStart(rule, event) {
+  dragKey.value = keyOf(rule)
+  // Closed while dragging: rows stay uniform, and the drop target is the list
+  // order itself, not a tall open editor.
+  openKey.value = ''
+  event.dataTransfer.effectAllowed = 'move'
+}
+function onDragOver(rule) {
+  if (!dragKey.value || dragKey.value === keyOf(rule)) return
+  const from = rules.value.findIndex((r) => keyOf(r) === dragKey.value)
+  const to = rules.value.findIndex((r) => keyOf(r) === keyOf(rule))
+  if (from === -1 || to === -1) return
+  const [moved] = rules.value.splice(from, 1)
+  rules.value.splice(to, 0, moved)
+}
+function onDragEnd() {
+  dragKey.value = ''
+}
 
 function newCondition() {
   return { field: 'uri_path', operator: 'contains', value: '', header_name: '' }

--- a/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
+++ b/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
@@ -186,7 +186,7 @@
             class="flex items-start gap-1.5 text-ink-amber-7 text-p-sm"
           >
             <span class="shrink-0 mt-0.5 size-3.5 lucide-triangle-alert" />
-            Matching requests bypass the WAF entirely - no managed rules, no inspection.
+            Matching requests bypass the firewall entirely - no managed rules, no inspection.
           </p>
         </div>
         </div>

--- a/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
+++ b/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
@@ -3,15 +3,10 @@
     <div class="flex justify-between items-start gap-4">
       <div class="min-w-0">
         <p class="font-medium text-ink-gray-8 text-base">Custom rules</p>
-        <!-- max-w here and shrink-0 on the button: with neither, this paragraph
-             ran to the button's exact left edge and wrapped into it. -->
         <p class="mt-0.5 max-w-md text-ink-gray-5 text-p-sm">
           Checked before the managed rules, top to bottom.
         </p>
       </div>
-      <!-- Stays live while a rule is unfinished, and points at the offender
-           instead: a disabled button with no target leaves you hunting for which
-           card it meant. -->
       <Button class="shrink-0" variant="subtle" icon-left="lucide-plus" @click="addRule">
         Add rule
       </Button>
@@ -25,8 +20,6 @@
       description="Add a rule to block or log requests by path, IP, method, header, and more."
     />
 
-    <!-- One bordered list, not floating cards: quieter, and "checked top to
-         bottom" reads as an actual ordered list. -->
     <div
       v-if="rules.length"
       class="bg-surface-elevation-1 border border-outline-gray-2 rounded-lg divide-y divide-outline-gray-1"
@@ -37,19 +30,13 @@
         :data-rule-key="keyOf(rule)"
         class="first:rounded-t-lg last:rounded-b-lg ring-1 ring-inset transition-shadow"
         :class="[
-          // Two durations, not one: the flag has to arrive fast enough to read
-          // as a response to the click, and leave slowly enough to be watched
-          // rather than blink. An inset ring, since rows share the list's
-          // border - transition-shadow because a ring is box-shadow underneath.
+          // Fast in, slow out. transition-shadow: a ring is box-shadow underneath.
           flaggedKey === keyOf(rule) ? 'ring-outline-red-3 duration-75' : 'ring-transparent duration-1000',
           dragKey === keyOf(rule) ? 'opacity-50' : '',
         ]"
         @dragover.prevent="onDragOver(rule)"
       >
-        <!-- Summary: what the rule is, always visible. The builder below is the
-             editor for it, which is why it collapses and this does not. The
-             whole row toggles; interactive children stop the click so it only
-             lands on dead space. -->
+        <!-- The whole row toggles; interactive children stop the click. -->
         <div class="flex items-center gap-3 px-3 py-2.5 cursor-pointer" @click="toggleOpen(rule)">
           <button
             type="button"
@@ -76,15 +63,10 @@
             </p>
             <p class="mt-0.5 text-ink-gray-6 text-p-sm">{{ preview(rule) }}</p>
           </button>
-          <!-- A broken rule is silently dropped by the renderer - it must not
-               look as confident as a working one. -->
+          <!-- The nginx renderer silently drops broken rules. -->
           <Badge v-if="ruleProblem(rule)" class="shrink-0" theme="amber">Incomplete</Badge>
-          <!-- Labelled, then the label is hidden: a bare Switch has no accessible
-               name at all (attrs land on the wrapper, not the control), while
-               `label` gives the real <label for> association. sr-only keeps it
-               out of a header row that has no space for the word, and the gap
-               override stops the hidden node from reserving one. Small and on
-               the right: enabled is the norm, so it shouldn't lead the row. -->
+          <!-- A bare Switch has no accessible name (attrs land on the wrapper);
+               `label` gives the <label for> association, sr-only hides it. -->
           <Switch
             size="sm"
             class="shrink-0 [&_[data-slot='label']]:sr-only [&>div]:!gap-x-0 [&>div]:!py-0"
@@ -104,9 +86,6 @@
           />
         </div>
 
-        <!-- No rule between the summary and the builder: only one rule can be
-             open at a time, so the row's own bounds already frame it and a line
-             was just cutting a single object in half. -->
         <div v-if="isOpen(rule)" class="space-y-4 px-3 pb-3">
         <FormControl
           type="text"
@@ -116,8 +95,7 @@
         />
 
         <div class="space-y-2">
-          <!-- All/Any only once there is something to combine: with a single
-               condition the choice has no meaning. -->
+          <!-- All/Any only once there is something to combine. -->
           <div class="flex flex-wrap items-center gap-2 text-ink-gray-7 text-base">
             <span>When</span>
             <Select
@@ -144,9 +122,7 @@
             :key="keyOf(cond)"
             class="gap-2 grid grid-cols-1 sm:grid-cols-[10rem_11rem_minmax(0,1fr)_2rem] items-start"
           >
-            <!-- The header-name input stacks inside the field column rather than
-                 taking a column of its own: as a sibling it shoved this row's
-                 operator and value out of line with every other row. -->
+            <!-- Stacked inside the field column to keep rows aligned. -->
             <div class="space-y-1.5 min-w-0">
               <Select v-model="cond.field" :options="fieldOptions" class="w-full" />
               <TextInput
@@ -162,8 +138,7 @@
               :placeholder="placeholder(cond.field)"
               class="w-full"
             />
-            <!-- A rule with no conditions is dropped silently by the renderer,
-                 so the last one cannot go. -->
+            <!-- Conditionless rules are dropped silently; the last one cannot go. -->
             <Button
               variant="ghost"
               icon="lucide-x"
@@ -184,8 +159,6 @@
             <span>Then</span>
             <Select v-model="rule.action" :options="actionOptions" class="w-48" />
           </div>
-          <!-- Skip is the one action that removes protection rather than adding
-               it, and as a plain option it looked like a peer of Block and Log. -->
           <p
             v-if="rule.action === 'skip'"
             class="flex items-start gap-1.5 text-ink-amber-7 text-p-sm"
@@ -195,8 +168,6 @@
           </p>
         </div>
 
-        <!-- In the editor, not the row: delete is rare and destructive, and it
-             was a red icon on every row for the sake of the odd occasion. -->
         <div class="flex justify-end">
           <Button variant="ghost" theme="red" icon-left="lucide-trash-2" @click="promptRemove(ri)">
             Delete rule
@@ -279,11 +250,8 @@ function placeholder(field) {
   return PLACEHOLDERS[field] || 'value'
 }
 
-// Stable identity for :key. Rules and conditions arrive from the API with no id
-// of their own, and an index key means deleting the first of three re-keys the
-// rest - Vue then patches the inputs in place and a focused caret jumps to the
-// wrong row. Keyed off object identity so it survives a splice without adding a
-// field the API payload would have to carry.
+// Identity-based :key. Index keys re-key rows on delete and Vue patches the
+// inputs in place, jumping a focused caret to the wrong row.
 const keys = new WeakMap()
 let nextKey = 0
 function keyOf(object) {
@@ -291,13 +259,7 @@ function keyOf(object) {
   return keys.get(object)
 }
 
-// Collapsed by default: the summary line is the rule, and the builder is the
-// editor for it. A rule added here is empty, so there is nothing to summarise
-// and it opens straight away.
-//
-// One key, not a set: opening a rule closes the one before it. Editing is a
-// one-at-a-time job here, and a column of open builders is the wall of controls
-// collapsing was meant to get rid of.
+// One key, not a set: opening a rule closes the one before it.
 const openKey = ref('')
 const isOpen = (rule) => openKey.value === keyOf(rule)
 function toggleOpen(rule) {
@@ -305,9 +267,7 @@ function toggleOpen(rule) {
   openKey.value = openKey.value === key ? '' : key
 }
 
-// Flashing the unfinished rule rather than blocking the button. Same predicate
-// the save path uses, so what stops you adding and what stops you saving can
-// never disagree.
+// Same predicate as the save path, so add and save cannot disagree.
 const flaggedKey = ref('')
 const root = ref(null)
 let flagTimer = null
@@ -319,11 +279,7 @@ function flagUnfinished() {
   openKey.value = key
   flaggedKey.value = key
   clearTimeout(flagTimer)
-  // Held just under a second, then the class flips and the 1s transition takes
-  // the outline back to gray on its own.
   flagTimer = setTimeout(() => (flaggedKey.value = ''), 900)
-  // Looked up rather than held in a ref map: this is a one-off nudge, and the
-  // card carries its key already.
   root.value?.querySelector(`[data-rule-key="${key}"]`)?.scrollIntoView({
     block: 'nearest',
     behavior: 'smooth',
@@ -333,14 +289,10 @@ function flagUnfinished() {
 
 onUnmounted(() => clearTimeout(flagTimer))
 
-// Reorder by dragging the grip. Rules are checked top to bottom, so order is a
-// real setting - the move is done live on dragover (the list re-sorts under the
-// cursor) and identity keys keep every row's state attached through the splice.
+// Live reorder on dragover; identity keys keep row state through the splice.
 const dragKey = ref('')
 function onDragStart(rule, event) {
   dragKey.value = keyOf(rule)
-  // Closed while dragging: rows stay uniform, and the drop target is the list
-  // order itself, not a tall open editor.
   openKey.value = ''
   event.dataTransfer.effectAllowed = 'move'
 }
@@ -369,10 +321,7 @@ function addRule() {
     conditions: [newCondition()],
   }
   rules.value.push(rule)
-  // Read the pushed item back rather than keying off the local: `rules` is a
-  // reactive array, so what the template iterates is a proxy of this object, not
-  // this object. keyOf() is identity-based, so keying the raw one here would
-  // register a key the template never asks for and the card would open closed.
+  // Key the reactive proxy the template iterates, not the raw local object.
   openKey.value = keyOf(rules.value[rules.value.length - 1])
 }
 function addCondition(rule) {
@@ -382,8 +331,6 @@ function removeCondition(rule, index) {
   rule.conditions.splice(index, 1)
 }
 
-// Confirmed, like every other destructive action in Settings - a WAF rule is at
-// least as consequential as an SSH key, and this used to delete on one click.
 const showRemove = ref(false)
 const removingIndex = ref(-1)
 const removingLabel = computed(() => rules.value[removingIndex.value]?.name || 'this rule')

--- a/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
+++ b/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
@@ -25,7 +25,7 @@
       class="bg-surface-elevation-1 border border-outline-gray-2 rounded-lg divide-y divide-outline-gray-1"
     >
       <div
-        v-for="(rule, ri) in rules"
+        v-for="rule in rules"
         :key="keyOf(rule)"
         :data-rule-key="keyOf(rule)"
         class="first:rounded-t-lg last:rounded-b-lg ring-1 ring-inset transition-shadow"
@@ -169,7 +169,7 @@
         </div>
 
         <div class="flex justify-end">
-          <Button variant="ghost" theme="red" icon-left="lucide-trash-2" @click="promptRemove(ri)">
+          <Button variant="ghost" theme="red" icon-left="lucide-trash-2" @click="promptRemove(rule)">
             Delete rule
           </Button>
         </div>
@@ -332,15 +332,17 @@ function removeCondition(rule, index) {
 }
 
 const showRemove = ref(false)
-const removingIndex = ref(-1)
-const removingLabel = computed(() => rules.value[removingIndex.value]?.name || 'this rule')
-function promptRemove(index) {
-  removingIndex.value = index
+const removingRule = ref(null)
+const removingLabel = computed(() => removingRule.value?.name || 'this rule')
+function promptRemove(rule) {
+  removingRule.value = rule
   showRemove.value = true
 }
 function confirmRemove() {
-  rules.value.splice(removingIndex.value, 1)
+  const index = rules.value.indexOf(removingRule.value)
+  if (index !== -1) rules.value.splice(index, 1)
   showRemove.value = false
+  removingRule.value = null
 }
 
 function preview(rule) {

--- a/admin/frontend/dashboard/src/components/settings/Workers.vue
+++ b/admin/frontend/dashboard/src/components/settings/Workers.vue
@@ -5,16 +5,18 @@
   <div v-else class="space-y-6">
     <div v-for="(group, index) in groups" :key="index" class="flex items-end gap-3">
       <div class="space-y-1.5 w-28">
-        <p v-if="index === 0" class="font-medium text-ink-gray-7 text-sm">No of Workers</p>
+        <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">No of Workers</p>
         <TextInput v-model="group.count" type="number" min="1" class="w-full" />
       </div>
       <div class="flex-1 space-y-1.5">
-        <p v-if="index === 0" class="font-medium text-ink-gray-7 text-sm">Queues</p>
+        <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">Queues</p>
         <TextInput v-model="group.queues" placeholder="default, short, long" class="w-full" />
       </div>
       <Button
         variant="subtle"
         icon="lucide-x"
+        label="Remove worker group"
+        tooltip="Remove worker group"
         :disabled="groups.length === 1"
         @click="removeGroup(index)"
       />

--- a/admin/frontend/dashboard/src/components/settings/sections.js
+++ b/admin/frontend/dashboard/src/components/settings/sections.js
@@ -43,7 +43,6 @@ export const SECURITY_SECTIONS = [
     label: 'Change password',
     description: 'Update the password that signs in to this bench.',
     component: ChangeAdminPassword,
-    action: 'Change',
   },
   {
     id: 'two-factor',
@@ -59,8 +58,8 @@ export const SECURITY_SECTIONS = [
   },
   {
     id: 'waf',
-    label: 'WAF settings',
-    description: 'Web application firewall rules for your sites.',
+    label: 'Web application firewall',
+    description: 'Inspect incoming requests for attacks before they reach your sites.',
     component: Waf,
   },
   {

--- a/admin/frontend/dashboard/src/components/sites/settings/General.vue
+++ b/admin/frontend/dashboard/src/components/sites/settings/General.vue
@@ -1,16 +1,13 @@
 <template>
   <div>
     <p class="font-semibold text-ink-gray-8 text-base">General</p>
-    <!-- Matches SettingsRow: label text-base ink-gray-8 medium, description text-p-sm ink-gray-6. -->
-    <div
-      class="mt-1 [&_[data-slot='label']]:font-medium [&_[data-slot='label']]:text-ink-gray-8 [&_[data-slot='description']]:text-ink-gray-6"
-    >
+    <div class="mt-1">
       <div
         v-for="s in visibleSettings"
         :key="s.key"
         class="py-4 border-b last:border-b-0 border-outline-alpha-gray-1"
       >
-        <Switch
+        <SettingsSwitch
           :label="s.label"
           :description="s.description"
           :model-value="getValue(s)"
@@ -25,7 +22,8 @@
 
 <script setup>
 import { computed, onMounted, ref } from 'vue'
-import { ErrorMessage, Switch } from 'frappe-ui'
+import { ErrorMessage } from 'frappe-ui'
+import SettingsSwitch from '@/components/settings/SettingsSwitch.vue'
 import { useSite } from '@/composables/sites/useSite'
 import { sitesApi } from '@/api/sites'
 import { settingsApi } from '@/api/settings'

--- a/admin/frontend/dashboard/src/composables/common/useUnsavedChanges.js
+++ b/admin/frontend/dashboard/src/composables/common/useUnsavedChanges.js
@@ -1,16 +1,28 @@
-import { onScopeDispose } from 'vue'
+import { getCurrentScope, onScopeDispose } from 'vue'
 
 // A dirty panel registers a predicate; whoever swaps it out asks first.
 // Module-level: the asking shell is not an ancestor of every panel.
 const guards = new Set()
 
 export function useUnsavedChanges(isDirty) {
+  // Without an active scope, onScopeDispose no-ops and the guard leaks
+  // forever, permanently blocking navigation. Fail loudly instead.
+  if (!getCurrentScope()) {
+    throw new Error('useUnsavedChanges must be called during component setup')
+  }
   const guard = () => Boolean(isDirty.value)
   guards.add(guard)
   onScopeDispose(() => guards.delete(guard))
 }
 
 export function hasUnsavedChanges() {
-  for (const guard of guards) if (guard()) return true
+  for (const guard of guards) {
+    try {
+      if (guard()) return true
+    } catch {
+      // The panel behind this guard is gone; stop trusting its verdict.
+      guards.delete(guard)
+    }
+  }
   return false
 }

--- a/admin/frontend/dashboard/src/composables/common/useUnsavedChanges.js
+++ b/admin/frontend/dashboard/src/composables/common/useUnsavedChanges.js
@@ -1,12 +1,7 @@
 import { onScopeDispose } from 'vue'
 
-// A panel holding unsaved work registers a predicate here; whoever is about to
-// swap that panel out asks it first.
-//
-// Module-level rather than provide/inject: the Settings shell doing the asking
-// is not an ancestor of every panel that could be dirty, and only one panel is
-// mounted at a time anyway. The guard removes itself when its owner's scope
-// dies, so an unmounted panel can never block navigation.
+// A dirty panel registers a predicate; whoever swaps it out asks first.
+// Module-level: the asking shell is not an ancestor of every panel.
 const guards = new Set()
 
 export function useUnsavedChanges(isDirty) {

--- a/admin/frontend/dashboard/src/composables/common/useUnsavedChanges.js
+++ b/admin/frontend/dashboard/src/composables/common/useUnsavedChanges.js
@@ -1,0 +1,21 @@
+import { onScopeDispose } from 'vue'
+
+// A panel holding unsaved work registers a predicate here; whoever is about to
+// swap that panel out asks it first.
+//
+// Module-level rather than provide/inject: the Settings shell doing the asking
+// is not an ancestor of every panel that could be dirty, and only one panel is
+// mounted at a time anyway. The guard removes itself when its owner's scope
+// dies, so an unmounted panel can never block navigation.
+const guards = new Set()
+
+export function useUnsavedChanges(isDirty) {
+  const guard = () => Boolean(isDirty.value)
+  guards.add(guard)
+  onScopeDispose(() => guards.delete(guard))
+}
+
+export function hasUnsavedChanges() {
+  for (const guard of guards) if (guard()) return true
+  return false
+}

--- a/admin/frontend/dashboard/src/utils/wafRules.js
+++ b/admin/frontend/dashboard/src/utils/wafRules.js
@@ -1,7 +1,7 @@
 // One definition of "this rule would not do what you meant", shared by the two
 // places that need it: the rules editor, which refuses to stack another rule on
-// top of an unfinished one, and the save path, which has to explain why. Two
-// call sites, one rule - they must not drift apart.
+// top of an unfinished one (and badges the offender), and the save path, which
+// holds the button. Two call sites, one rule - they must not drift apart.
 //
 // An empty condition value is the dangerous case, not the inert one: it matches
 // every request for that field, so a half-built Block rule blocks everything.
@@ -15,8 +15,4 @@ export function ruleProblem(rule) {
       return `does not name the request header in condition ${index + 1}`
   }
   return ''
-}
-
-export function ruleLabel(rule, index) {
-  return rule.name?.trim() || `Rule ${index + 1}`
 }

--- a/admin/frontend/dashboard/src/utils/wafRules.js
+++ b/admin/frontend/dashboard/src/utils/wafRules.js
@@ -1,12 +1,7 @@
-// One definition of "this rule would not do what you meant", shared by the two
-// places that need it: the rules editor, which refuses to stack another rule on
-// top of an unfinished one (and badges the offender), and the save path, which
-// holds the button. Two call sites, one rule - they must not drift apart.
-//
-// An empty condition value is the dangerous case, not the inert one: it matches
-// every request for that field, so a half-built Block rule blocks everything.
-// A rule with no conditions is dropped by the nginx renderer without a word.
 export function ruleProblem(rule) {
+  // Shared by the editor (Incomplete badge, Add refusal) and the save gate.
+  // An empty value matches every request for its field; a conditionless rule
+  // is dropped by the nginx renderer without a word.
   if (!rule.conditions?.length) return 'has no conditions, so it would never apply'
   for (const [index, condition] of rule.conditions.entries()) {
     if (!String(condition.value ?? '').trim())

--- a/admin/frontend/dashboard/src/utils/wafRules.js
+++ b/admin/frontend/dashboard/src/utils/wafRules.js
@@ -1,3 +1,25 @@
+export const FIELD_LABELS = {
+  uri_path: 'URI Path',
+  uri_full: 'Full URI',
+  query: 'Query String',
+  method: 'HTTP Method',
+  source_ip: 'Source IP',
+  user_agent: 'User Agent',
+  header: 'Request Header',
+  host: 'Host',
+}
+
+export const OPERATOR_LABELS = {
+  is: 'is',
+  is_not: 'is not',
+  contains: 'contains',
+  not_contains: 'does not contain',
+  starts_with: 'starts with',
+  matches: 'matches regex',
+}
+
+export const ACTION_LABELS = { block: 'Block', log: 'Log', skip: 'Skip' }
+
 export function ruleProblem(rule) {
   // Shared by the editor (Incomplete badge, Add refusal) and the save gate.
   // An empty value matches every request for its field; a conditionless rule
@@ -10,4 +32,25 @@ export function ruleProblem(rule) {
       return `does not name the request header in condition ${index + 1}`
   }
   return ''
+}
+
+/**
+ * The collapsed row's description, without the action - the row pins that
+ * separately so it never clips. Spelling out every condition outgrows the row at
+ * three of them, so past one the count is what a glance gets.
+ */
+export function ruleSummary(rule) {
+  const count = rule.conditions?.length || 0
+  if (count !== 1) return `When ${rule.match === 'any' ? 'any' : 'all'} of ${count} conditions match`
+  const [condition] = rule.conditions
+  const field =
+    condition.field === 'header'
+      ? `Header ${condition.header_name || '?'}`
+      : FIELD_LABELS[condition.field] || condition.field
+  const operator = OPERATOR_LABELS[condition.operator] || condition.operator
+  return `When ${field} ${operator} "${condition.value || '…'}"`
+}
+
+export function actionLabel(rule) {
+  return ACTION_LABELS[rule.action] || rule.action
 }

--- a/admin/frontend/dashboard/src/utils/wafRules.js
+++ b/admin/frontend/dashboard/src/utils/wafRules.js
@@ -1,0 +1,22 @@
+// One definition of "this rule would not do what you meant", shared by the two
+// places that need it: the rules editor, which refuses to stack another rule on
+// top of an unfinished one, and the save path, which has to explain why. Two
+// call sites, one rule - they must not drift apart.
+//
+// An empty condition value is the dangerous case, not the inert one: it matches
+// every request for that field, so a half-built Block rule blocks everything.
+// A rule with no conditions is dropped by the nginx renderer without a word.
+export function ruleProblem(rule) {
+  if (!rule.conditions?.length) return 'has no conditions, so it would never apply'
+  for (const [index, condition] of rule.conditions.entries()) {
+    if (!String(condition.value ?? '').trim())
+      return `is missing a value in condition ${index + 1}, which would match every request`
+    if (condition.field === 'header' && !condition.header_name?.trim())
+      return `does not name the request header in condition ${index + 1}`
+  }
+  return ''
+}
+
+export function ruleLabel(rule, index) {
+  return rule.name?.trim() || `Rule ${index + 1}`
+}

--- a/admin/frontend/dashboard/src/utils/wafRules.test.js
+++ b/admin/frontend/dashboard/src/utils/wafRules.test.js
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { actionLabel, ruleSummary } from './wafRules.js'
+
+const condition = (over = {}) => ({
+  field: 'uri_path',
+  operator: 'contains',
+  value: '/admin',
+  ...over,
+})
+
+test('ruleSummary spells out a lone condition', () => {
+  assert.equal(
+    ruleSummary({ match: 'all', conditions: [condition()] }),
+    'When URI Path contains "/admin"',
+  )
+})
+
+test('ruleSummary names the request header instead of the field', () => {
+  const header = condition({ field: 'header', header_name: 'X-Real-IP', value: '10.0.0.1' })
+  assert.equal(ruleSummary({ match: 'all', conditions: [header] }), 'When Header X-Real-IP contains "10.0.0.1"')
+})
+
+test('ruleSummary counts conditions past the first, and reports the match mode', () => {
+  const two = [condition(), condition({ field: 'method', value: 'POST' })]
+  assert.equal(ruleSummary({ match: 'all', conditions: two }), 'When all of 2 conditions match')
+  assert.equal(ruleSummary({ match: 'any', conditions: two }), 'When any of 2 conditions match')
+})
+
+test('ruleSummary survives a half-built rule', () => {
+  assert.equal(ruleSummary({ match: 'all', conditions: [] }), 'When all of 0 conditions match')
+  assert.equal(ruleSummary({ match: 'all' }), 'When all of 0 conditions match')
+  assert.equal(
+    ruleSummary({ match: 'all', conditions: [condition({ value: '' })] }),
+    'When URI Path contains "…"',
+  )
+})
+
+test('actionLabel falls back to the raw action', () => {
+  assert.equal(actionLabel({ action: 'block' }), 'Block')
+  assert.equal(actionLabel({ action: 'quarantine' }), 'quarantine')
+})


### PR DESCRIPTION
> Stacked on #342 — targets `ui-polish-3` because the settings empty states use the `EmptyState` component introduced there. Retarget to `develop` once #342 merges.

Everything under Settings, in eight commits: 20 files, +868/−324. The first half is the same drift-cleanup as #342 applied to a corner that had missed it; the second half is a redesign of the WAF panel and its rule builder — which had real correctness bugs — plus one interaction pattern (required fields hold the button) applied across every panel.

## One type scale

Rows rendered their label at **13px** while frappe-ui's own `InputLabel` renders at **14px** — so a `Switch` row and a `SettingsRow` sat in the same list at two different sizes, with the library's own component as the odd one out. Everything follows the library now: `text-base` for the label, `text-p-sm` for the description, which is stacked copy and wraps.

The knock-on work:

- Connected-account headers (GitHub, S3, LLM), the Devices header, disclosure summaries, column headers in Workers and Firewall, and the System Info rows all move up a step.
- Confirm-dialog body copy moves to `text-p-base` — it is the main statement of those dialogs, not a caption.
- Nothing sits at 12px any more except inline `font-mono` inside 13px prose, where matching the nominal size would make the mono *look* bigger, and the two uppercase eyebrow labels in System Info, where 14px caps would out-shout the rows they head.

## Switch labels were reading as disabled

A bare frappe-ui `Switch` renders its label in `ink-gray-5` at regular weight. That is right for a form field, but next to a `SettingsRow` it reads as disabled text — visible in Firewall and WAF, where the two kinds of row sit in one list.

`SettingsSwitch` applies the row treatment through the `data-slot` hooks the library documents. Not `labelClasses`: that prop is deprecated *and* no longer applied to anything, so passing it only produces a console warning.

The site Settings tab had pinned its Switch labels to `text-sm`, which would have left the same kind of row a step smaller than its counterpart here.

## Shared empty states

**Six** hand-rolled empty states become `EmptyState`. They had drifted apart — different box radii, a 44px round icon tile against the shared 40px rounded one, and in the SSH keys case a bare dashed box holding a single gray line, no icon, and nothing saying what an SSH key is for. Adopting the shared component also brings them onto the 14/13 scale for free.

The component grows a **`compact`** variant for exactly this setting: inside a panel, the full-height box made the absence the tallest thing in view. `py-6/gap-3` against the full `py-12/gap-4`, smaller and less-rounded icon tile; all six settings empty states use it, page-level ones keep the full size.

The two dashed boxes that remain are **error** states, not empty ones, so they keep their own red-bordered treatment.

## The dialog shell

The dialog moves up to `5xl` with its height pinned to `calc(100vh - 6rem)` — the 6rem is the chrome frappe-ui's `Dialog` puts around the panel (overlay `py-4` + content `my-8`), so a literal `100vh` overflowed the fold by exactly 96px and set the overlay scrolling. As tall as a modal can be while both rounded corners stay on screen.

Sidebar and content padding come from frappe-ui's own `SettingsDialog` — `bg-surface-sidebar`, 220px wide, `px-[4.4rem] pt-10 pb-16`. Measured identical to the reference.

`surface-sidebar` is theme-aware by design: a light gray against the panel in light mode, **transparent** in dark, where the panel is already raised off the backdrop and a second gray would muddy it. The active nav item moves to the library's treatment too (`surface-elevation-3` + `shadow-sm`) — the old `surface-gray-3` would have been mush on the new background. The back button drops to ghost so the header leads with the title, not a gray square.

The 70px side padding stays off below `sm`, which would otherwise leave a column narrower than its own labels.

> We are not using frappe-ui's `SettingsDialog` family — this dialog is hand-rolled on `Dialog bare`, and we duplicate its `SettingsRow` too. Migrating properly means redoing the routed sections and sub-sections, the header-actions teleport, the mobile back behaviour and the guard below. Worth doing, but not here.

## Unsaved changes are guarded

You could build a ruleset, click another section, and lose it with no warning.

Moving between panels is a route **param** change on the one `Settings` record, so a component-level `onBeforeRouteLeave` never fires for it — it only runs when the matched route *record* changes. Every exit funnels through this dialog instead (sidebar, back arrow, sub-section, dismiss), so the gate sits at those four call sites. A panel registers a dirty predicate; the shell asks before swapping it out. With nothing dirty the action runs straight through, so the ordinary case is unchanged.

Verified across all four exits, both branches (Keep editing / Discard), plus the two regression cases: no prompt when clean, and no stale guard left behind after a dirty panel unmounts.

Leaving the tab entirely stays with the browser's own `beforeunload` — that is its job, not the shell's.

## The WAF panel

Redesigned around one observation: the page was a flat stack of equal-weight blocks with up to two yellow Alert boxes shouting at once.

- **Alerts become one line.** The deployment gaps ("not deployed" / "ModSecurity not installed" — mutually exclusive by construction) are a single amber line under the Enable switch, shown only while the WAF is on. The "Log only" Alert becomes a hint under the Action field, where the choice is made; Paused and Block get one-liners too, so the layout never jumps.
- **Sensitivity is a segmented control.** Four fixed ordered options — a select was hiding the scale. One catch: `TabButtons` matches by `Object.is`, so the value is cast to `Number` at load; a stringy `"2"` would silently snap to Low and dirty the form on open.
- **The OWASP CRS heading goes.** Hierarchy is carried by rhythm instead: 48px between the three groups, 16px within — the 3:1 ratio is what makes a seam read as a section break.
- **Config stays visible with the WAF off.** Staging rules first and flipping the switch last is the safe rollout order (the enable moment is the risky one), and rules save independently of `enabled`. The switch and the absent setup note carry the off state.
- **Save renders only when dirty.** A permanently visible disabled button is chrome with nothing to say.
- **Advanced, reworked.** Examples move from placeholders — gone at the first keystroke — into persistent hints; path-level scope sits above the SecLang field and each names its level (both read as "don't inspect X" until you know the difference); the body-size unit convention is stated; the one thing that *adds* inspection goes last.

## WAF rule builder

The plain-English summary — `When URI Path contains "/admin" → Block` — was the smallest, faintest line on a rule card while being the one you actually read when auditing a list of them, and it merely repeated the controls above it. It becomes the row; the builder collapses beneath it, one open at a time. A rule you just added is empty, so there is nothing to summarise and it opens straight away.

The list itself: floating cards become **one bordered list** — quieter, and "checked top to bottom" reads as an actual ordered list. The per-row switch shrinks and moves right of the content (enabled is the norm; it shouldn't lead the row), delete moves into the editor (rare and destructive — it was a red icon on every row for the sake of the odd occasion), and the whole header row is the click target. Rules **reorder by dragging** the grip; order is a real setting, and a reorder is savable like any other edit.

### Correctness, roughly by consequence

- **Index keys.** Rules and conditions were keyed by array index, so deleting the first of three re-keyed the rest — Vue then patched the inputs in place and a focused caret jumped to another row. Keyed off object identity now, held in a `WeakMap` so the API payload carries no extra field — which is also what lets a dragged row keep its state through the splice.
- **Silent delete.** Removing a rule was one click with no confirmation, unlike every other destructive action in Settings.
- **Rules that do nothing.** The last condition could be removed, and the nginx renderer drops a rule with no conditions without saying so.
- **Rules that do everything.** An empty condition value matches *every* request for that field, so a half-built Block rule blocks everything. One `ruleProblem()` predicate backs everything that reacts to a broken rule — the **Incomplete badge** on its row, the refusal to stack another rule on top of it, and the held Save button — so they cannot disagree.
- **Overlap.** The section description ran to the exact left edge of "Add rule" — measured 968.55 against 968.55 — and wrapped into it.
- **Column drift.** Picking "Request Header" injected a fourth control into that row only, pushing its operator and value out of line with every other row. The header name stacks inside the field column instead.
- **Accessible names.** Eight icon-only buttons announced as a bare "button".

Rather than disabling "Add rule" while a rule is unfinished — a dead button with no indication of *which* rule — clicking it flashes the offender: red in 75ms, held ~900ms, then a 1s decay. An inset ring rather than the border, since rows now share the list's single border.

### Copy

- **`Off` → `Paused`.** It and the Enable switch both read as off, but they are not the same: the switch drops the module from the server config and coming back costs a rebuild, while this leaves it loaded with the engine idle — the state you want when checking whether the WAF is behind a broken site. The stored value is unchanged; only the word moves.
- **Sensitivity** was four bare words for the page's most consequential knob. Each level now says what it trades, and the anomaly threshold says that it compounds with them.
- **Skip** is the one action that removes protection rather than adding it, and it no longer sits as a silent peer of Block and Log.
- "Review the WAF analytics" is a link — darkened rather than underlined, so the hint doesn't read as two decorations deep.

## Required fields hold the button

One pattern across every panel: an **empty required field disables the button**, a **wrongly-filled field hints red under that input**, and the bottom `ErrorMessage` is reserved for server failures and cross-field problems.

- Connect/Add in **Git, LLM, S3 and SSH keys** gate on their required fields — retiring seven post-click "X is required." messages that used to appear at the bottom of the page, nowhere near the field they meant.
- **Firewall** shows an invalid IP under its own row. The lockout warning ("Block by default needs at least one Allow rule") stays at the bottom deliberately: it is a property of the whole ruleset, not one input.
- **WAF** hints a non-positive anomaly threshold under its own field; incomplete rules are already badged where they sit.
- **Two-factor** already followed the pattern on both steps.

## Screenshots

<!-- drop images below each heading -->

### Settings — type scale and shell
<img width="936" height="641" alt="Screenshot 2026-08-01 at 2 34 48 AM" src="https://github.com/user-attachments/assets/701e4d46-185e-4de7-aeb8-028a1e9d9cb6" />

### WAF — rule cards
<img width="728" height="545" alt="Screenshot 2026-08-01 at 7 25 59 AM" src="https://github.com/user-attachments/assets/1e5b806f-8a72-4c35-86f6-21b12673de5a" />


### Compact Empty states
<img width="715" height="254" alt="Screenshot 2026-08-01 at 7 26 40 AM" src="https://github.com/user-attachments/assets/569a989b-8b67-46a7-b742-698724bb3f33" />

### Unsaved changes
<img width="539" height="349" alt="Screenshot 2026-08-01 at 2 36 13 AM" src="https://github.com/user-attachments/assets/2005f1f3-e100-4753-bed5-87452eff31ed" />

## Testing

`yarn build` clean, `npm test` 35/35.

Verified in the browser rather than by eye — the type scale, switch label colour and weight, sidebar background and padding, dialog and section-gap dimensions were all read back from computed styles; the flash timing was sampled across its full 2s; the guard was exercised on every exit path; drag-reorder, the Incomplete badge, every disabled-button gate and every inline error were driven end-to-end (fill → error appears → fix → error clears, button revives).
