### PR TITLE
fix: limit wizard config keys, tighten admin defaults, drop sudo-password arg, block SSRF URLs

### DIFF
--- a/admin/backend/api/v1/setup/__init__.py
+++ b/admin/backend/api/v1/setup/__init__.py
@@ -7,6 +7,7 @@ from flask import Blueprint, current_app, g, jsonify, request
 from admin.backend.api.responses import accepted_task_response, error_response, no_content_response
 from admin.backend.api.v1.setup.config import (
     apply_existing_local_database,
+    filter_wizard_keys,
     read_defaults,
     validate_configuration,
 )
@@ -60,7 +61,7 @@ def update_configuration():
         return error_response("malformed_request", "Expected a JSON object.", 400)
 
     with exclusive_file_lock(bench_root / ".setup-configuration"):
-        return _update_configuration(bench_root, data)
+        return _update_configuration(bench_root, filter_wizard_keys(data))
 
 
 def _update_configuration(bench_root: Path, data: dict):

--- a/admin/backend/api/v1/setup/config.py
+++ b/admin/backend/api/v1/setup/config.py
@@ -11,6 +11,35 @@ from pilot.internal.validators import validate_branch_name, validate_repo_url
 _PASSWORD_KEYS = ("admin_password", "mariadb_password", "postgres_password")
 _DB_ENGINES = ("mariadb", "postgres")
 
+# Everything the setup wizard is allowed to write. It runs before authentication
+# (see allow_during_setup), so any other bench.toml key - admin.domain,
+# admin.allow_bench_management, admin.jwks_url, production settings, etc. - must
+# never reach write_flat from this endpoint.
+_ALLOWED_KEYS = frozenset(
+    {
+        "admin_password",
+        "app_repo",
+        "app_branch",
+        "db_type",
+        "db_mode",
+        "mariadb_admin_user",
+        "mariadb_existing",
+        "mariadb_host",
+        "mariadb_password",
+        "mariadb_port",
+        "postgres_admin_user",
+        "postgres_existing",
+        "postgres_host",
+        "postgres_password",
+        "postgres_port",
+    }
+)
+
+
+def filter_wizard_keys(data: dict) -> dict:
+    """Drop any key outside the wizard's own configuration schema."""
+    return {key: value for key, value in data.items() if key in _ALLOWED_KEYS}
+
 
 def validate_configuration(data: dict) -> str | None:
     if error := _validate_field_types(data):

--- a/install.sh
+++ b/install.sh
@@ -32,8 +32,6 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --user) BENCH_USER="$2"; shift 2 ;;
         --user=*) BENCH_USER="${1#*=}"; shift ;;
-        --sudo-password|--sudo-pass) SUDO_PASS="$2"; shift 2 ;;
-        --sudo-password=*|--sudo-pass=*) SUDO_PASS="${1#*=}"; shift ;;
         --dev) DEV_MODE=1; shift ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac

--- a/pilot/config/admin.py
+++ b/pilot/config/admin.py
@@ -1,6 +1,7 @@
 import re
 from dataclasses import dataclass, field
 
+from pilot import is_dev_build
 from pilot.exceptions import ConfigError
 
 _HOSTNAME_PATTERN = re.compile(
@@ -20,7 +21,9 @@ class AdminConfig:
     jwks_audience: str = ""
     domain: str = ""
     tls: bool = False
-    allow_bench_management: bool = True
+    # Off by default outside a --dev install: bench management exposes powerful,
+    # cross-bench operations and should be an explicit opt-in in production.
+    allow_bench_management: bool = field(default_factory=lambda: is_dev_build)
     # Break-glass codes for when no enrolled device is available. Stored in the clear so
     # an operator with server access can still read them; the API returns them only when
     # they are issued, never on demand.
@@ -38,7 +41,7 @@ class AdminConfig:
             jwks_audience=data.get("jwks_audience", ""),
             domain=data.get("domain", ""),
             tls=data.get("tls", False),
-            allow_bench_management=data.get("allow_bench_management", True),
+            allow_bench_management=data.get("allow_bench_management", is_dev_build),
             recovery_codes=list(data.get("recovery_codes", [])),
         )
 

--- a/pilot/config/llm.py
+++ b/pilot/config/llm.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from pilot.exceptions import ConfigError
+from pilot.internal.validators import validate_public_url
 
 
 @dataclass
@@ -22,3 +23,5 @@ class LLMConfig:
     def validate(self) -> None:
         if self.max_tokens <= 0:
             raise ConfigError("llm.max_tokens must be a positive integer.")
+        if error := validate_public_url(self.api_base):
+            raise ConfigError(f"llm.api_base: {error}")

--- a/pilot/integrations/llm/registry.py
+++ b/pilot/integrations/llm/registry.py
@@ -14,6 +14,7 @@ from pilot.integrations.llm.base import LLMIntegration
 from pilot.integrations.llm.frappe_llm import FrappeLLMIntegration
 from pilot.integrations.llm.lite import LiteLLMIntegration
 from pilot.integrations.llm.self_hosted import SelfHostedIntegration
+from pilot.internal.validators import validate_public_url
 
 if TYPE_CHECKING:
     from pilot.config.llm import LLMConfig
@@ -55,6 +56,8 @@ def models_for(provider: str, api_key: str = "", api_base: str = "") -> list[str
     """Selectable models for a provider (empty means free-text entry). Providers
     with `models_need_api_key` list models from their own API, so they need the key,
     and an `api_base` overrides wherever that provider defaults to."""
+    if error := validate_public_url(api_base):
+        raise ValueError(f"api_base: {error}")
     return _integration_for(provider).get_models(provider, api_key, api_base)
 
 

--- a/pilot/internal/validators.py
+++ b/pilot/internal/validators.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import ipaddress
 import re
+import urllib.parse
 
 _APP_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_\-]*$")
 _BRANCH_RE = re.compile(r"^[A-Za-z0-9._/\-]+$")
@@ -76,6 +78,31 @@ def validate_admin_password(password: str) -> str | None:
         return "Password must contain at least one number."
     if not _SYMBOL_RE.search(password):
         return "Password must contain at least one symbol."
+    return None
+
+
+def validate_public_url(url: str) -> str | None:
+    """Reject a non-http(s) URL or one targeting a literal loopback, link-local,
+    or reserved address (SSRF into cloud metadata or internal services). A
+    private DNS name (e.g. a docker-network service) still passes, since
+    resolving it here would make config validation depend on the network."""
+    if not url:
+        return None
+    parsed = urllib.parse.urlsplit(url)
+    if parsed.scheme not in ("http", "https"):
+        return "URL must start with http:// or https://."
+    hostname = parsed.hostname
+    if not hostname:
+        return "URL must include a host."
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        return None
+    # ponytail: literal-IP check only - a DNS name that resolves to one of these
+    # addresses at request time still gets through. Validate the resolved
+    # address at the HTTP client too (or pin it) if that gap matters.
+    if address.is_loopback or address.is_link_local or address.is_multicast or address.is_reserved or address.is_unspecified:
+        return f"URL must not point at {address} (a private or reserved network address)."
     return None
 
 

--- a/tests/admin/backend/api/test_setup_api.py
+++ b/tests/admin/backend/api/test_setup_api.py
@@ -90,6 +90,35 @@ def test_configuration_update_is_sanitized_and_preserves_unknown_keys(
     assert BenchConfig.read_raw(tmp_path)["plugin"] == {"custom_key": "custom-value"}
 
 
+def test_configuration_update_ignores_keys_outside_the_wizard_schema(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The wizard runs before authentication, so it must only ever be able to
+    write the handful of fields it actually asks for - not arbitrary bench.toml
+    settings like admin.allow_bench_management or admin.jwks_url."""
+    monkeypatch.setattr("pilot.config.admin.is_dev_build", True)
+    client = setup_client(tmp_path)
+
+    response = client.put(
+        "/api/v1/setup/configuration",
+        json={
+            "admin_password": "admin-secret",
+            "mariadb_password": "database-secret",
+            "admin_allow_bench_management": False,
+            "admin_domain": "attacker.example",
+            "admin_jwks_url": "http://169.254.169.254/jwks.json",
+            "production_process_manager": "supervisor",
+        },
+    )
+
+    assert response.status_code == 200
+    config = BenchConfig.read(tmp_path)
+    assert config.admin.allow_bench_management is True
+    assert config.admin.domain == ""
+    assert config.admin.jwks_url == ""
+    assert config.production.process_manager == ""
+
+
 def test_authenticated_reload_can_save_without_resending_secrets(tmp_path: Path) -> None:
     client = setup_client(tmp_path)
     assert save_configuration(client).status_code == 200

--- a/tests/admin/backend/test_admin_session.py
+++ b/tests/admin/backend/test_admin_session.py
@@ -172,9 +172,20 @@ def test_bootstrap_reports_postgres_engine(tmp_path: Path) -> None:
     assert app.test_client().get("/api/v1/bootstrap").get_json()["db_type"] == "postgres"
 
 
-def test_bootstrap_reports_allow_bench_management_default_true(tmp_path: Path) -> None:
+def test_bootstrap_reports_allow_bench_management_default_true_in_dev_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("pilot.config.admin.is_dev_build", True)
     client = _client(tmp_path)
     assert client.get("/api/v1/bootstrap").get_json()["allow_bench_management"] is True
+
+
+def test_bootstrap_reports_allow_bench_management_default_false_outside_dev_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("pilot.config.admin.is_dev_build", False)
+    client = _client(tmp_path)
+    assert client.get("/api/v1/bootstrap").get_json()["allow_bench_management"] is False
 
 
 def test_bootstrap_reports_allow_bench_management_when_disabled(tmp_path: Path) -> None:

--- a/tests/pilot/config/test_config.py
+++ b/tests/pilot/config/test_config.py
@@ -420,10 +420,20 @@ def test_admin_tls_roundtrip() -> None:
     assert "tls = false" in config.dumps()
 
 
-def test_admin_allow_bench_management_defaults_to_true() -> None:
+def test_admin_allow_bench_management_defaults_to_true_in_dev_build(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("pilot.config.admin.is_dev_build", True)
     config = load_from_dict(copy.deepcopy(MINIMAL_VALID_DATA))
     assert config.admin.allow_bench_management is True
     assert "allow_bench_management = true" in config.dumps()
+
+
+def test_admin_allow_bench_management_defaults_to_false_outside_dev_build(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("pilot.config.admin.is_dev_build", False)
+    config = load_from_dict(copy.deepcopy(MINIMAL_VALID_DATA))
+    assert config.admin.allow_bench_management is False
+    assert "allow_bench_management = false" in config.dumps()
 
 
 def test_admin_allow_bench_management_can_be_disabled() -> None:
@@ -432,6 +442,26 @@ def test_admin_allow_bench_management_can_be_disabled() -> None:
     config = load_from_dict(data)
     assert config.admin.allow_bench_management is False
     assert "allow_bench_management = false" in config.dumps()
+
+
+def test_llm_api_base_accepts_a_private_hostname() -> None:
+    from pilot.config.llm import LLMConfig
+
+    LLMConfig(provider="self-hosted", api_base="http://vllm:8000/v1").validate()
+
+
+def test_llm_api_base_rejects_loopback() -> None:
+    from pilot.config.llm import LLMConfig
+
+    with pytest.raises(ConfigError, match=r"llm\.api_base"):
+        LLMConfig(provider="self-hosted", api_base="http://127.0.0.1:8000/v1").validate()
+
+
+def test_llm_api_base_rejects_cloud_metadata_address() -> None:
+    from pilot.config.llm import LLMConfig
+
+    with pytest.raises(ConfigError, match=r"llm\.api_base"):
+        LLMConfig(provider="self-hosted", api_base="http://169.254.169.254/v1").validate()
 
 
 def test_admin_internal_port_is_port_plus_one() -> None:

--- a/tests/pilot/integrations/test_llm.py
+++ b/tests/pilot/integrations/test_llm.py
@@ -290,6 +290,11 @@ def test_registry_passes_key_through(monkeypatch: pytest.MonkeyPatch, fake_litel
     assert registry.models_for("frappe-llm", "sk-key", _FRAPPE_BASE) == ["qwen3.6-27b-fp8"]
 
 
+def test_registry_rejects_an_api_base_pointing_at_a_private_address() -> None:
+    with pytest.raises(ValueError, match="api_base"):
+        registry.models_for("frappe-llm", "sk-key", "http://169.254.169.254/v1")
+
+
 # -- response caching --------------------------------------------------------
 
 

--- a/tests/pilot/internal/test_validators.py
+++ b/tests/pilot/internal/test_validators.py
@@ -1,0 +1,46 @@
+"""Tests for pilot.internal.validators."""
+
+from __future__ import annotations
+
+from pilot.internal.validators import validate_public_url
+
+
+def test_public_url_accepts_a_dns_name() -> None:
+    assert validate_public_url("http://vllm:8000/v1") is None
+    assert validate_public_url("https://frappe-llm.example/v1") is None
+
+
+def test_public_url_accepts_a_routable_ip() -> None:
+    assert validate_public_url("http://8.8.8.8/v1") is None
+
+
+def test_public_url_accepts_a_private_lan_ip() -> None:
+    """Self-hosted integrations legitimately live on a private network."""
+    assert validate_public_url("http://192.168.1.50:8000/v1") is None
+
+
+def test_public_url_rejects_non_http_scheme() -> None:
+    assert validate_public_url("file:///etc/passwd") is not None
+    assert validate_public_url("ftp://example.com") is not None
+
+
+def test_public_url_rejects_a_url_without_a_host() -> None:
+    assert validate_public_url("http:///path") is not None
+
+
+def test_public_url_rejects_loopback() -> None:
+    assert validate_public_url("http://127.0.0.1:8000") is not None
+    assert validate_public_url("http://[::1]:8000") is not None
+
+
+def test_public_url_rejects_link_local_and_cloud_metadata() -> None:
+    assert validate_public_url("http://169.254.169.254/latest/meta-data/") is not None
+
+
+def test_public_url_rejects_unspecified_and_multicast() -> None:
+    assert validate_public_url("http://0.0.0.0:8000") is not None
+    assert validate_public_url("http://224.0.0.1:8000") is not None
+
+
+def test_public_url_allows_a_blank_value() -> None:
+    assert validate_public_url("") is None


### PR DESCRIPTION
## Summary

This PR fixes 4 issues.

- The setup wizard can now write only its own fields. Before this fix, the wizard could write any bench.toml key. This included admin.allow_bench_management and admin.jwks_url. The wizard runs before login. This was a security risk.
- `admin.allow_bench_management` now defaults to `False`. It defaults to `True` only for a `--dev` install. This setting turns on strong bench management actions. It should not turn on by default.
- The `--sudo-password` / `--sudo-pass` install.sh argument is removed. It had no real use. You can still set `SUDO_PASS` as an environment variable for unattended installs.
- `llm.api_base` is now checked for SSRF. The check blocks URLs that point at loopback, link-local, or other reserved addresses (for example, cloud metadata endpoints). The check allows private DNS names, so self-hosted LLM setups still work.

Note: `s3` and the GitHub integration do not have a free-text endpoint field in this codebase today. The S3 endpoint comes from a fixed template. The GitHub API base is a fixed constant. So no SSRF fix was needed for those two.

## Test plan

- [x] `uv run ruff check admin pilot tests`
- [x] `uv run pytest` (2140 passed)
- [x] Added tests for the new wizard key filter, the new default, and the new URL check

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>