### PR TITLE
Updates page redesign

### DIFF
--- a/admin/backend/api/v1/migrations.py
+++ b/admin/backend/api/v1/migrations.py
@@ -13,7 +13,8 @@ from admin.backend.api.responses import (
 from admin.backend.api.v1.sites.shared import task_failure
 from pilot.core.bench import Bench
 from pilot.core.bench.migration.operation import MigrationOperation
-from pilot.exceptions import MigrationNotFoundError
+from pilot.exceptions import MigrationNotFoundError, TaskNotFoundError
+from pilot.internal.tasks.store import TaskStore
 from pilot.managers.task import TaskReader
 from pilot.tasks.bypass_patch import BypassPatchTask
 from pilot.tasks.retry_update import RetryUpdateTask
@@ -62,9 +63,10 @@ _CHAIN_LABELS = {
 
 
 def _task_logs(operation: MigrationOperation) -> list[dict]:
-    """Retained chain-task logs as a flat list, with attempt numbers."""
+    """Retained chain-task logs as a flat list, with attempt numbers and status."""
     logs: list[dict] = []
     attempts: dict[tuple, int] = {}
+    store = TaskStore(operation.bench.path)
     for record in operation.chain:
         base = _CHAIN_LABELS.get(record.get("command", ""))
         task_id = record.get("task_id")
@@ -76,8 +78,19 @@ def _task_logs(operation: MigrationOperation) -> list[dict]:
         key = (record["command"], site)
         attempts[key] = attempts.get(key, 0) + 1
         label = base if attempts[key] == 1 else f"{base} (attempt {attempts[key]})"
-        logs.append({"id": task_id, "label": label, "site": site})
+        logs.append(
+            {"id": task_id, "label": label, "site": site, "status": _task_status(store, task_id)}
+        )
     return logs
+
+
+def _task_status(store: TaskStore, task_id: str) -> str | None:
+    """Status file only: TaskReader.read_task also walks the queue for a position
+    this list never shows. None once the task is no longer readable."""
+    try:
+        return store.read_status(task_id).value
+    except (TaskNotFoundError, FileNotFoundError):
+        return None
 
 
 def _accepted(operation: MigrationOperation, task_id: str):

--- a/admin/frontend/dashboard/src/api/updates.js
+++ b/admin/frontend/dashboard/src/api/updates.js
@@ -1,3 +1,4 @@
+import { ACTIVE_STATES, ATTENTION_STATES } from '../utils/updateFormat.js'
 import { request } from './client'
 
 export const updatesApi = {
@@ -10,18 +11,6 @@ export const updatesApi = {
   bypassPatch: (id, patch) =>
     request.post(`migrations/${id}/actions/bypass-patch`, { json: { patch } }).json(),
 }
-
-export const ACTIVE_STATES = [
-  'preparing',
-  'backing_up',
-  'updating',
-  'migrating',
-  'retrying',
-  'reverting_apps',
-  'reverting_sites',
-  'restarting',
-]
-export const ATTENTION_STATES = ['needs_attention', 'revert_failed']
 
 export function isResolved(operation) {
   return !operation || operation.state === 'completed' || operation.state === 'reverted'

--- a/admin/frontend/dashboard/src/components/common/StatusListView.vue
+++ b/admin/frontend/dashboard/src/components/common/StatusListView.vue
@@ -1,0 +1,40 @@
+<template>
+  <!-- ListRow's own hover paints surface-sidebar, transparent in the dark
+       theme. Rows are links, hence the descendant selector. -->
+  <ListView
+    class="[&_a:hover]:bg-surface-gray-1"
+    :columns="columns"
+    :rows="rows"
+    row-key="id"
+    :options="{ selectable: false, showTooltip: true, getRowRoute }"
+  >
+    <template #cell="{ column, row, item }">
+      <!-- Keyed on the column, not on the badge: a row without one still has to
+           reach this branch, or it falls through to ListRowItem and renders a
+           null. Hidden rather than dropped for the same reason. -->
+      <Badge
+        v-if="column.key === 'badge'"
+        v-show="row.badge"
+        :label="row.badge?.label"
+        :theme="row.badge?.theme"
+        variant="subtle"
+      />
+      <ListRowItem v-else :column="column" :row="row" :item="item" :align="column.align" />
+    </template>
+  </ListView>
+</template>
+
+<script setup>
+import { Badge, ListRowItem, ListView } from 'frappe-ui'
+
+/**
+ * A ListView whose `badge` column renders a Badge and whose other columns
+ * render as text. Rows need an `id` and, where the badge shows, a `badge` of
+ * `{ label, theme }` or null.
+ */
+defineProps({
+  columns: { type: Array, required: true },
+  rows: { type: Array, required: true },
+  getRowRoute: { type: Function, required: true },
+})
+</script>

--- a/admin/frontend/dashboard/src/components/navigation/list.ts
+++ b/admin/frontend/dashboard/src/components/navigation/list.ts
@@ -11,8 +11,8 @@ export const sidebarSections = [
     items: [
       { label: 'Analytics', icon: 'lucide-chart-line', to: '/insights/analytics' },
       { label: 'Updates', icon: 'lucide-git-pull-request-arrow', to: '/updates' },
-      { label: 'Logs', icon: 'lucide-scroll-text', to: '/insights/logs' },
       { label: 'Tasks', icon: 'lucide-list-checks', to: '/insights/tasks' },
+      { label: 'Logs', icon: 'lucide-scroll-text', to: '/insights/logs' },
     ],
   },
   {

--- a/admin/frontend/dashboard/src/components/tasks/TaskStep.vue
+++ b/admin/frontend/dashboard/src/components/tasks/TaskStep.vue
@@ -27,13 +27,8 @@
         :class="[hasOutput ? '' : 'invisible', expanded ? 'rotate-180' : '']"
       />
     </div>
-    <LogView
-      v-if="expanded && hasOutput"
-      class="mt-1"
-      :lines="lines"
-      :streaming="streaming"
-      :rounded="false"
-    />
+    <!-- The step list insets this by p-1, so its rounding never reaches here. -->
+    <LogView v-if="expanded && hasOutput" class="mt-1" :lines="lines" :streaming="streaming" />
   </div>
 </template>
 

--- a/admin/frontend/dashboard/src/components/tasks/TaskStep.vue
+++ b/admin/frontend/dashboard/src/components/tasks/TaskStep.vue
@@ -5,9 +5,9 @@
       :class="hasOutput ? 'cursor-pointer hover:bg-surface-gray-1' : ''"
       @click="toggle"
     >
-      <span class="place-items-center grid rounded size-6 shrink-0" :class="iconBg">
+      <span class="place-items-center grid rounded-full size-6 shrink-0" :class="iconBg">
         <span v-if="status === 'done'" class="size-3.5 lucide-check" />
-        <span v-else-if="status === 'running'" class="size-3.5 animate-spin lucide-loader-circle" />
+        <Spinner v-else-if="status === 'running'" size="sm" />
         <span v-else-if="status === 'failed'" class="size-3.5 lucide-x" />
         <span v-else class="bg-ink-gray-3 rounded-full size-1.5" />
       </span>
@@ -39,6 +39,7 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
+import { Spinner } from 'frappe-ui'
 import LogView from '../logs/LogView.vue'
 
 const props = defineProps({

--- a/admin/frontend/dashboard/src/components/tasks/TaskSteps.vue
+++ b/admin/frontend/dashboard/src/components/tasks/TaskSteps.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="hasSteps"
-    class="flex flex-col gap-1 p-1.5 border border-outline-gray-2 rounded-lg min-w-0"
+    class="flex flex-col gap-1 p-1 border border-outline-gray-2 rounded-lg min-w-0"
   >
     <TaskStep
       v-for="section in stepSections"

--- a/admin/frontend/dashboard/src/components/updates/JobRow.vue
+++ b/admin/frontend/dashboard/src/components/updates/JobRow.vue
@@ -1,0 +1,23 @@
+<template>
+  <button
+    type="button"
+    class="flex items-center gap-1.5 px-2.5 py-2 rounded transition-colors w-full hover:bg-surface-gray-1 text-sm text-left"
+    :class="failed ? 'text-ink-red-7' : 'text-ink-gray-7'"
+  >
+    <span
+      class="size-4 shrink-0"
+      :class="failed ? 'lucide-circle-x' : 'lucide-square-terminal'"
+    />
+    {{ job.label }}
+  </button>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({ job: { type: Object, required: true } })
+
+// A retried step leaves several jobs behind, so only the one that broke the chain
+// earns colour. Killing a migrate mid-run stops the update just as a crash does.
+const failed = computed(() => ['failed', 'killed'].includes(props.job.status))
+</script>

--- a/admin/frontend/dashboard/src/components/updates/UpdateSection.vue
+++ b/admin/frontend/dashboard/src/components/updates/UpdateSection.vue
@@ -10,6 +10,7 @@
       <div class="flex items-center gap-2">
         <span class="size-4 text-ink-gray-5 shrink-0" :class="icon" />
         <h2 class="text-base font-medium text-ink-gray-8">{{ title }}</h2>
+        <Badge :label="count" theme="gray" variant="subtle" size="sm" />
       </div>
       <span
         class="size-4 text-ink-gray-5 transition-transform group-open/section:rotate-180 lucide-chevron-down"
@@ -21,9 +22,13 @@
 </template>
 
 <script setup>
+import { Badge } from 'frappe-ui'
+
 defineProps({
   icon: { type: String, required: true },
   title: { type: String, required: true },
+  // A string too: an unresolved multi-site update counts as "2/5".
+  count: { type: [Number, String], required: true },
   open: { type: Boolean, default: true },
 })
 

--- a/admin/frontend/dashboard/src/components/updates/UpdateSection.vue
+++ b/admin/frontend/dashboard/src/components/updates/UpdateSection.vue
@@ -1,0 +1,31 @@
+<template>
+  <details
+    :open="open"
+    class="group/section rounded-lg border border-outline-gray-2 p-1"
+    @toggle="$emit('update:open', $event.target.open)"
+  >
+    <summary
+      class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
+    >
+      <div class="flex items-center gap-2">
+        <span class="size-4 text-ink-gray-5 shrink-0" :class="icon" />
+        <h2 class="text-base font-medium text-ink-gray-8">{{ title }}</h2>
+      </div>
+      <span
+        class="size-4 text-ink-gray-5 transition-transform group-open/section:rotate-180 lucide-chevron-down"
+      />
+    </summary>
+
+    <div><slot /></div>
+  </details>
+</template>
+
+<script setup>
+defineProps({
+  icon: { type: String, required: true },
+  title: { type: String, required: true },
+  open: { type: Boolean, default: true },
+})
+
+defineEmits(['update:open'])
+</script>

--- a/admin/frontend/dashboard/src/layouts/MainLayout.vue
+++ b/admin/frontend/dashboard/src/layouts/MainLayout.vue
@@ -92,7 +92,7 @@ function breadcrumbsFromRouteMeta({ title = '' }) {
 
         <div id="header-badge" class="flex items-center" />
         <div id="header-actions" class="flex items-center gap-2 ml-auto">
-          <UpdateStatusButton v-if="route.name !== 'SiteDetail'" />
+          <UpdateStatusButton v-if="!['SiteDetail', 'UpdateDetail'].includes(route.name)" />
         </div>
       </div>
     </header>
@@ -133,7 +133,8 @@ function breadcrumbsFromRouteMeta({ title = '' }) {
           <Breadcrumbs :items="breadcrumbs" />
           <div id="header-badge" class="flex items-center" />
           <div id="header-actions" class="flex items-center gap-2 ml-auto">
-            <UpdateStatusButton />
+            <!-- Its own page already states the update's status twice over. -->
+            <UpdateStatusButton v-if="route.name !== 'UpdateDetail'" />
           </div>
         </div>
       </div>

--- a/admin/frontend/dashboard/src/layouts/MainLayout.vue
+++ b/admin/frontend/dashboard/src/layouts/MainLayout.vue
@@ -133,7 +133,6 @@ function breadcrumbsFromRouteMeta({ title = '' }) {
           <Breadcrumbs :items="breadcrumbs" />
           <div id="header-badge" class="flex items-center" />
           <div id="header-actions" class="flex items-center gap-2 ml-auto">
-            <!-- Its own page already states the update's status twice over. -->
             <UpdateStatusButton v-if="route.name !== 'UpdateDetail'" />
           </div>
         </div>

--- a/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
+++ b/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
@@ -101,9 +101,8 @@ import {
   isTaskActive,
   isTaskCancellable,
   redirectRouteOnSuccess,
-  siteLabel,
-  siteRoute,
   statusConfig,
+  taskScope,
 } from '@/utils/taskFormat'
 
 const route = useRoute()
@@ -139,12 +138,7 @@ async function loadAiStatus() {
   }
 }
 
-// What the task ran against. A bench-level task has no site; it belongs to the server.
-const scope = computed(() => {
-  const label = siteLabel(task.value)
-  if (label === 'Server-level') return { label: 'Server', route: { name: 'Server' } }
-  return { label, route: siteRoute(task.value) }
-})
+const scope = computed(() => taskScope(task.value))
 
 const metaLine = computed(() => {
   const parts = []

--- a/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
+++ b/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
@@ -53,18 +53,14 @@
 
     <div class="flex justify-between items-center gap-4 mt-5 px-2 min-w-0">
       <RouterLink
-        v-if="site?.route"
-        :to="site.route"
+        :to="scope.route"
         class="group flex items-center gap-1 min-w-0 font-medium text-ink-gray-9 text-lg no-underline"
       >
-        <span class="truncate">{{ site.label }}</span>
+        <span class="truncate">{{ scope.label }}</span>
         <span
           class="opacity-0 group-hover:opacity-100 size-4 text-ink-gray-5 transition-opacity shrink-0 lucide-arrow-up-right"
         />
       </RouterLink>
-      <p v-else-if="site" class="min-w-0 font-medium text-ink-gray-9 text-lg truncate">
-        {{ site.label }}
-      </p>
       <p class="text-ink-gray-8 text-base shrink-0">{{ metaLine }}</p>
     </div>
 
@@ -143,9 +139,10 @@ async function loadAiStatus() {
   }
 }
 
-const site = computed(() => {
+// What the task ran against. A bench-level task has no site; it belongs to the server.
+const scope = computed(() => {
   const label = siteLabel(task.value)
-  if (label === 'Server-level') return null
+  if (label === 'Server-level') return { label: 'Server', route: { name: 'Server' } }
   return { label, route: siteRoute(task.value) }
 })
 

--- a/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
+++ b/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
@@ -51,7 +51,7 @@
 
     <TaskDebugDialog v-model="showDebug" :task-id="taskId" />
 
-    <div class="flex justify-between items-center gap-4 px-2 min-w-0">
+    <div class="flex justify-between items-center gap-4 mt-5 px-2 min-w-0">
       <RouterLink
         v-if="site?.route"
         :to="site.route"
@@ -71,7 +71,7 @@
     <ErrorMessage v-if="actionError" :message="actionError" class="mt-3" />
 
     <!-- Steps -->
-    <div class="mt-4">
+    <div class="mt-3">
       <TaskStream
         v-if="isTaskActive(task)"
         :url="tasksApi.streamUrl(taskId)"

--- a/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
+++ b/admin/frontend/dashboard/src/pages/tasks/TaskDetail.vue
@@ -51,24 +51,21 @@
 
     <TaskDebugDialog v-model="showDebug" :task-id="taskId" />
 
-    <div
-      class="gap-4 grid grid-cols-2"
-      :class="metadata.length > 3 ? 'sm:grid-cols-4' : 'sm:grid-cols-3'"
-    >
-      <div v-for="item in metadata" :key="item.label" class="min-w-0">
-        <p class="text-ink-gray-5 text-sm">{{ item.label }}</p>
-        <RouterLink
-          v-if="item.route"
-          :to="item.route"
-          class="group flex items-center gap-1 mt-1 min-w-0 text-ink-gray-8 text-base no-underline"
-        >
-          <span class="truncate">{{ item.value }}</span>
-          <span
-            class="opacity-0 group-hover:opacity-100 size-3.5 text-ink-gray-5 transition-opacity shrink-0 lucide-arrow-up-right"
-          />
-        </RouterLink>
-        <p v-else class="mt-1 text-ink-gray-8 text-base truncate">{{ item.value }}</p>
-      </div>
+    <div class="flex justify-between items-center gap-4 px-2 min-w-0">
+      <RouterLink
+        v-if="site?.route"
+        :to="site.route"
+        class="group flex items-center gap-1 min-w-0 font-medium text-ink-gray-9 text-lg no-underline"
+      >
+        <span class="truncate">{{ site.label }}</span>
+        <span
+          class="opacity-0 group-hover:opacity-100 size-4 text-ink-gray-5 transition-opacity shrink-0 lucide-arrow-up-right"
+        />
+      </RouterLink>
+      <p v-else-if="site" class="min-w-0 font-medium text-ink-gray-9 text-lg truncate">
+        {{ site.label }}
+      </p>
+      <p class="text-ink-gray-8 text-base shrink-0">{{ metaLine }}</p>
     </div>
 
     <ErrorMessage v-if="actionError" :message="actionError" class="mt-3" />
@@ -146,23 +143,20 @@ async function loadAiStatus() {
   }
 }
 
-const metadata = computed(() => {
-  const items = [
-    { label: 'Started', value: fmtDateTime(task.value.started_at) },
-    {
-      label: 'Finished',
-      value: task.value.finished_at ? fmtDateTime(task.value.finished_at) : '-',
-    },
-    { label: 'Duration', value: fmtDuration(task.value.duration_seconds) || '-' },
-  ]
-  if (task.value.status === 'queued' && task.value.queue_position) {
-    items.unshift({ label: 'Queue position', value: `#${task.value.queue_position}` })
-  }
-  const site = siteLabel(task.value)
-  if (site !== 'Server-level') {
-    items.unshift({ label: 'Site', value: site, route: siteRoute(task.value) })
-  }
-  return items
+const site = computed(() => {
+  const label = siteLabel(task.value)
+  if (label === 'Server-level') return null
+  return { label, route: siteRoute(task.value) }
+})
+
+const metaLine = computed(() => {
+  const parts = []
+  if (task.value.status === 'queued' && task.value.queue_position)
+    parts.push(`#${task.value.queue_position} in queue`)
+  if (task.value.started_at) parts.push(`Started ${fmtDateTime(task.value.started_at)}`)
+  const duration = fmtDuration(task.value.duration_seconds)
+  if (duration) parts.push(`took ${duration}`)
+  return parts.join(' · ')
 })
 
 function updateStatus(event) {

--- a/admin/frontend/dashboard/src/pages/tasks/Tasks.vue
+++ b/admin/frontend/dashboard/src/pages/tasks/Tasks.vue
@@ -57,28 +57,13 @@
       <ErrorMessage :message="error" />
     </div>
 
-    <!-- ListRow's own hover paints surface-sidebar, transparent in the dark
-         theme. Rows are links, hence the descendant selector. -->
-    <ListView
+    <StatusListView
       v-else-if="rows.length"
-      class="mt-4 [&_a:hover]:bg-surface-gray-1"
+      class="mt-4"
       :columns="columns"
       :rows="rows"
-      row-key="id"
-      :options="{ selectable: false, showTooltip: true, getRowRoute }"
-    >
-      <template #cell="{ column, row, item }">
-        <!-- Success is the norm; only exceptional states get a badge. -->
-        <Badge
-          v-if="column.key === 'badge'"
-          v-show="row.badge"
-          :label="row.badge?.label"
-          :theme="row.badge?.theme"
-          variant="subtle"
-        />
-        <ListRowItem v-else :column="column" :row="row" :item="item" :align="column.align" />
-      </template>
-    </ListView>
+      :get-row-route="getRowRoute"
+    />
 
     <EmptyState
       v-else
@@ -97,9 +82,10 @@
 <script setup>
 import { computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { Badge, Button, Dropdown, ErrorMessage, ListRowItem, ListView, TabButtons } from 'frappe-ui'
+import { Button, Dropdown, ErrorMessage, TabButtons } from 'frappe-ui'
 import EmptyState from '@/components/common/EmptyState.vue'
 import ListRowSkeleton from '@/components/common/ListRowSkeleton.vue'
+import StatusListView from '@/components/common/StatusListView.vue'
 import StickyToolbar from '@/components/common/StickyToolbar.vue'
 import { useIsMobile } from '@/composables/common/useIsMobile'
 import { useTasks } from '@/composables/tasks/useTasks'

--- a/admin/frontend/dashboard/src/pages/tasks/Tasks.vue
+++ b/admin/frontend/dashboard/src/pages/tasks/Tasks.vue
@@ -57,51 +57,32 @@
       <ErrorMessage :message="error" />
     </div>
 
-    <div
-      v-else-if="visibleTasks.length"
-      class="flex flex-col -mx-3 mt-4 divide-y divide-outline-gray-1"
+    <!-- ListRow's own hover paints surface-sidebar, transparent in the dark
+         theme. Rows are links, hence the descendant selector. -->
+    <ListView
+      v-else-if="rows.length"
+      class="mt-4 [&_a:hover]:bg-surface-gray-1"
+      :columns="columns"
+      :rows="rows"
+      row-key="id"
+      :options="{ selectable: false, showTooltip: true, getRowRoute }"
     >
-      <RouterLink
-        v-for="task in visibleTasks"
-        :key="task.task_id"
-        :to="taskDetailRoute(task.task_id)"
-        class="items-center gap-3 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] hover:bg-surface-gray-1 px-3 py-2.5 rounded no-underline transition-colors"
-      >
-        <div class="min-w-0">
-          <!-- truncate is inert on inline boxes. -->
-          <p class="font-medium text-ink-gray-9 text-base truncate">
-            {{ commandLabel(task.command) }}
-          </p>
-          <p class="mt-0.5 text-ink-gray-6 text-p-sm truncate">
-            {{ siteLabel(task) }}
-            <template v-if="task.status === 'queued' && task.queue_position">
-              · #{{ task.queue_position }} in queue</template
-            >
-          </p>
-        </div>
-
+      <template #cell="{ column, row, item }">
         <!-- Success is the norm; only exceptional states get a badge. -->
         <Badge
-          v-if="task.status !== 'success'"
-          :label="statusConfig(task).label"
-          :theme="statusConfig(task).theme"
+          v-if="column.key === 'badge'"
+          v-show="row.badge"
+          :label="row.badge?.label"
+          :theme="row.badge?.theme"
           variant="subtle"
         />
-        <span v-else />
-        <div class="flex justify-end items-center gap-3 min-w-0">
-          <span class="text-ink-gray-6 text-sm truncate">
-            <template v-if="task.status !== 'queued' && fmtDuration(task.duration_seconds)"
-              >took {{ fmtDuration(task.duration_seconds) }} · </template
-            >{{ relativeTime(task.started_at || task.queued_at) }}
-          </span>
-          <span class="lucide-chevron-right size-4 text-ink-gray-6 shrink-0" />
-        </div>
-      </RouterLink>
-    </div>
+        <ListRowItem v-else :column="column" :row="row" :item="item" :align="column.align" />
+      </template>
+    </ListView>
 
     <EmptyState
       v-else
-      class="mt-4"
+      class="mt-8"
       icon="lucide-list-checks"
       :title="isFiltered ? 'No matching tasks' : 'No tasks yet'"
       :description="
@@ -116,7 +97,7 @@
 <script setup>
 import { computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { Badge, Button, Dropdown, ErrorMessage, TabButtons } from 'frappe-ui'
+import { Badge, Button, Dropdown, ErrorMessage, ListRowItem, ListView, TabButtons } from 'frappe-ui'
 import EmptyState from '@/components/common/EmptyState.vue'
 import ListRowSkeleton from '@/components/common/ListRowSkeleton.vue'
 import StickyToolbar from '@/components/common/StickyToolbar.vue'
@@ -124,11 +105,10 @@ import { useIsMobile } from '@/composables/common/useIsMobile'
 import { useTasks } from '@/composables/tasks/useTasks'
 import {
   commandLabel,
-  fmtDuration,
-  relativeTime,
   siteLabel,
   statusConfig,
   TASK_TYPES,
+  taskTiming,
   taskType,
 } from '@/utils/taskFormat'
 import { taskDetailRoute } from '@/utils/taskRoute'
@@ -162,6 +142,28 @@ const visibleTasks = computed(() =>
       (!typeFilter.value || taskType(task) === typeFilter.value),
   ),
 )
+
+// Numeric widths are fr units (ListView convention) so the columns stretch to
+// fill the row instead of leaving dead space.
+const columns = [
+  { label: 'Task', key: 'title', align: 'left', width: 2 },
+  { label: 'Site', key: 'site', align: 'left', width: 2 },
+  { label: 'Status', key: 'badge', align: 'left', width: 1.5 },
+  { label: 'Last run', key: 'timing', align: 'right', width: 2 },
+]
+
+// ListRowItem reads row[column.key], so each task is flattened to what renders.
+const rows = computed(() =>
+  visibleTasks.value.map((task) => ({
+    id: task.task_id,
+    title: commandLabel(task.command),
+    site: siteLabel(task),
+    badge: task.status === 'success' ? null : statusConfig(task),
+    timing: taskTiming(task),
+  })),
+)
+
+const getRowRoute = (row) => taskDetailRoute(row.id)
 
 // "Other" is a fallback for unknown commands; listed only once one exists.
 const typeMenu = computed(() => {

--- a/admin/frontend/dashboard/src/pages/tasks/Tasks.vue
+++ b/admin/frontend/dashboard/src/pages/tasks/Tasks.vue
@@ -65,16 +65,9 @@
         v-for="task in visibleTasks"
         :key="task.task_id"
         :to="taskDetailRoute(task.task_id)"
-        class="flex items-center gap-3 hover:bg-surface-gray-1 px-3 py-2.5 rounded no-underline transition-colors"
+        class="items-center gap-3 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] hover:bg-surface-gray-1 px-3 py-2.5 rounded no-underline transition-colors"
       >
-        <span
-          class="place-items-center grid rounded size-6 shrink-0"
-          :class="statusConfig(task).iconBg"
-        >
-          <span class="size-3.5" :class="statusConfig(task).icon" />
-        </span>
-
-        <div class="flex-1 min-w-0">
+        <div class="min-w-0">
           <!-- truncate is inert on inline boxes. -->
           <p class="font-medium text-ink-gray-9 text-base truncate">
             {{ commandLabel(task.command) }}
@@ -87,12 +80,22 @@
           </p>
         </div>
 
-        <span class="text-ink-gray-6 text-sm shrink-0">
-          <template v-if="task.status !== 'queued' && fmtDuration(task.duration_seconds)"
-            >took {{ fmtDuration(task.duration_seconds) }} · </template
-          >{{ relativeTime(task.started_at || task.queued_at) }}
-        </span>
-        <span class="lucide-chevron-right size-4 text-ink-gray-6 shrink-0" />
+        <!-- Success is the norm; only exceptional states get a badge. -->
+        <Badge
+          v-if="task.status !== 'success'"
+          :label="statusConfig(task).label"
+          :theme="statusConfig(task).theme"
+          variant="subtle"
+        />
+        <span v-else />
+        <div class="flex justify-end items-center gap-3 min-w-0">
+          <span class="text-ink-gray-6 text-sm truncate">
+            <template v-if="task.status !== 'queued' && fmtDuration(task.duration_seconds)"
+              >took {{ fmtDuration(task.duration_seconds) }} · </template
+            >{{ relativeTime(task.started_at || task.queued_at) }}
+          </span>
+          <span class="lucide-chevron-right size-4 text-ink-gray-6 shrink-0" />
+        </div>
       </RouterLink>
     </div>
 
@@ -113,7 +116,7 @@
 <script setup>
 import { computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { Button, Dropdown, ErrorMessage, TabButtons } from 'frappe-ui'
+import { Badge, Button, Dropdown, ErrorMessage, TabButtons } from 'frappe-ui'
 import EmptyState from '@/components/common/EmptyState.vue'
 import ListRowSkeleton from '@/components/common/ListRowSkeleton.vue'
 import StickyToolbar from '@/components/common/StickyToolbar.vue'

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -320,7 +320,7 @@
             <code class="rounded bg-surface-gray-2 px-1 font-mono">{{ op.diagnosis?.patch }}</code>
             as completed for
             <b class="text-ink-gray-9">{{ op.failed_site }}</b> without running it. This cannot be
-            undone. Retry the update afterwards to continue.
+            undone, and the migration carries on from where it stopped.
           </p>
         </template>
         <template #actions>

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -156,9 +156,12 @@
           <summary
             class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
           >
-            <h2 class="text-base font-medium text-ink-gray-8">
-              Target apps ({{ op.apps.length }})
-            </h2>
+            <div class="flex items-center gap-2">
+              <span class="size-4 text-ink-gray-5 shrink-0 lucide-box" />
+              <h2 class="text-base font-medium text-ink-gray-8">
+                Target apps ({{ op.apps.length }})
+              </h2>
+            </div>
             <span
               class="size-4 text-ink-gray-5 transition-transform group-open/apps:rotate-180 lucide-chevron-down"
             />
@@ -172,7 +175,7 @@
             >
               <div class="flex items-center gap-2 min-w-0 flex-1">
                 <AppIcon :name="app.name" class="!rounded-sm size-5" initial-class="text-xs" />
-                <p class="min-w-0 truncate font-medium text-ink-gray-9 text-base">
+                <p class="min-w-0 truncate text-ink-gray-9 text-base">
                   {{ app.name }}
                 </p>
               </div>
@@ -211,7 +214,12 @@
           <summary
             class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
           >
-            <h2 class="text-base font-medium text-ink-gray-8">Server ({{ serverJobs.length }})</h2>
+            <div class="flex items-center gap-2">
+              <span class="size-4 text-ink-gray-5 shrink-0 lucide-server" />
+              <h2 class="text-base font-medium text-ink-gray-8">
+                Server ({{ serverJobs.length }})
+              </h2>
+            </div>
             <span
               class="size-4 text-ink-gray-5 transition-transform group-open/server:rotate-180 lucide-chevron-down"
             />
@@ -237,7 +245,10 @@
           <summary
             class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
           >
-            <h2 class="text-base font-medium text-ink-gray-8">Sites ({{ sitesCount }})</h2>
+            <div class="flex items-center gap-2">
+              <span class="size-4 text-ink-gray-5 shrink-0 lucide-globe" />
+              <h2 class="text-base font-medium text-ink-gray-8">Sites ({{ sitesCount }})</h2>
+            </div>
             <span
               class="size-4 text-ink-gray-5 transition-transform group-open/sites:rotate-180 lucide-chevron-down"
             />
@@ -258,7 +269,7 @@
                     expandedSites.has(site.name) ? 'rotate-90' : '',
                   ]"
                 />
-                <p class="flex-1 min-w-0 font-medium text-ink-gray-9 text-base truncate">
+                <p class="flex-1 min-w-0 text-ink-gray-9 text-base truncate">
                   {{ site.name }}
                 </p>
                 <span
@@ -295,9 +306,12 @@
         <summary
           class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
         >
-          <h2 class="text-base font-medium text-ink-gray-8">
-            Skipped patches ({{ op.decisions.length }})
-          </h2>
+          <div class="flex items-center gap-2">
+            <span class="size-4 text-ink-gray-5 shrink-0 lucide-skip-forward" />
+            <h2 class="text-base font-medium text-ink-gray-8">
+              Skipped patches ({{ op.decisions.length }})
+            </h2>
+          </div>
           <span
             class="size-4 text-ink-gray-5 transition-transform group-open/decisions:rotate-180 lucide-chevron-down"
           />

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -49,7 +49,8 @@
             :key="job.id"
             variant="ghost"
             size="sm"
-            icon-left="lucide-square-terminal"
+            :theme="isJobFailed(job) ? 'red' : 'gray'"
+            :icon-left="isJobFailed(job) ? 'lucide-circle-x' : 'lucide-square-terminal'"
             @click="openTaskLog(job)"
           >
             {{ job.label }}
@@ -263,10 +264,14 @@
                   v-for="job in siteJobs(site.name)"
                   :key="job.id"
                   type="button"
-                  class="flex items-center gap-1.5 px-1.5 py-1.5 rounded transition-colors w-full text-ink-gray-7 hover:bg-surface-gray-1 text-sm text-left"
+                  class="flex items-center gap-1.5 px-1.5 py-1.5 rounded transition-colors w-full hover:bg-surface-gray-1 text-sm text-left"
+                  :class="isJobFailed(job) ? 'text-ink-red-7' : 'text-ink-gray-7'"
                   @click="openTaskLog(job)"
                 >
-                  <span class="lucide-square-terminal size-4 shrink-0" />
+                  <span
+                    class="size-4 shrink-0"
+                    :class="isJobFailed(job) ? 'lucide-circle-x' : 'lucide-square-terminal'"
+                  />
                   {{ job.label }}
                 </button>
               </div>
@@ -396,6 +401,10 @@ const durationSeconds = computed(() => {
 
 // Bench-wide chain tasks (update, revert apps, restart); site-bound ones live in the site tree.
 const serverJobs = computed(() => (op.value?.task_logs || []).filter((log) => !log.site))
+
+// A retried step leaves several jobs behind, so only the one that broke the chain
+// earns colour. Killing a migrate mid-run stops the update just as a crash does.
+const isJobFailed = (job) => job.status === 'failed' || job.status === 'killed'
 
 const alertTitle = computed(() =>
   op.value?.state === 'revert_failed' ? 'Restore failed' : 'This update needs attention',

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -165,7 +165,7 @@
           @toggle="appsOpen = $event.target.open"
         >
           <summary
-            class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-2"
+            class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
           >
             <h2 class="text-base font-medium text-ink-gray-8">
               Target apps ({{ op.apps.length }})
@@ -220,7 +220,7 @@
           @toggle="sitesOpen = $event.target.open"
         >
           <summary
-            class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-2"
+            class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
           >
             <h2 class="text-base font-medium text-ink-gray-8">Sites ({{ sitesCount }})</h2>
             <span
@@ -271,7 +271,7 @@
         class="group/decisions mt-2 rounded-lg border border-outline-gray-2 p-1.5"
       >
         <summary
-          class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-2"
+          class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
         >
           <h2 class="text-base font-medium text-ink-gray-8">
             Skipped patches ({{ op.decisions.length }})

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -122,6 +122,7 @@
             <Button
               v-if="op.state === 'needs_attention' && op.diagnosis?.patch && !patchAlreadySkipped"
               variant="subtle"
+              theme="red"
               :loading="acting"
               @click="confirmSkip = true"
             >
@@ -237,13 +238,22 @@
 
           <div>
             <div v-for="site in op.sites" :key="site.name">
-              <div class="flex items-center gap-3 px-2.5 py-2">
-                <RouterLink
-                  :to="{ name: 'SiteDetail', params: { name: site.name } }"
-                  class="flex-1 min-w-0 font-medium text-ink-gray-9 text-base truncate no-underline hover:text-ink-gray-7"
-                >
+              <div
+                class="flex items-center gap-2 px-2.5 py-2 rounded transition-colors"
+                :class="siteJobs(site.name).length ? 'cursor-pointer hover:bg-surface-gray-1' : ''"
+                @click="toggleSiteJobs(site.name)"
+              >
+                <!-- Hidden, not omitted: keeps job-less rows aligned. -->
+                <span
+                  class="size-4 text-ink-gray-5 transition-transform shrink-0 lucide-chevron-right"
+                  :class="[
+                    siteJobs(site.name).length ? '' : 'invisible',
+                    expandedSites.has(site.name) ? 'rotate-90' : '',
+                  ]"
+                />
+                <p class="flex-1 min-w-0 font-medium text-ink-gray-9 text-base truncate">
                   {{ site.name }}
-                </RouterLink>
+                </p>
                 <span
                   v-if="siteCaption(site)"
                   class="flex items-center gap-1.5 text-sm shrink-0"
@@ -252,18 +262,6 @@
                   <Spinner v-if="siteStatus(site).busy" size="sm" class="text-ink-amber-7" />
                   {{ siteCaption(site) }}
                 </span>
-                <Button
-                  v-if="siteJobs(site.name).length"
-                  variant="ghost"
-                  size="sm"
-                  tooltip="Site jobs"
-                  @click="toggleSiteJobs(site.name)"
-                >
-                  <span
-                    class="size-4 text-ink-gray-5 transition-transform lucide-chevron-down"
-                    :class="expandedSites.has(site.name) ? 'rotate-180' : ''"
-                  />
-                </Button>
               </div>
               <div
                 v-if="expandedSites.has(site.name)"
@@ -444,6 +442,7 @@ const openTaskLog = (log) => router.push({ name: 'TaskDetail', params: { taskId:
 const expandedSites = ref(new Set())
 
 function toggleSiteJobs(siteName) {
+  if (!siteJobs(siteName).length) return
   const expanded = new Set(expandedSites.value)
   if (!expanded.delete(siteName)) expanded.add(siteName)
   expandedSites.value = expanded

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -6,7 +6,7 @@
         <Skeleton class="rounded w-44 h-4" />
         <Skeleton class="rounded w-24 h-4" />
       </div>
-      <div class="mt-6 p-1.5 border border-outline-gray-2 rounded-lg">
+      <div class="mt-6 p-1 border border-outline-gray-2 rounded-lg">
         <div class="flex justify-between items-center px-2.5 py-2">
           <Skeleton class="rounded w-24 h-4" />
           <Skeleton class="rounded w-12 h-3" />
@@ -169,7 +169,7 @@
         <details
           v-if="op.apps?.length"
           :open="appsOpen"
-          class="group/apps rounded-lg border border-outline-gray-2 p-1.5"
+          class="group/apps rounded-lg border border-outline-gray-2 p-1"
           @toggle="appsOpen = $event.target.open"
         >
           <summary
@@ -224,7 +224,7 @@
         <details
           v-if="op.sites?.length"
           :open="sitesOpen"
-          class="group/sites rounded-lg border border-outline-gray-2 p-1.5"
+          class="group/sites rounded-lg border border-outline-gray-2 p-1"
           @toggle="sitesOpen = $event.target.open"
         >
           <summary
@@ -287,7 +287,7 @@
       <details
         v-if="op.decisions?.length"
         open
-        class="group/decisions mt-2 rounded-lg border border-outline-gray-2 p-1.5"
+        class="group/decisions mt-2 rounded-lg border border-outline-gray-2 p-1"
       >
         <summary
           class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -41,22 +41,7 @@
         />
       </Teleport>
 
-      <div class="flex justify-between items-center gap-4 px-2 min-w-0">
-        <p class="text-ink-gray-8 text-base truncate">{{ metaLine }}</p>
-        <div class="flex flex-wrap justify-end items-center gap-1 shrink-0">
-          <Button
-            v-for="job in serverJobs"
-            :key="job.id"
-            variant="ghost"
-            size="sm"
-            :theme="isJobFailed(job) ? 'red' : 'gray'"
-            :icon-left="isJobFailed(job) ? 'lucide-circle-x' : 'lucide-square-terminal'"
-            @click="openTaskLog(job)"
-          >
-            {{ job.label }}
-          </Button>
-        </div>
-      </div>
+      <p class="mt-5 px-2 font-medium text-ink-gray-8 text-base truncate">{{ metaLine }}</p>
 
       <ErrorMessage v-if="error" class="mt-4" :message="error" />
 
@@ -158,7 +143,10 @@
       </section>
 
       <!-- Run order: apps update first, then sites migrate. -->
-      <div v-if="op.sites?.length || op.apps?.length" class="mt-6 space-y-2">
+      <div
+        v-if="op.sites?.length || op.apps?.length || serverJobs.length"
+        class="mt-3 space-y-2"
+      >
         <details
           v-if="op.apps?.length"
           :open="appsOpen"
@@ -213,6 +201,32 @@
           </div>
         </details>
 
+        <!-- Bench-wide jobs, run before any site is touched. -->
+        <details
+          v-if="serverJobs.length"
+          :open="serverOpen"
+          class="group/server rounded-lg border border-outline-gray-2 p-1"
+          @toggle="serverOpen = $event.target.open"
+        >
+          <summary
+            class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
+          >
+            <h2 class="text-base font-medium text-ink-gray-8">Server ({{ serverJobs.length }})</h2>
+            <span
+              class="size-4 text-ink-gray-5 transition-transform group-open/server:rotate-180 lucide-chevron-down"
+            />
+          </summary>
+
+          <div>
+            <JobRow
+              v-for="job in serverJobs"
+              :key="job.id"
+              :job="job"
+              @click="openTaskLog(job)"
+            />
+          </div>
+        </details>
+
         <!-- Sites -->
         <details
           v-if="op.sites?.length"
@@ -260,20 +274,12 @@
                 v-if="expandedSites.has(site.name)"
                 class="mb-1 ml-4 pl-3 border-l border-outline-gray-2"
               >
-                <button
+                <JobRow
                   v-for="job in siteJobs(site.name)"
                   :key="job.id"
-                  type="button"
-                  class="flex items-center gap-1.5 px-1.5 py-1.5 rounded transition-colors w-full hover:bg-surface-gray-1 text-sm text-left"
-                  :class="isJobFailed(job) ? 'text-ink-red-7' : 'text-ink-gray-7'"
+                  :job="job"
                   @click="openTaskLog(job)"
-                >
-                  <span
-                    class="size-4 shrink-0"
-                    :class="isJobFailed(job) ? 'lucide-circle-x' : 'lucide-square-terminal'"
-                  />
-                  {{ job.label }}
-                </button>
+                />
               </div>
             </div>
           </div>
@@ -363,6 +369,7 @@ import {
   Tooltip,
 } from 'frappe-ui'
 import AppIcon from '@/components/apps/AppIcon.vue'
+import JobRow from '@/components/updates/JobRow.vue'
 import LogView from '@/components/logs/LogView.vue'
 import UpdateStateBadge from '@/components/updates/UpdateStateBadge.vue'
 import { useAppRegistry } from '@/composables/apps/useAppRegistry'
@@ -401,10 +408,6 @@ const durationSeconds = computed(() => {
 
 // Bench-wide chain tasks (update, revert apps, restart); site-bound ones live in the site tree.
 const serverJobs = computed(() => (op.value?.task_logs || []).filter((log) => !log.site))
-
-// A retried step leaves several jobs behind, so only the one that broke the chain
-// earns colour. Killing a migrate mid-run stops the update just as a crash does.
-const isJobFailed = (job) => job.status === 'failed' || job.status === 'killed'
 
 const alertTitle = computed(() =>
   op.value?.state === 'revert_failed' ? 'Restore failed' : 'This update needs attention',
@@ -508,19 +511,23 @@ function revisionHint(app) {
   return app.updated_sha ? `Updated to ${target}` : `Will update to ${target}`
 }
 
-const anySiteFailed = computed(() =>
-  (op.value?.sites || []).some((site) => siteStatus(site).value === 'failed'),
+const anythingFailed = computed(
+  () =>
+    (op.value?.sites || []).some((site) => siteStatus(site).value === 'failed') ||
+    serverJobs.value.some((job) => job.status === 'failed'),
 )
 
 // A settled run starts collapsed; anything unresolved or failed starts open.
 const sitesOpen = ref(true)
 const appsOpen = ref(true)
+const serverOpen = ref(true)
 let openDefaultsSet = false
 
 function applyOpenDefaults() {
   if (openDefaultsSet || !op.value) return
   openDefaultsSet = true
-  const settled = isResolved(op.value) && !anySiteFailed.value
+  const settled = isResolved(op.value) && !anythingFailed.value
+  serverOpen.value = !settled
   sitesOpen.value = !settled
   appsOpen.value = !settled
 }

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -147,26 +147,12 @@
         v-if="op.sites?.length || op.apps?.length || serverJobs.length"
         class="mt-3 space-y-2"
       >
-        <details
+        <UpdateSection
           v-if="op.apps?.length"
-          :open="appsOpen"
-          class="group/apps rounded-lg border border-outline-gray-2 p-1"
-          @toggle="appsOpen = $event.target.open"
+          v-model:open="appsOpen"
+          icon="lucide-box"
+          :title="`Target apps (${op.apps.length})`"
         >
-          <summary
-            class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
-          >
-            <div class="flex items-center gap-2">
-              <span class="size-4 text-ink-gray-5 shrink-0 lucide-box" />
-              <h2 class="text-base font-medium text-ink-gray-8">
-                Target apps ({{ op.apps.length }})
-              </h2>
-            </div>
-            <span
-              class="size-4 text-ink-gray-5 transition-transform group-open/apps:rotate-180 lucide-chevron-down"
-            />
-          </summary>
-
           <div>
             <div
               v-for="app in op.apps"
@@ -202,58 +188,30 @@
               </Tooltip>
             </div>
           </div>
-        </details>
+        </UpdateSection>
 
         <!-- Bench-wide jobs, run before any site is touched. -->
-        <details
+        <UpdateSection
           v-if="serverJobs.length"
-          :open="serverOpen"
-          class="group/server rounded-lg border border-outline-gray-2 p-1"
-          @toggle="serverOpen = $event.target.open"
+          v-model:open="serverOpen"
+          icon="lucide-server"
+          :title="`Server (${serverJobs.length})`"
         >
-          <summary
-            class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
-          >
-            <div class="flex items-center gap-2">
-              <span class="size-4 text-ink-gray-5 shrink-0 lucide-server" />
-              <h2 class="text-base font-medium text-ink-gray-8">
-                Server ({{ serverJobs.length }})
-              </h2>
-            </div>
-            <span
-              class="size-4 text-ink-gray-5 transition-transform group-open/server:rotate-180 lucide-chevron-down"
-            />
-          </summary>
-
-          <div>
-            <JobRow
-              v-for="job in serverJobs"
-              :key="job.id"
-              :job="job"
-              @click="openTaskLog(job)"
-            />
-          </div>
-        </details>
+          <JobRow
+            v-for="job in serverJobs"
+            :key="job.id"
+            :job="job"
+            @click="openTaskLog(job)"
+          />
+        </UpdateSection>
 
         <!-- Sites -->
-        <details
+        <UpdateSection
           v-if="op.sites?.length"
-          :open="sitesOpen"
-          class="group/sites rounded-lg border border-outline-gray-2 p-1"
-          @toggle="sitesOpen = $event.target.open"
+          v-model:open="sitesOpen"
+          icon="lucide-globe"
+          :title="`Sites (${sitesCount})`"
         >
-          <summary
-            class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
-          >
-            <div class="flex items-center gap-2">
-              <span class="size-4 text-ink-gray-5 shrink-0 lucide-globe" />
-              <h2 class="text-base font-medium text-ink-gray-8">Sites ({{ sitesCount }})</h2>
-            </div>
-            <span
-              class="size-4 text-ink-gray-5 transition-transform group-open/sites:rotate-180 lucide-chevron-down"
-            />
-          </summary>
-
           <div>
             <div v-for="site in op.sites" :key="site.name">
               <div
@@ -294,43 +252,26 @@
               </div>
             </div>
           </div>
-        </details>
+        </UpdateSection>
       </div>
 
       <!-- User decisions -->
-      <details
+      <UpdateSection
         v-if="op.decisions?.length"
-        open
-        class="group/decisions mt-2 rounded-lg border border-outline-gray-2 p-1"
+        class="mt-2"
+        icon="lucide-skip-forward"
+        :title="`Skipped patches (${op.decisions.length})`"
       >
-        <summary
-          class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
+        <div
+          v-for="(decision, index) in op.decisions"
+          :key="index"
+          class="px-2.5 py-2 text-sm text-ink-gray-7"
         >
-          <div class="flex items-center gap-2">
-            <span class="size-4 text-ink-gray-5 shrink-0 lucide-skip-forward" />
-            <h2 class="text-base font-medium text-ink-gray-8">
-              Skipped patches ({{ op.decisions.length }})
-            </h2>
-          </div>
-          <span
-            class="size-4 text-ink-gray-5 transition-transform group-open/decisions:rotate-180 lucide-chevron-down"
-          />
-        </summary>
-
-        <div>
-          <div
-            v-for="(decision, index) in op.decisions"
-            :key="index"
-            class="px-2.5 py-2 text-sm text-ink-gray-7"
-          >
-            <code class="rounded bg-surface-gray-2 px-1 font-mono text-xs">{{
-              decision.patch
-            }}</code>
-            on
-            <span class="font-medium text-ink-gray-8">{{ decision.site }}</span>
-          </div>
+          <code class="rounded bg-surface-gray-2 px-1 font-mono text-xs">{{ decision.patch }}</code>
+          on
+          <span class="font-medium text-ink-gray-8">{{ decision.site }}</span>
         </div>
-      </details>
+      </UpdateSection>
 
       <!-- Skip patch confirmation -->
       <Dialog v-model="confirmSkip" :options="{ title: 'Skip this patch permanently?' }">
@@ -385,6 +326,7 @@ import {
 import AppIcon from '@/components/apps/AppIcon.vue'
 import JobRow from '@/components/updates/JobRow.vue'
 import LogView from '@/components/logs/LogView.vue'
+import UpdateSection from '@/components/updates/UpdateSection.vue'
 import UpdateStateBadge from '@/components/updates/UpdateStateBadge.vue'
 import { useAppRegistry } from '@/composables/apps/useAppRegistry'
 import { processLine } from '@/utils/ansi'

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -151,7 +151,8 @@
           v-if="op.apps?.length"
           v-model:open="appsOpen"
           icon="lucide-box"
-          :title="`Target apps (${op.apps.length})`"
+          title="Target apps"
+          :count="op.apps.length"
         >
           <div>
             <div
@@ -195,7 +196,8 @@
           v-if="serverJobs.length"
           v-model:open="serverOpen"
           icon="lucide-server"
-          :title="`Server (${serverJobs.length})`"
+          title="Server"
+          :count="serverJobs.length"
         >
           <JobRow
             v-for="job in serverJobs"
@@ -210,7 +212,8 @@
           v-if="op.sites?.length"
           v-model:open="sitesOpen"
           icon="lucide-globe"
-          :title="`Sites (${sitesCount})`"
+          title="Sites"
+          :count="sitesCount"
         >
           <div>
             <div v-for="site in op.sites" :key="site.name">
@@ -260,7 +263,8 @@
         v-if="op.decisions?.length"
         class="mt-2"
         icon="lucide-skip-forward"
-        :title="`Skipped patches (${op.decisions.length})`"
+        title="Skipped patches"
+        :count="op.decisions.length"
       >
         <div
           v-for="(decision, index) in op.decisions"

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -106,11 +106,27 @@
             </template>
           </p>
 
-          <p v-if="pending" class="mt-4 flex items-center gap-2 text-p-sm text-ink-gray-7">
+          <!-- Links to the running action task so the user can watch it. -->
+          <button
+            v-if="pending"
+            type="button"
+            class="mt-4 flex items-center gap-2 text-p-sm text-ink-gray-7 hover:text-ink-gray-9"
+            @click="openTaskLog({ id: pending.task_id })"
+          >
             <Spinner size="md" class="text-ink-amber-7" />
             {{ pendingLabel }}
-          </p>
+            <span class="lucide-square-terminal size-4" />
+          </button>
+          <!-- Skip patch leads: it is the cheapest recovery, ahead of a restore. -->
           <div v-else class="mt-4 flex flex-wrap gap-2">
+            <Button
+              v-if="op.state === 'needs_attention' && op.diagnosis?.patch && !patchAlreadySkipped"
+              variant="subtle"
+              :loading="acting"
+              @click="confirmSkip = true"
+            >
+              Skip patch
+            </Button>
             <Button
               v-if="op.state === 'needs_attention'"
               variant="subtle"
@@ -126,15 +142,6 @@
               @click="confirmRestore = true"
             >
               Restore backup
-            </Button>
-            <Button
-              v-if="op.state === 'needs_attention' && op.diagnosis?.patch && !patchAlreadySkipped"
-              variant="subtle"
-              theme="red"
-              :loading="acting"
-              @click="confirmSkip = true"
-            >
-              Skip patch
             </Button>
           </div>
         </div>
@@ -229,36 +236,50 @@
           </summary>
 
           <div>
-            <div
-              v-for="site in op.sites"
-              :key="site.name"
-              class="flex items-center gap-3 px-2.5 py-2"
-            >
-              <RouterLink
-                :to="{ name: 'SiteDetail', params: { name: site.name } }"
-                class="flex-1 min-w-0 font-medium text-ink-gray-9 text-base truncate no-underline hover:text-ink-gray-7"
+            <div v-for="site in op.sites" :key="site.name">
+              <div class="flex items-center gap-3 px-2.5 py-2">
+                <RouterLink
+                  :to="{ name: 'SiteDetail', params: { name: site.name } }"
+                  class="flex-1 min-w-0 font-medium text-ink-gray-9 text-base truncate no-underline hover:text-ink-gray-7"
+                >
+                  {{ site.name }}
+                </RouterLink>
+                <span
+                  v-if="siteCaption(site)"
+                  class="flex items-center gap-1.5 text-sm shrink-0"
+                  :class="siteStatus(site).value === 'failed' ? 'text-ink-red-7' : 'text-ink-gray-5'"
+                >
+                  <Spinner v-if="siteStatus(site).busy" size="sm" class="text-ink-amber-7" />
+                  {{ siteCaption(site) }}
+                </span>
+                <Button
+                  v-if="siteJobs(site.name).length"
+                  variant="ghost"
+                  size="sm"
+                  tooltip="Site jobs"
+                  @click="toggleSiteJobs(site.name)"
+                >
+                  <span
+                    class="size-4 text-ink-gray-5 transition-transform lucide-chevron-down"
+                    :class="expandedSites.has(site.name) ? 'rotate-180' : ''"
+                  />
+                </Button>
+              </div>
+              <div
+                v-if="expandedSites.has(site.name)"
+                class="mb-1 ml-4 pl-3 border-l border-outline-gray-2"
               >
-                {{ site.name }}
-              </RouterLink>
-              <span
-                v-if="siteCaption(site)"
-                class="flex items-center gap-1.5 text-sm shrink-0"
-                :class="siteStatus(site).value === 'failed' ? 'text-ink-red-7' : 'text-ink-gray-5'"
-              >
-                <Spinner v-if="siteStatus(site).busy" size="sm" class="text-ink-amber-7" />
-                {{ siteCaption(site) }}
-              </span>
-              <Dropdown
-                v-if="siteLogOptions(site.name).length"
-                :options="siteLogOptions(site.name)"
-                placement="bottom-end"
-              >
-                <template #default="{ open }">
-                  <Button variant="ghost" size="sm" :active="open" tooltip="Site jobs">
-                    <span class="lucide-list-checks size-4" />
-                  </Button>
-                </template>
-              </Dropdown>
+                <button
+                  v-for="job in siteJobs(site.name)"
+                  :key="job.id"
+                  type="button"
+                  class="flex items-center gap-1.5 px-1 py-1.5 rounded w-full text-ink-gray-7 hover:text-ink-gray-9 text-sm text-left"
+                  @click="openTaskLog(job)"
+                >
+                  <span class="lucide-square-terminal size-4 shrink-0" />
+                  {{ job.label }}
+                </button>
+              </div>
             </div>
           </div>
         </details>
@@ -341,7 +362,6 @@ import {
   Badge,
   Button,
   Dialog,
-  Dropdown,
   ErrorMessage,
   Skeleton,
   Spinner,
@@ -421,14 +441,16 @@ const metaLine = computed(() => {
 
 const openTaskLog = (log) => router.push({ name: 'TaskDetail', params: { taskId: log.id } })
 
-function siteLogOptions(siteName) {
-  return (op.value?.task_logs || [])
-    .filter((log) => log.site === siteName)
-    .map((log) => ({
-      label: log.label,
-      icon: 'lucide-square-terminal',
-      onClick: () => openTaskLog(log),
-    }))
+const expandedSites = ref(new Set())
+
+function toggleSiteJobs(siteName) {
+  const expanded = new Set(expandedSites.value)
+  if (!expanded.delete(siteName)) expanded.add(siteName)
+  expandedSites.value = expanded
+}
+
+function siteJobs(siteName) {
+  return (op.value?.task_logs || []).filter((log) => log.site === siteName)
 }
 
 async function load() {

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -43,25 +43,17 @@
 
       <div class="flex justify-between items-center gap-4 px-2 min-w-0">
         <p class="text-ink-gray-8 text-base truncate">{{ metaLine }}</p>
-        <div class="flex items-center gap-3 shrink-0">
-          <button
-            v-if="updateTaskId"
-            type="button"
-            class="flex items-center gap-1.5 text-ink-gray-7 hover:text-ink-gray-8 text-base"
-            @click="openTaskLog({ id: updateTaskId })"
+        <div class="flex flex-wrap justify-end items-center gap-1 shrink-0">
+          <Button
+            v-for="job in serverJobs"
+            :key="job.id"
+            variant="ghost"
+            size="sm"
+            icon-left="lucide-square-terminal"
+            @click="openTaskLog(job)"
           >
-            <span class="lucide-square-terminal size-4" />
-            Update task
-          </button>
-          <button
-            v-if="revertTaskId"
-            type="button"
-            class="flex items-center gap-1.5 text-ink-gray-7 hover:text-ink-gray-8 text-base"
-            @click="openTaskLog({ id: revertTaskId })"
-          >
-            <span class="lucide-square-terminal size-4" />
-            Revert task
-          </button>
+            {{ job.label }}
+          </Button>
         </div>
       </div>
 
@@ -110,7 +102,7 @@
           <button
             v-if="pending"
             type="button"
-            class="mt-4 flex items-center gap-2 text-p-sm text-ink-gray-7 hover:text-ink-gray-9"
+            class="mt-4 flex items-center gap-2 px-2 py-1 rounded transition-colors text-p-sm text-ink-gray-7 hover:bg-surface-gray-1"
             @click="openTaskLog({ id: pending.task_id })"
           >
             <Spinner size="md" class="text-ink-amber-7" />
@@ -271,7 +263,7 @@
                   v-for="job in siteJobs(site.name)"
                   :key="job.id"
                   type="button"
-                  class="flex items-center gap-1.5 px-1 py-1.5 rounded w-full text-ink-gray-7 hover:text-ink-gray-9 text-sm text-left"
+                  class="flex items-center gap-1.5 px-1.5 py-1.5 rounded transition-colors w-full text-ink-gray-7 hover:bg-surface-gray-1 text-sm text-left"
                   @click="openTaskLog(job)"
                 >
                   <span class="lucide-square-terminal size-4 shrink-0" />
@@ -402,12 +394,8 @@ const durationSeconds = computed(() => {
   return Math.max(0, (end - new Date(op.value.started_at).getTime()) / 1000)
 })
 
-// Retries append fresh 'update' chain entries; the latest attempt is the one worth opening.
-// 'restore' is the task_ids role the restore/revert action is queued under (api/updates.js).
-const updateTaskId = computed(
-  () => op.value?.chain?.findLast((entry) => entry.command === 'update')?.task_id,
-)
-const revertTaskId = computed(() => op.value?.task_ids?.restore)
+// Bench-wide chain tasks (update, revert apps, restart); site-bound ones live in the site tree.
+const serverJobs = computed(() => (op.value?.task_logs || []).filter((log) => !log.site))
 
 const alertTitle = computed(() =>
   op.value?.state === 'revert_failed' ? 'Restore failed' : 'This update needs attention',

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -1,34 +1,35 @@
 <template>
   <div class="mx-auto max-w-3xl">
-    <div v-if="loading && !op" class="flex justify-center py-12">
-      <LoadingText />
+    <!-- Skeleton mirrors the page: meta row, then a card of rows. -->
+    <div v-if="loading && !op" class="px-2">
+      <div class="flex justify-between items-center py-2">
+        <Skeleton class="rounded w-44 h-4" />
+        <Skeleton class="rounded w-24 h-4" />
+      </div>
+      <div class="mt-6 p-1.5 border border-outline-gray-2 rounded-lg">
+        <div class="flex justify-between items-center px-2.5 py-2">
+          <Skeleton class="rounded w-24 h-4" />
+          <Skeleton class="rounded w-12 h-3" />
+        </div>
+        <div
+          v-for="index in 3"
+          :key="index"
+          class="px-2.5 py-2"
+          :style="{ opacity: 1 - index * 0.25 }"
+        >
+          <Skeleton class="rounded w-48 h-4" />
+        </div>
+      </div>
     </div>
     <ErrorMessage v-else-if="error && !op" class="mt-4" :message="error" />
 
     <template v-else-if="op">
-      <!-- Header -->
-      <div class="flex justify-between items-center gap-3">
-        <div class="flex items-center gap-2 min-w-0">
-          <Button
-            class="shrink-0"
-            variant="subtle"
-            size="sm"
-            icon="lucide-arrow-left"
-            label="Back to updates"
-            tooltip="Back to updates"
-            @click="router.push({ name: 'Updates' })"
-          />
-          <h1 class="flex-1 min-w-0 font-semibold text-ink-gray-9 text-xl truncate">{{ title }}</h1>
-          <Badge
-            v-if="pending"
-            class="shrink-0"
-            theme="amber"
-            variant="subtle"
-            size="md"
-            :label="pendingLabel"
-          />
-          <UpdateStateBadge v-else class="shrink-0" :state="op.state" />
-        </div>
+      <Teleport defer to="#header-badge">
+        <Badge v-if="pending" theme="amber" variant="subtle" size="md" :label="pendingLabel" />
+        <UpdateStateBadge v-else :state="op.state" />
+      </Teleport>
+
+      <Teleport defer to="#header-actions">
         <Button
           variant="subtle"
           size="sm"
@@ -38,155 +39,220 @@
           :loading="refreshing"
           @click="refresh"
         />
-      </div>
+      </Teleport>
 
-      <!-- Metadata -->
-      <div
-        class="gap-4 grid grid-cols-2 mt-4 px-0 py-4 rounded-xl sm:grid-cols-5"
-      >
-        <div v-for="item in metadata" :key="item.label">
-          <p class="text-xs text-ink-gray-4">{{ item.label }}</p>
+      <div class="flex justify-between items-center gap-4 px-2 min-w-0">
+        <p class="text-ink-gray-8 text-base truncate">{{ metaLine }}</p>
+        <div class="flex items-center gap-3 shrink-0">
           <button
-            v-if="item.taskId"
+            v-if="updateTaskId"
             type="button"
-            class="mt-1 block truncate text-sm text-ink-gray-8 hover:underline"
-            @click="openTaskLog({ id: item.taskId })"
+            class="flex items-center gap-1.5 text-ink-gray-7 hover:text-ink-gray-8 text-base"
+            @click="openTaskLog({ id: updateTaskId })"
           >
-            {{ item.value }}
+            <span class="lucide-square-terminal size-4" />
+            Update task
           </button>
-          <p v-else class="mt-1 truncate text-sm text-ink-gray-8">{{ item.value }}</p>
+          <button
+            v-if="revertTaskId"
+            type="button"
+            class="flex items-center gap-1.5 text-ink-gray-7 hover:text-ink-gray-8 text-base"
+            @click="openTaskLog({ id: revertTaskId })"
+          >
+            <span class="lucide-square-terminal size-4" />
+            Revert task
+          </button>
         </div>
       </div>
 
       <ErrorMessage v-if="error" class="mt-4" :message="error" />
 
       <!-- Unresolved failure -->
-      <section
-        v-if="isAttention"
-        class="mt-4 overflow-hidden rounded-xl border border-outline-red-2"
-      >
-        <div class="flex items-start gap-3 bg-surface-red-1 p-4 sm:p-5">
-          <span class="lucide-alert-triangle mt-0.5 size-5 shrink-0 text-ink-red-6" />
-          <div class="min-w-0 flex-1">
-            <h2 class="font-semibold text-sm">This update needs attention</h2>
-            <!-- Tool output indents and box-draws; keep it preformatted. -->
-            <pre
-              v-if="op.diagnosis?.message"
-              class="mt-1 max-h-96 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5 text-ink-red-8"
-              >{{ op.diagnosis.message }}</pre
+      <section v-if="isAttention" class="mt-4 overflow-hidden rounded-lg border border-outline-gray-2">
+        <div class="p-4">
+          <div class="flex items-center gap-2">
+            <span class="lucide-alert-triangle size-4 shrink-0 text-ink-red-6" />
+            <h2 class="font-medium text-ink-red-8 text-base">
+              {{ alertTitle }}
+            </h2>
+          </div>
+          <!-- Tool output indents and box-draws; keep it preformatted. -->
+          <pre
+            v-if="op.diagnosis?.message"
+            class="mt-2 max-h-96 overflow-auto whitespace-pre-wrap break-words font-mono text-xs leading-5 text-ink-gray-8"
+            >{{ op.diagnosis.message }}</pre>
+          <p v-if="op.diagnosis?.patch" class="mt-2 text-p-sm text-ink-gray-7">
+            Failing patch
+            <code
+              class="ml-1 rounded bg-surface-gray-2 px-1.5 py-0.5 font-mono text-xs text-ink-gray-8"
             >
-            <p v-if="op.diagnosis?.patch" class="mt-2 text-p-sm text-ink-gray-7">
-              Failing patch
-              <code
-                class="ml-1 rounded bg-surface-red-2 px-1.5 py-0.5 font-mono text-xs text-ink-red-9"
-              >
-                {{ op.diagnosis.patch }}
-              </code>
-            </p>
-            <p
-              v-if="patchAlreadySkipped"
-              class="mt-2 flex items-center gap-1 text-p-sm font-medium text-ink-green-7"
+              {{ op.diagnosis.patch }}
+            </code>
+          </p>
+          <p
+            v-if="patchAlreadySkipped"
+            class="mt-2 flex items-center gap-1 text-p-sm font-medium text-ink-green-7"
+          >
+            <span class="lucide-check size-4" />
+            Patch skipped
+          </p>
+          <p class="mt-3 text-p-sm text-ink-gray-6">
+            <template v-if="op.state === 'revert_failed'"
+              >Fix the cause and run the restore again.</template
             >
-              <span class="lucide-check size-4" />
-              Patch Skipped
-            </p>
-            <p class="mt-3 text-p-sm text-ink-gray-6">
-              <template v-if="op.state === 'revert_failed'"
-                >Fix the cause and run the restore again.</template
-              >
-              <template v-else>
-                Fix the cause manually, then retry. Or restore everything back to its pre-update
-                state.
-              </template>
-            </p>
+            <template v-else>
+              Fix the cause manually, then retry. Or restore everything back to its pre-update
+              state.
+            </template>
+          </p>
 
-            <p v-if="pending" class="mt-4 flex items-center gap-2 text-p-sm text-ink-gray-7">
-              <span class="lucide-loader-circle size-4 animate-spin text-ink-amber-7" />
-              {{ pendingLabel }}
-            </p>
-            <div v-else class="mt-4 flex flex-wrap gap-2">
-              <Button
-                v-if="op.state === 'needs_attention' && op.diagnosis?.patch && !patchAlreadySkipped"
-                variant="solid"
-                theme="red"
-                :loading="acting"
-                @click="confirmSkip = true"
-              >
-                Skip patch
-              </Button>
-              <Button
-                v-if="op.state === 'needs_attention'"
-                variant="outline"
-                theme="gray"
-                :loading="acting"
-                @click="doRetry"
-              >
-                Retry update
-              </Button>
-              <Button
-                v-if="op.can_restore"
-                variant="outline"
-                theme="gray"
-                :loading="acting"
-                @click="confirmRestore = true"
-              >
-                Restore backup
-              </Button>
-            </div>
+          <p v-if="pending" class="mt-4 flex items-center gap-2 text-p-sm text-ink-gray-7">
+            <Spinner size="md" class="text-ink-amber-7" />
+            {{ pendingLabel }}
+          </p>
+          <div v-else class="mt-4 flex flex-wrap gap-2">
+            <Button
+              v-if="op.state === 'needs_attention'"
+              variant="subtle"
+              :loading="acting"
+              @click="doRetry"
+            >
+              Retry update
+            </Button>
+            <Button
+              v-if="op.can_restore"
+              variant="subtle"
+              :loading="acting"
+              @click="confirmRestore = true"
+            >
+              Restore backup
+            </Button>
+            <Button
+              v-if="op.state === 'needs_attention' && op.diagnosis?.patch && !patchAlreadySkipped"
+              variant="subtle"
+              theme="red"
+              :loading="acting"
+              @click="confirmSkip = true"
+            >
+              Skip patch
+            </Button>
           </div>
         </div>
 
-        <details
+        <div
           v-if="op.diagnosis?.output_excerpt"
-          class="border-t border-outline-red-2 bg-surface-base"
+          class="border-t border-outline-gray-1 px-2.5 py-1.5"
         >
-          <summary
-            class="cursor-pointer px-4 py-3 text-p-sm font-medium text-ink-gray-7 hover:bg-surface-gray-1 sm:px-5"
-          >
-            Show error output
-          </summary>
-          <pre
-            class="m-3 max-h-64 overflow-auto rounded-lg bg-surface-gray-9 p-3 font-mono text-xs leading-relaxed whitespace-pre-wrap text-ink-gray-1 sm:m-4"
-          >
-    {{ op.diagnosis.output_excerpt }}</pre>
-        </details>
+          <Button variant="ghost" @click="showOutput = !showOutput">
+            {{ showOutput ? 'Hide error output' : 'Show error output' }}
+            <template #suffix>
+              <span
+                class="size-4 transition-transform lucide-chevron-down"
+                :class="showOutput ? 'rotate-180' : ''"
+              />
+            </template>
+          </Button>
+          <LogView v-if="showOutput" class="mt-1 mb-2" :lines="outputLines" wrap />
+        </div>
       </section>
 
-      <!-- Sites -->
-      <section class="mt-4 overflow-hidden rounded-xl border border-outline-gray-2">
-        <div
-          class="flex items-center justify-between border-b border-outline-gray-1 px-4 py-3.5 sm:px-5"
+      <!-- Run order: apps update first, then sites migrate. -->
+      <div v-if="op.sites?.length || op.apps?.length" class="mt-6 space-y-2">
+        <details
+          v-if="op.apps?.length"
+          :open="appsOpen"
+          class="group/apps rounded-lg border border-outline-gray-2 p-1.5"
+          @toggle="appsOpen = $event.target.open"
         >
-          <div class="flex items-center gap-2">
-            <span class="lucide-server size-4 text-ink-gray-5" />
-            <h2 class="text-base font-semibold text-ink-gray-8">Sites</h2>
-          </div>
-          <span class="text-p-sm text-ink-gray-5">{{ countLabel(op.sites?.length, 'site') }}</span>
-        </div>
-
-        <div v-if="op.sites?.length" class="divide-y divide-outline-gray-1">
-          <div
-            v-for="site in op.sites"
-            :key="site.name"
-            class="flex items-center justify-between gap-4 px-4 py-3 sm:px-5"
+          <summary
+            class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-2"
           >
-            <RouterLink
-              :to="{ name: 'SiteDetail', params: { name: site.name } }"
-              class="min-w-0 flex-1 truncate font-medium text-ink-gray-9 text-sm no-underline hover:text-ink-gray-7"
+            <h2 class="text-base font-medium text-ink-gray-8">
+              Target apps ({{ op.apps.length }})
+            </h2>
+            <span
+              class="size-4 text-ink-gray-5 transition-transform group-open/apps:rotate-180 lucide-chevron-down"
+            />
+          </summary>
+
+          <div>
+            <div
+              v-for="app in op.apps"
+              :key="app.name"
+              class="flex items-center justify-between gap-4 px-2.5 py-2"
             >
-              {{ site.name }}
-            </RouterLink>
-            <div class="flex shrink-0 items-center gap-1.5">
+              <div class="flex items-center gap-2 min-w-0 flex-1">
+                <AppIcon :name="app.name" class="!rounded-sm size-5" initial-class="text-xs" />
+                <p class="min-w-0 truncate font-medium text-ink-gray-9 text-base">
+                  {{ app.name }}
+                </p>
+              </div>
+              <Tooltip :text="revisionHint(app)">
+                <component
+                  :is="app.compare_url ? 'a' : 'div'"
+                  :href="app.compare_url || undefined"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="flex shrink-0 items-center gap-2 font-mono text-xs text-ink-gray-6"
+                  :class="app.compare_url ? 'hover:text-ink-gray-8' : ''"
+                >
+                  <span>{{ shortSha(app.sha) }}</span>
+                  <span class="lucide-arrow-right size-3.5 text-ink-gray-4" aria-hidden="true" />
+                  <span :class="app.updated_sha ? 'text-ink-green-7' : 'text-ink-gray-5'">
+                    {{ shortSha(app.updated_sha || app.target_sha) }}
+                  </span>
+                  <span
+                    v-if="app.compare_url"
+                    class="lucide-external-link size-3.5 text-ink-gray-4"
+                    aria-hidden="true"
+                  />
+                </component>
+              </Tooltip>
+            </div>
+          </div>
+        </details>
+
+        <!-- Sites -->
+        <details
+          v-if="op.sites?.length"
+          :open="sitesOpen"
+          class="group/sites rounded-lg border border-outline-gray-2 p-1.5"
+          @toggle="sitesOpen = $event.target.open"
+        >
+          <summary
+            class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-2"
+          >
+            <h2 class="text-base font-medium text-ink-gray-8">Sites ({{ sitesCount }})</h2>
+            <span
+              class="size-4 text-ink-gray-5 transition-transform group-open/sites:rotate-180 lucide-chevron-down"
+            />
+          </summary>
+
+          <div>
+            <div
+              v-for="site in op.sites"
+              :key="site.name"
+              class="flex items-center gap-3 px-2.5 py-2"
+            >
+              <RouterLink
+                :to="{ name: 'SiteDetail', params: { name: site.name } }"
+                class="flex-1 min-w-0 font-medium text-ink-gray-9 text-base truncate no-underline hover:text-ink-gray-7"
+              >
+                {{ site.name }}
+              </RouterLink>
               <span
-                v-if="siteStatus(site).busy"
-                class="lucide-loader-circle size-3.5 animate-spin text-ink-amber-7"
-              />
-              <Badge
-                :theme="badgeTone(siteStatus(site).tone)"
-                variant="subtle"
-                :label="siteStatus(site).label"
-              />
-              <Dropdown :options="siteLogOptions(site.name)" placement="bottom-end">
+                v-if="siteCaption(site)"
+                class="flex items-center gap-1.5 text-sm shrink-0"
+                :class="siteStatus(site).value === 'failed' ? 'text-ink-red-7' : 'text-ink-gray-5'"
+              >
+                <Spinner v-if="siteStatus(site).busy" size="sm" class="text-ink-amber-7" />
+                {{ siteCaption(site) }}
+              </span>
+              <Dropdown
+                v-if="siteLogOptions(site.name).length"
+                :options="siteLogOptions(site.name)"
+                placement="bottom-end"
+              >
                 <template #default="{ open }">
                   <Button variant="ghost" size="sm" :active="open" tooltip="Site jobs">
                     <span class="lucide-list-checks size-4" />
@@ -195,78 +261,40 @@
               </Dropdown>
             </div>
           </div>
-        </div>
-        <p v-else class="px-5 py-8 text-center text-p-sm text-ink-gray-5">
-          No sites are part of this update.
-        </p>
-      </section>
-
-      <!-- Apps -->
-      <section
-        v-if="op.apps?.length"
-        class="mt-4 overflow-hidden rounded-xl border border-outline-gray-2"
-      >
-        <div
-          class="flex items-center justify-between border-b border-outline-gray-1 px-4 py-3.5 sm:px-5"
-        >
-          <div class="flex items-center gap-2">
-            <span class="lucide-git-branch size-4 text-ink-gray-5" />
-            <h2 class="text-base font-semibold text-ink-gray-8">Target apps</h2>
-          </div>
-          <span class="text-p-sm text-ink-gray-5">{{ countLabel(op.apps.length, 'app') }}</span>
-        </div>
-
-        <div class="divide-y divide-outline-gray-1">
-          <div
-            v-for="app in op.apps"
-            :key="app.name"
-            class="flex items-center justify-between gap-4 px-4 py-3 sm:px-5"
-          >
-            <p class="min-w-0 flex-1 truncate font-medium text-ink-gray-9 text-sm">
-              {{ app.name }}
-            </p>
-            <div class="flex shrink-0 items-center gap-2 font-mono text-xs text-ink-gray-6">
-              <span>{{ shortSha(app.sha) }}</span>
-              <span class="lucide-arrow-right size-3.5 text-ink-gray-4" aria-hidden="true" />
-              <span :class="app.updated_sha ? 'text-ink-green-7' : 'text-ink-gray-5'">
-                {{ shortSha(app.updated_sha || app.target_sha) }}
-              </span>
-              <a
-                v-if="app.compare_url"
-                :href="app.compare_url"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="lucide-external-link size-3.5 text-ink-gray-4 hover:text-ink-gray-7"
-                aria-label="Open diff"
-              />
-            </div>
-          </div>
-        </div>
-      </section>
+        </details>
+      </div>
 
       <!-- User decisions -->
-      <section
+      <details
         v-if="op.decisions?.length"
-        class="mt-4 overflow-hidden rounded-xl border border-outline-gray-2"
+        open
+        class="group/decisions mt-2 rounded-lg border border-outline-gray-2 p-1.5"
       >
-        <div class="flex items-center gap-2 border-b border-outline-gray-1 px-4 py-3.5 sm:px-5">
-          <span class="lucide-gavel size-4 text-ink-gray-5" />
-          <h2 class="text-base font-semibold text-ink-gray-8">Decisions</h2>
-        </div>
-        <div class="divide-y divide-outline-gray-1">
+        <summary
+          class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-2"
+        >
+          <h2 class="text-base font-medium text-ink-gray-8">
+            Skipped patches ({{ op.decisions.length }})
+          </h2>
+          <span
+            class="size-4 text-ink-gray-5 transition-transform group-open/decisions:rotate-180 lucide-chevron-down"
+          />
+        </summary>
+
+        <div>
           <div
             v-for="(decision, index) in op.decisions"
             :key="index"
-            class="px-4 py-3 text-sm text-ink-gray-7 sm:px-5"
+            class="px-2.5 py-2 text-sm text-ink-gray-7"
           >
-            Skipped patch
-            <code class="rounded bg-surface-gray-2 px-1 font-mono text-xs"
-              >{{ decision.patch }}</code
-            >
-            on <span class="font-medium text-ink-gray-8">{{ decision.site }}</span>
+            <code class="rounded bg-surface-gray-2 px-1 font-mono text-xs">{{
+              decision.patch
+            }}</code>
+            on
+            <span class="font-medium text-ink-gray-8">{{ decision.site }}</span>
           </div>
         </div>
-      </section>
+      </details>
 
       <!-- Skip patch confirmation -->
       <Dialog v-model="confirmSkip" :options="{ title: 'Skip this patch permanently?' }">
@@ -274,8 +302,9 @@
           <p class="text-p-sm text-ink-gray-6">
             Skipping marks
             <code class="rounded bg-surface-gray-2 px-1 font-mono">{{ op.diagnosis?.patch }}</code>
-            as completed for <b class="text-ink-gray-9">{{ op.failed_site }}</b> without running it.
-            This cannot be undone. Retry the update afterwards to continue.
+            as completed for
+            <b class="text-ink-gray-9">{{ op.failed_site }}</b> without running it. This cannot be
+            undone. Retry the update afterwards to continue.
           </p>
         </template>
         <template #actions>
@@ -308,7 +337,21 @@
 <script setup>
 import { computed, onMounted, onUnmounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { Badge, Button, Dialog, Dropdown, ErrorMessage, LoadingText } from 'frappe-ui'
+import {
+  Badge,
+  Button,
+  Dialog,
+  Dropdown,
+  ErrorMessage,
+  Skeleton,
+  Spinner,
+  Tooltip,
+} from 'frappe-ui'
+import AppIcon from '@/components/apps/AppIcon.vue'
+import LogView from '@/components/logs/LogView.vue'
+import UpdateStateBadge from '@/components/updates/UpdateStateBadge.vue'
+import { useAppRegistry } from '@/composables/apps/useAppRegistry'
+import { processLine } from '@/utils/ansi'
 import { updatesApi, isActive, isResolved, needsAttention } from '@/api/updates'
 import { useBreadcrumbs } from '@/composables/common/useBreadcrumbs'
 import { fmtDateTime, fmtDuration } from '@/utils/taskFormat'
@@ -341,45 +384,58 @@ const durationSeconds = computed(() => {
   return Math.max(0, (end - new Date(op.value.started_at).getTime()) / 1000)
 })
 
-// The 'update' phase runs once per operation, so a single chain entry identifies it;
+// Retries append fresh 'update' chain entries; the latest attempt is the one worth opening.
 // 'restore' is the task_ids role the restore/revert action is queued under (api/updates.js).
 const updateTaskId = computed(
-  () => op.value?.chain?.find((entry) => entry.command === 'update')?.task_id,
+  () => op.value?.chain?.findLast((entry) => entry.command === 'update')?.task_id,
 )
 const revertTaskId = computed(() => op.value?.task_ids?.restore)
 
-const metadata = computed(() => [
-  { label: 'Started', value: fmtDateTime(op.value.started_at) },
-  { label: 'Finished', value: op.value.finished_at ? fmtDateTime(op.value.finished_at) : '-' },
-  { label: 'Duration', value: fmtDuration(durationSeconds.value) || '-' },
-  {
-    label: 'Update Task',
-    value: updateTaskId.value ? 'View task' : '-',
-    taskId: updateTaskId.value,
-  },
-  {
-    label: 'Revert Task',
-    value: revertTaskId.value ? 'View task' : '-',
-    taskId: revertTaskId.value,
-  },
-])
+const alertTitle = computed(() =>
+  op.value?.state === 'revert_failed' ? 'Restore failed' : 'This update needs attention',
+)
+
+const showOutput = ref(false)
+const outputLines = computed(() =>
+  (op.value?.diagnosis?.output_excerpt || '').split('\n').map(processLine),
+)
+
+const sitesCount = computed(() => {
+  const sites = op.value?.sites || []
+  if (sites.length > 1 && !isResolved(op.value)) {
+    const migrated = sites.filter((site) =>
+      ['success', 'recovered'].includes(site.migration_status),
+    ).length
+    return `${migrated}/${sites.length}`
+  }
+  return `${sites.length}`
+})
+
+const metaLine = computed(() => {
+  const parts = []
+  if (op.value.started_at) parts.push(`Started ${fmtDateTime(op.value.started_at)}`)
+  const duration = fmtDuration(durationSeconds.value)
+  if (duration) parts.push(isActive(op.value) ? `running for ${duration}` : `took ${duration}`)
+  return parts.join(' · ')
+})
 
 const openTaskLog = (log) => router.push({ name: 'TaskDetail', params: { taskId: log.id } })
 
 function siteLogOptions(siteName) {
-  const logs = (op.value?.task_logs || []).filter((log) => log.site === siteName)
-  if (!logs.length) return [{ label: 'No tasks yet', disabled: true }]
-  return logs.map((log) => ({
-    label: log.label,
-    icon: 'lucide-square-terminal',
-    onClick: () => openTaskLog(log),
-  }))
+  return (op.value?.task_logs || [])
+    .filter((log) => log.site === siteName)
+    .map((log) => ({
+      label: log.label,
+      icon: 'lucide-square-terminal',
+      onClick: () => openTaskLog(log),
+    }))
 }
 
 async function load() {
   try {
     op.value = await updatesApi.detail(props.operationId)
     error.value = ''
+    applyOpenDefaults()
     setBreadcrumbs([{ label: 'Updates', route: { name: 'Updates' } }, { label: title.value }])
   } catch (e) {
     error.value = e?.message || 'Could not load this update.'
@@ -426,11 +482,40 @@ const doSkip = () => {
   return runAction(() => updatesApi.bypassPatch(props.operationId, op.value.diagnosis.patch))
 }
 
-const badgeTone = (tone) => (tone === 'orange' ? 'amber' : tone)
-const countLabel = (count = 0, noun) => `${count} ${noun}${count === 1 ? '' : 's'}`
 const shortSha = (sha) => sha?.slice(0, 7) || '—'
 
+// Green sha = the checkout happened; gray = still just the plan.
+function revisionHint(app) {
+  const target = shortSha(app.updated_sha || app.target_sha)
+  return app.updated_sha ? `Updated to ${target}` : `Will update to ${target}`
+}
+
+const anySiteFailed = computed(() =>
+  (op.value?.sites || []).some((site) => siteStatus(site).value === 'failed'),
+)
+
+// A settled run starts collapsed; anything unresolved or failed starts open.
+const sitesOpen = ref(true)
+const appsOpen = ref(true)
+let openDefaultsSet = false
+
+function applyOpenDefaults() {
+  if (openDefaultsSet || !op.value) return
+  openDefaultsSet = true
+  const settled = isResolved(op.value) && !anySiteFailed.value
+  sitesOpen.value = !settled
+  appsOpen.value = !settled
+}
+
+function siteCaption(site) {
+  const status = siteStatus(site)
+  if (status.value === 'pending') return ''
+  if (status.value === 'success') return 'Migrated'
+  return status.label
+}
+
 onMounted(async () => {
+  useAppRegistry().load()
   loading.value = true
   try {
     await load()

--- a/admin/frontend/dashboard/src/pages/updates/Updates.vue
+++ b/admin/frontend/dashboard/src/pages/updates/Updates.vue
@@ -43,28 +43,13 @@
       <ErrorMessage :message="error" />
     </div>
 
-    <!-- ListRow's own hover paints surface-sidebar, transparent in the dark
-         theme. Rows are links, hence the descendant selector. -->
-    <ListView
+    <StatusListView
       v-else-if="rows.length"
-      class="mt-4 [&_a:hover]:bg-surface-gray-1"
+      class="mt-4"
       :columns="columns"
       :rows="rows"
-      row-key="id"
-      :options="{ selectable: false, showTooltip: true, getRowRoute }"
-    >
-      <template #cell="{ column, row, item }">
-        <!-- Completed is the norm; only exceptional states get a badge. -->
-        <Badge
-          v-if="column.key === 'badge'"
-          v-show="row.badge"
-          :label="row.badge?.label"
-          :theme="row.badge?.theme"
-          variant="subtle"
-        />
-        <ListRowItem v-else :column="column" :row="row" :item="item" :align="column.align" />
-      </template>
-    </ListView>
+      :get-row-route="getRowRoute"
+    />
 
     <EmptyState
       v-else
@@ -83,9 +68,10 @@
 <script setup>
 import { computed, onMounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { Badge, Button, ErrorMessage, ListRowItem, ListView, TabButtons } from 'frappe-ui'
+import { Button, ErrorMessage, TabButtons } from 'frappe-ui'
 import EmptyState from '@/components/common/EmptyState.vue'
 import ListRowSkeleton from '@/components/common/ListRowSkeleton.vue'
+import StatusListView from '@/components/common/StatusListView.vue'
 import StickyToolbar from '@/components/common/StickyToolbar.vue'
 import { useIsMobile } from '@/composables/common/useIsMobile'
 import { updatesApi } from '@/api/updates'

--- a/admin/frontend/dashboard/src/pages/updates/Updates.vue
+++ b/admin/frontend/dashboard/src/pages/updates/Updates.vue
@@ -27,23 +27,26 @@
         v-for="op in operations"
         :key="op.id"
         :to="{ name: 'UpdateDetail', params: { operationId: op.id } }"
-        class="flex items-center gap-3 hover:bg-surface-gray-1 px-3 py-2.5 rounded no-underline transition-colors"
+        class="items-center gap-3 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] hover:bg-surface-gray-1 px-3 py-2.5 rounded no-underline transition-colors"
       >
-        <span
-          class="place-items-center grid rounded size-6 shrink-0"
-          :class="rowIcon(op).iconBg"
-        >
-          <span class="size-3.5" :class="rowIcon(op).icon" />
-        </span>
-
-        <div class="flex-1 min-w-0">
+        <div class="min-w-0">
           <!-- A block, not a span: `truncate` is inert on an inline box. -->
           <p class="font-medium text-ink-gray-9 text-base truncate">{{ opTitle(op) }}</p>
           <p class="mt-0.5 text-ink-gray-6 text-p-sm truncate">{{ subtitle(op) }}</p>
         </div>
 
-        <span class="text-ink-gray-6 text-sm shrink-0">{{ timing(op) }}</span>
-        <span class="lucide-chevron-right size-4 text-ink-gray-6 shrink-0" />
+        <!-- Completed is the norm; only exceptional states get a badge. -->
+        <Badge
+          v-if="badge(op)"
+          :label="badge(op).label"
+          :theme="badge(op).theme"
+          variant="subtle"
+        />
+        <span v-else />
+        <div class="flex justify-end items-center gap-3 min-w-0">
+          <span class="text-ink-gray-6 text-sm truncate">{{ timing(op) }}</span>
+          <span class="lucide-chevron-right size-4 text-ink-gray-6 shrink-0" />
+        </div>
       </RouterLink>
     </div>
 
@@ -58,30 +61,31 @@
 
 <script setup>
 import { onMounted, ref } from 'vue'
-import { Button, ErrorMessage } from 'frappe-ui'
+import { Badge, Button, ErrorMessage } from 'frappe-ui'
 import EmptyState from '@/components/common/EmptyState.vue'
 import ListRowSkeleton from '@/components/common/ListRowSkeleton.vue'
 import { updatesApi } from '@/api/updates'
-import { appsSummary, opTitle, pendingActionLabel, stateIcon, stateLabel } from '@/utils/updateFormat'
-import { fmtDuration, relativeTime } from '@/utils/taskFormat'
+import { opTitle, pendingActionLabel, stateLabel, stateTone } from '@/utils/updateFormat'
+import { fmtDateTime, fmtDuration, relativeTime } from '@/utils/taskFormat'
 
 const operations = ref([])
 const loading = ref(false)
 const error = ref('')
 
-const rowIcon = (op) => stateIcon(op.pending_action ? 'retrying' : op.state)
-
-function subtitle(op) {
-  const count = op.sites?.length || 0
-  const parts = [
-    op.pending_action ? pendingActionLabel(op.pending_action) : stateLabel(op.state),
-    `${count} site${count === 1 ? '' : 's'}`,
-    appsSummary(op),
-  ]
-  return parts.filter(Boolean).join(' · ')
+function badge(op) {
+  if (op.pending_action) return { label: pendingActionLabel(op.pending_action), theme: 'amber' }
+  if (op.state === 'completed') return null
+  const tone = stateTone(op.state)
+  return { label: stateLabel(op.state), theme: tone === 'orange' ? 'amber' : tone }
 }
 
-// Duration and age live together on the right, the way the task rows read them.
+// Two runs of the same apps share a title, so the run time stays on the row to tell them apart.
+function subtitle(op) {
+  const sites = op.sites || []
+  const where = sites.length === 1 ? sites[0].name : `${sites.length} sites`
+  return [where, fmtDateTime(op.started_at || op.created_at)].join(' · ')
+}
+
 function timing(op) {
   const parts = []
   if (op.finished_at && op.started_at) {

--- a/admin/frontend/dashboard/src/pages/updates/Updates.vue
+++ b/admin/frontend/dashboard/src/pages/updates/Updates.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="mx-auto max-w-3xl">
-    <Teleport defer to="#header-actions">
+    <!-- The tabs need a phone's full content width, so Refresh only joins them
+         once there is room to spare. -->
+    <Teleport v-if="isMobile" defer to="#header-actions">
       <Button
         variant="subtle"
         size="sm"
@@ -12,65 +14,123 @@
       />
     </Teleport>
 
-    <div v-if="loading && !operations.length" class="-mx-3">
+    <!-- A flex item sizes to the strip's natural width and overflows the screen;
+         a block child is held to the content width and fits. -->
+    <StickyToolbar :class="isMobile ? '' : 'flex items-center gap-2'">
+      <TabButtons
+        :size="isMobile ? 'md' : 'sm'"
+        :options="UPDATE_FILTERS"
+        :modelValue="statusFilter"
+        @update:modelValue="onFilterChange"
+      />
+      <Button
+        v-if="!isMobile"
+        class="ml-auto"
+        variant="subtle"
+        size="sm"
+        :loading="loading"
+        icon="lucide-refresh-cw"
+        label="Refresh"
+        tooltip="Refresh"
+        @click="load"
+      />
+    </StickyToolbar>
+
+    <div v-if="loading && !operations.length" class="-mx-3 mt-4">
       <ListRowSkeleton v-for="index in 6" :key="index" :index="index - 1" />
     </div>
     <div v-else-if="error" class="mt-4">
       <ErrorMessage :message="error" />
     </div>
 
-    <div
-      v-else-if="operations.length"
-      class="flex flex-col -mx-3 divide-y divide-outline-gray-1"
+    <!-- ListRow's own hover paints surface-sidebar, transparent in the dark
+         theme. Rows are links, hence the descendant selector. -->
+    <ListView
+      v-else-if="rows.length"
+      class="mt-4 [&_a:hover]:bg-surface-gray-1"
+      :columns="columns"
+      :rows="rows"
+      row-key="id"
+      :options="{ selectable: false, showTooltip: true, getRowRoute }"
     >
-      <RouterLink
-        v-for="op in operations"
-        :key="op.id"
-        :to="{ name: 'UpdateDetail', params: { operationId: op.id } }"
-        class="items-center gap-3 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] hover:bg-surface-gray-1 px-3 py-2.5 rounded no-underline transition-colors"
-      >
-        <div class="min-w-0">
-          <!-- A block, not a span: `truncate` is inert on an inline box. -->
-          <p class="font-medium text-ink-gray-9 text-base truncate">{{ opTitle(op) }}</p>
-          <p class="mt-0.5 text-ink-gray-6 text-p-sm truncate">{{ subtitle(op) }}</p>
-        </div>
-
+      <template #cell="{ column, row, item }">
         <!-- Completed is the norm; only exceptional states get a badge. -->
         <Badge
-          v-if="badge(op)"
-          :label="badge(op).label"
-          :theme="badge(op).theme"
+          v-if="column.key === 'badge'"
+          v-show="row.badge"
+          :label="row.badge?.label"
+          :theme="row.badge?.theme"
           variant="subtle"
         />
-        <span v-else />
-        <div class="flex justify-end items-center gap-3 min-w-0">
-          <span class="text-ink-gray-6 text-sm truncate">{{ timing(op) }}</span>
-          <span class="lucide-chevron-right size-4 text-ink-gray-6 shrink-0" />
-        </div>
-      </RouterLink>
-    </div>
+        <ListRowItem v-else :column="column" :row="row" :item="item" :align="column.align" />
+      </template>
+    </ListView>
 
     <EmptyState
       v-else
+      class="mt-8"
       icon="lucide-git-pull-request-arrow"
-      title="No updates yet"
-      description="App updates across your sites appear here, with backup and recovery."
+      :title="isFiltered ? 'No matching updates' : 'No updates yet'"
+      :description="
+        isFiltered
+          ? 'No updates are in this state right now.'
+          : 'App updates across your sites appear here, with backup and recovery.'
+      "
     />
   </div>
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue'
-import { Badge, Button, ErrorMessage } from 'frappe-ui'
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { Badge, Button, ErrorMessage, ListRowItem, ListView, TabButtons } from 'frappe-ui'
 import EmptyState from '@/components/common/EmptyState.vue'
 import ListRowSkeleton from '@/components/common/ListRowSkeleton.vue'
+import StickyToolbar from '@/components/common/StickyToolbar.vue'
+import { useIsMobile } from '@/composables/common/useIsMobile'
 import { updatesApi } from '@/api/updates'
-import { opTitle, pendingActionLabel, stateLabel, stateTone } from '@/utils/updateFormat'
-import { fmtDateTime, fmtDuration, relativeTime } from '@/utils/taskFormat'
+import {
+  matchesUpdateFilter,
+  opTitle,
+  pendingActionLabel,
+  siteNames,
+  sitesLabel,
+  stateLabel,
+  stateTone,
+  UPDATE_FILTERS,
+} from '@/utils/updateFormat'
+import { fmtDuration, relativeTime } from '@/utils/taskFormat'
+
+const route = useRoute()
+const router = useRouter()
+const isMobile = useIsMobile()
 
 const operations = ref([])
 const loading = ref(false)
 const error = ref('')
+
+const FILTER_VALUES = UPDATE_FILTERS.map((option) => option.value)
+
+// In the URL like the tasks list, so a filtered view survives a reload and can
+// be pasted to someone else.
+const statusFilter = computed(() => {
+  const value = typeof route.query.status === 'string' ? route.query.status : 'all'
+  return FILTER_VALUES.includes(value) ? value : 'all'
+})
+const isFiltered = computed(() => statusFilter.value !== 'all')
+
+// Filtered here rather than by the API: its status filter matches a single
+// state, and every tab but Completed and Reverted covers several.
+const visibleOperations = computed(() =>
+  operations.value.filter((op) => matchesUpdateFilter(op, statusFilter.value)),
+)
+
+function onFilterChange(value) {
+  const query = { ...route.query }
+  if (value === 'all') delete query.status
+  else query.status = value
+  router.replace({ name: 'Updates', query })
+}
 
 function badge(op) {
   if (op.pending_action) return { label: pendingActionLabel(op.pending_action), theme: 'amber' }
@@ -79,12 +139,29 @@ function badge(op) {
   return { label: stateLabel(op.state), theme: tone === 'orange' ? 'amber' : tone }
 }
 
-// Two runs of the same apps share a title, so the run time stays on the row to tell them apart.
-function subtitle(op) {
-  const sites = op.sites || []
-  const where = sites.length === 1 ? sites[0].name : `${sites.length} sites`
-  return [where, fmtDateTime(op.started_at || op.created_at)].join(' · ')
-}
+// Numeric widths are fr units (ListView convention) so the columns stretch to
+// fill the row instead of leaving dead space.
+const columns = [
+  { label: 'Update', key: 'title', align: 'left', width: 2 },
+  { label: 'Site', key: 'site', align: 'left', width: 2, getTooltip: (row) => row.siteNames },
+  { label: 'Status', key: 'badge', align: 'left', width: 1.5 },
+  { label: 'Last run', key: 'timing', align: 'right', width: 2 },
+]
+
+// ListRowItem reads row[column.key], so the operation is flattened to the four
+// strings the columns render.
+const rows = computed(() =>
+  visibleOperations.value.map((op) => ({
+    id: op.id,
+    title: opTitle(op),
+    site: sitesLabel(op),
+    siteNames: siteNames(op),
+    badge: badge(op),
+    timing: timing(op),
+  })),
+)
+
+const getRowRoute = (row) => ({ name: 'UpdateDetail', params: { operationId: row.id } })
 
 function timing(op) {
   const parts = []
@@ -103,9 +180,9 @@ async function load() {
       updatesApi.current().catch(() => null),
       updatesApi.list({ limit: 50 }),
     ])
-    const rows = history.data || []
+    const past = history.data || []
     // Pin the active/unresolved operation at the top (it is also in history).
-    operations.value = current ? [current, ...rows.filter((op) => op.id !== current.id)] : rows
+    operations.value = current ? [current, ...past.filter((op) => op.id !== current.id)] : past
   } catch (e) {
     error.value = e?.message || 'Could not load updates.'
   } finally {

--- a/admin/frontend/dashboard/src/utils/taskFormat.js
+++ b/admin/frontend/dashboard/src/utils/taskFormat.js
@@ -155,6 +155,14 @@ export function siteRoute(task) {
   return { name: 'SiteDetail', params: { name: site } }
 }
 
+// What a task ran against, so a detail header reads the same either way. A
+// bench-level task has no site: it belongs to the server itself.
+export function taskScope(task) {
+  const label = siteLabel(task)
+  if (label === 'Server-level') return { label: 'Server', route: { name: 'Server' } }
+  return { label, route: siteRoute(task) }
+}
+
 const REDIRECT_ON_SUCCESS_COMMANDS = [
   'new-site',
   'install-app',

--- a/admin/frontend/dashboard/src/utils/taskFormat.js
+++ b/admin/frontend/dashboard/src/utils/taskFormat.js
@@ -144,22 +144,25 @@ const SITE_ARG_KEY = {
   'new-site-from-backup': 'name',
 }
 
+// Work with no site of its own belongs to the server. Doubles as the value the
+// site filter carries, so it has to read as a label.
+export const SERVER_SCOPE = 'Server'
+
 export function siteLabel(task) {
   const key = SITE_ARG_KEY[task.command]
-  return (key && task.args?.[key]) || 'Server-level'
+  return (key && task.args?.[key]) || SERVER_SCOPE
 }
 
 export function siteRoute(task) {
   const site = siteLabel(task)
-  if (site === 'Server-level') return null
+  if (site === SERVER_SCOPE) return null
   return { name: 'SiteDetail', params: { name: site } }
 }
 
-// What a task ran against, so a detail header reads the same either way. A
-// bench-level task has no site: it belongs to the server itself.
+// What a task ran against, so a detail header reads the same either way.
 export function taskScope(task) {
   const label = siteLabel(task)
-  if (label === 'Server-level') return { label: 'Server', route: { name: 'Server' } }
+  if (label === SERVER_SCOPE) return { label, route: { name: 'Server' } }
   return { label, route: siteRoute(task) }
 }
 

--- a/admin/frontend/dashboard/src/utils/taskFormat.js
+++ b/admin/frontend/dashboard/src/utils/taskFormat.js
@@ -2,32 +2,22 @@ export const STATUS_CONFIG = {
   queued: {
     label: 'Queued',
     theme: 'blue',
-    icon: 'lucide-clock-3',
-    iconBg: 'bg-surface-gray-2 text-ink-gray-6',
   },
   success: {
     label: 'Success',
     theme: 'green',
-    icon: 'lucide-check',
-    iconBg: 'bg-surface-gray-2 text-ink-gray-6',
   },
   failed: {
     label: 'Failed',
     theme: 'red',
-    icon: 'lucide-x',
-    iconBg: 'bg-surface-red-2 text-ink-red-8',
   },
   running: {
     label: 'Running',
     theme: 'amber',
-    icon: 'lucide-loader-circle animate-spin',
-    iconBg: 'bg-surface-amber-2 text-ink-amber-8',
   },
   killed: {
     label: 'Killed',
     theme: 'gray',
-    icon: 'lucide-square',
-    iconBg: 'bg-surface-gray-2 text-ink-gray-6',
   },
 }
 

--- a/admin/frontend/dashboard/src/utils/taskFormat.js
+++ b/admin/frontend/dashboard/src/utils/taskFormat.js
@@ -224,3 +224,19 @@ export function fmtDateTime(iso) {
   if (!iso) return '-'
   return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
 }
+
+/**
+ * The list's trailing column. A queued task has no duration, so its place in
+ * the queue takes that slot - it is the only thing worth knowing about a task
+ * that has not started.
+ */
+export function taskTiming(task) {
+  if (task.status === 'queued') {
+    const position = task.queue_position ? `#${task.queue_position} in queue` : ''
+    return [position, relativeTime(task.queued_at)].filter(Boolean).join(' · ')
+  }
+  const duration = fmtDuration(task.duration_seconds)
+  return [duration ? `took ${duration}` : '', relativeTime(task.started_at || task.queued_at)]
+    .filter(Boolean)
+    .join(' · ')
+}

--- a/admin/frontend/dashboard/src/utils/taskFormat.test.js
+++ b/admin/frontend/dashboard/src/utils/taskFormat.test.js
@@ -8,6 +8,7 @@ import {
   relativeTime,
   siteRoute,
   statusConfig,
+  taskScope,
 } from './taskFormat.js'
 
 test('queued tasks have their own presentation', () => {
@@ -33,6 +34,17 @@ test('siteRoute links to the site behind a site-scoped task', () => {
     params: { name: 'a.local' },
   })
   assert.equal(siteRoute({ command: 'build', args: {} }), null)
+})
+
+test('taskScope names the server when a task is not bound to a site', () => {
+  assert.deepEqual(taskScope({ command: 'migrate', args: { site: 'a.local' } }), {
+    label: 'a.local',
+    route: { name: 'SiteDetail', params: { name: 'a.local' } },
+  })
+  assert.deepEqual(taskScope({ command: 'build', args: {} }), {
+    label: 'Server',
+    route: { name: 'Server' },
+  })
 })
 
 test('site-creating and app tasks redirect to the site page on success', () => {

--- a/admin/frontend/dashboard/src/utils/taskFormat.test.js
+++ b/admin/frontend/dashboard/src/utils/taskFormat.test.js
@@ -9,6 +9,7 @@ import {
   siteRoute,
   statusConfig,
   taskScope,
+  taskTiming,
 } from './taskFormat.js'
 
 test('queued tasks have their own presentation', () => {
@@ -98,4 +99,28 @@ test('cancelling follows the flag the backend sends', () => {
   assert.equal(isTaskCancellable({ status: 'running', is_cancellable: false }), false)
   assert.equal(isTaskCancellable({ status: 'running' }), false)
   assert.equal(isTaskCancellable(null), false)
+})
+
+test('taskTiming leads a queued task with its place in the queue', () => {
+  const queued = { status: 'queued', queue_position: 3, queued_at: new Date().toISOString() }
+  assert.match(taskTiming(queued), /^#3 in queue · /)
+  // Nothing has started, so a stale duration from an earlier attempt is ignored.
+  assert.doesNotMatch(taskTiming({ ...queued, duration_seconds: 42 }), /took/)
+})
+
+test('taskTiming omits the position when the queue has not reported one', () => {
+  const queued = { status: 'queued', queued_at: new Date().toISOString() }
+  assert.doesNotMatch(taskTiming(queued), /queue/)
+  assert.doesNotMatch(taskTiming(queued), /^ · /)
+})
+
+test('taskTiming reports how long a finished task took', () => {
+  const done = { status: 'success', duration_seconds: 93, started_at: new Date().toISOString() }
+  assert.match(taskTiming(done), /^took 1m 33s · /)
+})
+
+test('taskTiming falls back to the queued time when a task never started', () => {
+  const killed = { status: 'killed', queued_at: new Date().toISOString() }
+  assert.equal(taskTiming(killed).includes('took'), false)
+  assert.equal(taskTiming(killed).startsWith(' · '), false)
 })

--- a/admin/frontend/dashboard/src/utils/taskFormat.test.js
+++ b/admin/frontend/dashboard/src/utils/taskFormat.test.js
@@ -6,6 +6,8 @@ import {
   isTaskCancellable,
   redirectRouteOnSuccess,
   relativeTime,
+  SERVER_SCOPE,
+  siteLabel,
   siteRoute,
   statusConfig,
   taskScope,
@@ -27,6 +29,14 @@ test('queued and running tasks are active', () => {
 test('task timing tolerates a missing timestamp', () => {
   assert.equal(relativeTime(null), '')
   assert.equal(relativeTime(undefined), '')
+})
+
+test('siteLabel names the site, or the server when a task has none', () => {
+  assert.equal(siteLabel({ command: 'migrate', args: { site: 'a.local' } }), 'a.local')
+  assert.equal(siteLabel({ command: 'new-site', args: { name: 'a.local' } }), 'a.local')
+  assert.equal(siteLabel({ command: 'build', args: {} }), SERVER_SCOPE)
+  assert.equal(siteLabel({ command: 'migrate', args: {} }), SERVER_SCOPE)
+  assert.equal(siteLabel({ command: 'build' }), SERVER_SCOPE)
 })
 
 test('siteRoute links to the site behind a site-scoped task', () => {

--- a/admin/frontend/dashboard/src/utils/updateFormat.js
+++ b/admin/frontend/dashboard/src/utils/updateFormat.js
@@ -6,7 +6,12 @@ export function kindLabel(kind) {
 
 export function opTitle(op) {
   if (op?.kind === 'site_migrate') return `Migrate ${op.sites?.[0]?.name || 'site'}`
-  // Updates all look the same; the run time is what tells them apart.
+  // An update stores no name; name it by what it moves. Up to two picked apps read fine
+  // by name — beyond that, a count. Never "all apps": the bench's app list changes.
+  const picked = op?.apps_filter || []
+  if (picked.length && picked.length <= 2) return `Update ${picked.join(', ')}`
+  const count = picked.length || op?.apps?.length || 0
+  if (count) return `Update ${count} app${count === 1 ? '' : 's'}`
   return fmtDateTime(op?.started_at || op?.created_at)
 }
 
@@ -68,23 +73,6 @@ const STATE_LABEL = {
   reverting_apps: 'Reverting apps',
   reverting_sites: 'Recovering sites',
   restarting: 'Restarting services',
-}
-
-// Gray unless the state is worth interrupting for - see STATUS_CONFIG in
-// taskFormat.js, which this row shares its shape with.
-const STATE_ICON = {
-  green: { icon: 'lucide-check', iconBg: 'bg-surface-gray-2 text-ink-gray-6' },
-  red: { icon: 'lucide-x', iconBg: 'bg-surface-red-2 text-ink-red-8' },
-  blue: { icon: 'lucide-rotate-ccw', iconBg: 'bg-surface-gray-2 text-ink-gray-6' },
-  orange: {
-    icon: 'lucide-loader-circle animate-spin',
-    iconBg: 'bg-surface-amber-2 text-ink-amber-8',
-  },
-  gray: { icon: 'lucide-clock-3', iconBg: 'bg-surface-gray-2 text-ink-gray-6' },
-}
-
-export function stateIcon(state) {
-  return STATE_ICON[stateTone(state)]
 }
 
 export function stateTone(state) {

--- a/admin/frontend/dashboard/src/utils/updateFormat.js
+++ b/admin/frontend/dashboard/src/utils/updateFormat.js
@@ -1,5 +1,41 @@
 import { fmtDateTime } from './taskFormat.js'
 
+export const ACTIVE_STATES = [
+  'preparing',
+  'backing_up',
+  'updating',
+  'migrating',
+  'retrying',
+  'reverting_apps',
+  'reverting_sites',
+  'restarting',
+]
+export const ATTENTION_STATES = ['needs_attention', 'revert_failed']
+
+// The API's status filter matches one state exactly, so these groups can only
+// be applied client-side.
+const FILTER_STATES = {
+  active: ACTIVE_STATES,
+  attention: ATTENTION_STATES,
+  completed: ['completed'],
+  reverted: ['reverted'],
+}
+
+// One-word labels: five of them have to fit a 375px phone without scrolling.
+export const UPDATE_FILTERS = [
+  { label: 'All', value: 'all' },
+  { label: 'Running', value: 'active' },
+  { label: 'Attention', value: 'attention' },
+  { label: 'Completed', value: 'completed' },
+  { label: 'Reverted', value: 'reverted' },
+]
+
+// Every state belongs to exactly one group, so no update is unreachable.
+export function matchesUpdateFilter(operation, filter) {
+  if (filter === 'all') return true
+  return (FILTER_STATES[filter] || []).includes(operation?.state)
+}
+
 export function opTitle(op) {
   if (op?.kind === 'site_migrate') return `Migrate ${op.sites?.[0]?.name || 'site'}`
   // Operations store no name; two picked apps read fine by name, more become a count.
@@ -8,6 +44,22 @@ export function opTitle(op) {
   const count = picked.length || op?.apps?.length || 0
   if (count) return `Update ${count} app${count === 1 ? '' : 's'}`
   return fmtDateTime(op?.started_at || op?.created_at)
+}
+
+/**
+ * The Site column. One site reads by name; several would outgrow the column, so
+ * they collapse to a count and `siteNames` carries the full list into the cell's
+ * tooltip. An operation touching no site is bench-level work.
+ */
+export function sitesLabel(op) {
+  const sites = op?.sites || []
+  if (!sites.length) return 'Server'
+  if (sites.length === 1) return sites[0].name
+  return `${sites.length} sites`
+}
+
+export function siteNames(op) {
+  return (op?.sites || []).map((site) => site.name).join(', ')
 }
 
 export function patchSkipped(op) {

--- a/admin/frontend/dashboard/src/utils/updateFormat.js
+++ b/admin/frontend/dashboard/src/utils/updateFormat.js
@@ -80,7 +80,7 @@ export function siteStatus(site) {
   if (site.migration_status === 'success')
     return { label: 'Success', tone: 'green', value: 'success' }
   if (site.migration_status === 'running')
-    return { label: 'Running', tone: 'orange', busy: true, value: 'running' }
+    return { label: 'Migrating', tone: 'orange', busy: true, value: 'running' }
   if (site.migration_status === 'failed') return { label: 'Failed', tone: 'red', value: 'failed' }
   if (site.backup_status === 'backing_up')
     return { label: 'Backing up', tone: 'orange', busy: true, value: 'backing_up' }

--- a/admin/frontend/dashboard/src/utils/updateFormat.js
+++ b/admin/frontend/dashboard/src/utils/updateFormat.js
@@ -1,13 +1,8 @@
 import { fmtDateTime } from './taskFormat.js'
 
-export function kindLabel(kind) {
-  return kind === 'update' ? 'App update' : 'Site migration'
-}
-
 export function opTitle(op) {
   if (op?.kind === 'site_migrate') return `Migrate ${op.sites?.[0]?.name || 'site'}`
-  // An update stores no name; name it by what it moves. Up to two picked apps read fine
-  // by name — beyond that, a count. Never "all apps": the bench's app list changes.
+  // Operations store no name; two picked apps read fine by name, more become a count.
   const picked = op?.apps_filter || []
   if (picked.length && picked.length <= 2) return `Update ${picked.join(', ')}`
   const count = picked.length || op?.apps?.length || 0
@@ -36,13 +31,6 @@ export function pendingActionLabel(pending) {
   if (!pending) return ''
   const action = ACTION_LABEL[pending.role] || 'Action'
   return pending.status === 'running' ? `${action} in progress` : `${action} queued`
-}
-
-export function appsSummary(op) {
-  const names = (op.apps || []).map((a) => a.name)
-  if (!names.length) return ''
-  if (names.length <= 2) return names.join(', ')
-  return `${names.slice(0, 2).join(', ')} +${names.length - 2}`
 }
 
 const STATE_TONE = {

--- a/admin/frontend/dashboard/src/utils/updateFormat.js
+++ b/admin/frontend/dashboard/src/utils/updateFormat.js
@@ -1,4 +1,4 @@
-import { fmtDateTime } from './taskFormat.js'
+import { fmtDateTime, SERVER_SCOPE } from './taskFormat.js'
 
 export const ACTIVE_STATES = [
   'preparing',
@@ -53,7 +53,7 @@ export function opTitle(op) {
  */
 export function sitesLabel(op) {
   const sites = op?.sites || []
-  if (!sites.length) return 'Server'
+  if (!sites.length) return SERVER_SCOPE
   if (sites.length === 1) return sites[0].name
   return `${sites.length} sites`
 }

--- a/admin/frontend/dashboard/src/utils/updateFormat.test.js
+++ b/admin/frontend/dashboard/src/utils/updateFormat.test.js
@@ -2,8 +2,6 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
-  appsSummary,
-  kindLabel,
   opTitle,
   patchSkipped,
   pendingActionLabel,
@@ -12,11 +10,6 @@ import {
   stateTone,
 } from './updateFormat.js'
 import { fmtDateTime } from './taskFormat.js'
-
-test('kindLabel formats update and site_migrate', () => {
-  assert.equal(kindLabel('update'), 'App update')
-  assert.equal(kindLabel('site_migrate'), 'Site migration')
-})
 
 test('opTitle names the operation', () => {
   assert.equal(opTitle({ kind: 'update', apps_filter: ['erpnext'] }), 'Update erpnext')
@@ -37,16 +30,6 @@ test('opTitle names the operation', () => {
     'Migrate s1.localhost',
   )
   assert.equal(opTitle({ kind: 'site_migrate', sites: [] }), 'Migrate site')
-})
-
-test('appsSummary formats app list', () => {
-  assert.equal(appsSummary({ apps: [] }), '')
-  assert.equal(appsSummary({ apps: [{ name: 'erpnext' }] }), 'erpnext')
-  assert.equal(appsSummary({ apps: [{ name: 'erpnext' }, { name: 'hrms' }] }), 'erpnext, hrms')
-  assert.equal(
-    appsSummary({ apps: [{ name: 'erpnext' }, { name: 'hrms' }, { name: 'crm' }] }),
-    'erpnext, hrms +1',
-  )
 })
 
 test('stateTone and stateLabel format operation states', () => {

--- a/admin/frontend/dashboard/src/utils/updateFormat.test.js
+++ b/admin/frontend/dashboard/src/utils/updateFormat.test.js
@@ -79,7 +79,7 @@ test('siteStatus formats per-site lifecycle', () => {
   assert.equal(siteStatus({ migration_status: 'recovering' }).label, 'Recovering')
   assert.equal(siteStatus({ migration_status: 'recovered' }).label, 'Recovered')
   assert.equal(siteStatus({ migration_status: 'success' }).label, 'Success')
-  assert.equal(siteStatus({ migration_status: 'running' }).label, 'Running')
+  assert.equal(siteStatus({ migration_status: 'running' }).label, 'Migrating')
   assert.equal(siteStatus({ migration_status: 'failed' }).label, 'Failed')
   assert.equal(siteStatus({ backup_status: 'backing_up' }).label, 'Backing up')
   assert.equal(siteStatus({ backup_status: 'pending' }).label, 'Pending')

--- a/admin/frontend/dashboard/src/utils/updateFormat.test.js
+++ b/admin/frontend/dashboard/src/utils/updateFormat.test.js
@@ -2,12 +2,16 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 
 import {
+  matchesUpdateFilter,
   opTitle,
   patchSkipped,
   pendingActionLabel,
+  siteNames,
   siteStatus,
+  sitesLabel,
   stateLabel,
   stateTone,
+  UPDATE_FILTERS,
 } from './updateFormat.js'
 import { fmtDateTime } from './taskFormat.js'
 
@@ -83,6 +87,67 @@ test('siteStatus formats per-site lifecycle', () => {
   assert.equal(siteStatus({ migration_status: 'failed' }).label, 'Failed')
   assert.equal(siteStatus({ backup_status: 'backing_up' }).label, 'Backing up')
   assert.equal(siteStatus({ backup_status: 'pending' }).label, 'Pending')
+})
+
+test('sitesLabel names one site and counts the rest', () => {
+  assert.equal(sitesLabel({ sites: [{ name: 'a.localhost' }] }), 'a.localhost')
+  assert.equal(sitesLabel({ sites: [{ name: 'a.localhost' }, { name: 'b.localhost' }] }), '2 sites')
+  assert.equal(sitesLabel({ sites: Array(12).fill({ name: 'x' }) }), '12 sites')
+})
+
+test('sitesLabel calls an operation with no sites bench-level', () => {
+  assert.equal(sitesLabel({ sites: [] }), 'Server')
+  assert.equal(sitesLabel({}), 'Server')
+  assert.equal(sitesLabel(null), 'Server')
+})
+
+test('siteNames spells out the full list for the tooltip', () => {
+  assert.equal(
+    siteNames({ sites: [{ name: 'a.localhost' }, { name: 'b.localhost' }] }),
+    'a.localhost, b.localhost',
+  )
+  assert.equal(siteNames({}), '')
+})
+
+test('matchesUpdateFilter groups the states behind each tab', () => {
+  assert.equal(matchesUpdateFilter({ state: 'needs_attention' }, 'all'), true)
+  assert.equal(matchesUpdateFilter({ state: 'backing_up' }, 'active'), true)
+  assert.equal(matchesUpdateFilter({ state: 'completed' }, 'active'), false)
+  // A failed revert still wants a human, so it sits with the other red state.
+  assert.equal(matchesUpdateFilter({ state: 'needs_attention' }, 'attention'), true)
+  assert.equal(matchesUpdateFilter({ state: 'revert_failed' }, 'attention'), true)
+  assert.equal(matchesUpdateFilter({ state: 'completed' }, 'completed'), true)
+  assert.equal(matchesUpdateFilter({ state: 'reverted' }, 'reverted'), true)
+})
+
+test('matchesUpdateFilter survives an unknown filter or a stateless operation', () => {
+  assert.equal(matchesUpdateFilter({ state: 'completed' }, 'nonsense'), false)
+  assert.equal(matchesUpdateFilter({}, 'active'), false)
+  assert.equal(matchesUpdateFilter(null, 'all'), true)
+})
+
+// The canary: a new state added without a home would be filtered out of every
+// tab but All, so it would silently vanish from four of the five views.
+test('every operation state belongs to exactly one tab', () => {
+  const states = [
+    'completed',
+    'reverted',
+    'needs_attention',
+    'revert_failed',
+    'preparing',
+    'backing_up',
+    'updating',
+    'migrating',
+    'retrying',
+    'reverting_apps',
+    'reverting_sites',
+    'restarting',
+  ]
+  const tabs = UPDATE_FILTERS.filter(({ value }) => value !== 'all')
+  for (const state of states) {
+    const matched = tabs.filter(({ value }) => matchesUpdateFilter({ state }, value))
+    assert.equal(matched.length, 1, `${state} matched ${matched.length} tabs, expected 1`)
+  }
 })
 
 test('pendingActionLabel describes a queued action', () => {

--- a/admin/frontend/dashboard/src/utils/updateFormat.test.js
+++ b/admin/frontend/dashboard/src/utils/updateFormat.test.js
@@ -19,7 +19,16 @@ test('kindLabel formats update and site_migrate', () => {
 })
 
 test('opTitle names the operation', () => {
-  const op = { kind: 'update', started_at: '2026-07-21T12:15:37+00:00' }
+  assert.equal(opTitle({ kind: 'update', apps_filter: ['erpnext'] }), 'Update erpnext')
+  assert.equal(opTitle({ kind: 'update', apps_filter: ['erpnext', 'hrms'] }), 'Update erpnext, hrms')
+  assert.equal(opTitle({ kind: 'update', apps_filter: ['a', 'b', 'c'] }), 'Update 3 apps')
+  // No filter means the whole bench; a count stays stable as apps come and go.
+  assert.equal(
+    opTitle({ kind: 'update', apps: [{ name: 'frappe' }, { name: 'central' }] }),
+    'Update 2 apps',
+  )
+  // Nothing resolved yet: fall back to the run time, the only thing that tells runs apart.
+  const op = { kind: 'update', apps: [], started_at: '2026-07-21T12:15:37+00:00' }
   assert.equal(opTitle(op), fmtDateTime(op.started_at))
   const queued = { kind: 'update', created_at: '2026-07-21T13:00:00+00:00' }
   assert.equal(opTitle(queued), fmtDateTime(queued.created_at))

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -291,7 +291,7 @@ Starting an update or standalone migration returns both an operation identity an
 
 The global migration status button shows unresolved failures before active work, and active work before ordinary update availability.
 
-Each site row links to its retained backup and migration task attempts. The Target Apps card shows the original and updated commit and offers a GitHub comparison link when the app uses a GitHub repository.
+Each site row links to its retained backup and migration task attempts. Every entry in `task_logs` carries the task's own `status`, which is how the UI marks the attempt that failed; it is `null` only when the task is no longer readable. The Target Apps card shows the original and updated commit and offers a GitHub comparison link when the app uses a GitHub repository.
 
 ## Code Map
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -255,7 +255,9 @@ Successful sites are not migrated again. If the retry succeeds, Pilot continues 
 
 This action is available only when Pilot identified a failing patch.
 
-The API and operation both verify that the requested patch exactly matches the current diagnosis. Pilot then runs Frappe's `bypass-patch` command and records the decision. It does not retry automatically; the user must still choose Retry.
+The API and operation both verify that the requested patch exactly matches the current diagnosis. Pilot then runs Frappe's `bypass-patch` command and records the decision.
+
+`bypass_patch` re-arms the chain before returning: the failed site goes back to pending and the operation returns to `migrating`, so `BypassPatchTask` queues the next step itself. The migration resumes on its own — the user does not choose Retry afterwards.
 
 The normal update form never enables broad `--skip-failing` behavior.
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -293,7 +293,7 @@ Starting an update or standalone migration returns both an operation identity an
 
 The global migration status button shows unresolved failures before active work, and active work before ordinary update availability.
 
-Each site row links to its retained backup and migration task attempts. Every entry in `task_logs` carries the task's own `status`, which is how the UI marks the attempt that failed; it is `null` only when the task is no longer readable. The Target Apps card shows the original and updated commit and offers a GitHub comparison link when the app uses a GitHub repository.
+The detail page groups the chain into a Server section and a Sites section, split on whether a `task_logs` entry names a site: bench-level tasks (`update`, `revert-apps`, `restart-services`) on one side, per-site ones under their site row on the other. Every entry carries the task's own `status`, which is how the UI marks the attempt that failed; it is `null` only when the task is no longer readable. The Target Apps card shows the original and updated commit and offers a GitHub comparison link when the app uses a GitHub repository.
 
 ## Code Map
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -293,6 +293,8 @@ Starting an update or standalone migration returns both an operation identity an
 
 The global migration status button shows unresolved failures before active work, and active work before ordinary update availability.
 
+The list page filters by status through five tabs — All, Running, Attention, Completed, Reverted — held in the `status` query parameter so a filtered view survives a reload. Running covers every in-flight state and Attention covers both `needs_attention` and `revert_failed`, groupings the `status` API parameter cannot express because it matches one state exactly; the list therefore filters client-side over the page it already fetched.
+
 The detail page groups the chain into a Server section and a Sites section, split on whether a `task_logs` entry names a site: bench-level tasks (`update`, `revert-apps`, `restart-services`) on one side, per-site ones under their site row on the other. Every entry carries the task's own `status`, which is how the UI marks the attempt that failed; it is `null` only when the task is no longer readable. The Target Apps card shows the original and updated commit and offers a GitHub comparison link when the app uses a GitHub repository.
 
 ## Code Map

--- a/tests/admin/backend/api/test_migrations_api.py
+++ b/tests/admin/backend/api/test_migrations_api.py
@@ -16,6 +16,13 @@ def _write_bench_toml(bench_dir: Path, name: str, **settings) -> None:
     (bench_dir / "bench.toml").write_text(BenchConfig.from_flat(name, settings).dumps())
 
 
+def _write_task(bench_root: Path, task_id: str, status: str | None) -> None:
+    task_dir = bench_root / "tasks" / task_id
+    task_dir.mkdir(parents=True)
+    if status is not None:
+        (task_dir / "status").write_text(status)
+
+
 def _client(bench_root: Path, password: str = "secret"):
     from admin.backend.app import create_app
     from admin.backend.internal.session import Session
@@ -158,26 +165,56 @@ def test_migration_detail_includes_retained_task_logs(tmp_path: Path) -> None:
     (site_dir / "site_config.json").write_text("{}")
     client = _client(bench_root)
     operation = Bench(bench_root).migrations.create_site_migrate("site1.localhost")
+    backup = "20260101-000001-aaaaaa"
+    first_try = "20260101-000002-bbbbbb"
+    second_try = "20260101-000003-cccccc"
     operation.chain = [
-        {"command": "migration-backup", "task_id": "backup-1", "site": "site1.localhost"},
-        {"command": "migrate", "task_id": "migrate-1", "site": "site1.localhost"},
-        {"command": "migrate", "task_id": "migrate-2", "site": "site1.localhost"},
+        {"command": "migration-backup", "task_id": backup, "site": "site1.localhost"},
+        {"command": "migrate", "task_id": first_try, "site": "site1.localhost"},
+        {"command": "migrate", "task_id": second_try, "site": "site1.localhost"},
     ]
     operation.store.save(operation)
-    for task_id in ("backup-1", "migrate-1", "migrate-2"):
-        (bench_root / "tasks" / task_id).mkdir(parents=True)
+    for task_id, status in ((backup, "success"), (first_try, "failed"), (second_try, "running")):
+        _write_task(bench_root, task_id, status)
 
     response = client.get(f"/api/v1/migrations/{operation.id}")
 
     assert response.status_code == 200
     data = response.get_json()
+    # Status is what tells the UI which attempt of a retried step was the one that broke.
     assert data["task_logs"] == [
-        {"id": "backup-1", "label": "Backup", "site": "site1.localhost"},
-        {"id": "migrate-1", "label": "Migrate", "site": "site1.localhost"},
-        {"id": "migrate-2", "label": "Migrate (attempt 2)", "site": "site1.localhost"},
+        {"id": backup, "label": "Backup", "site": "site1.localhost", "status": "success"},
+        {"id": first_try, "label": "Migrate", "site": "site1.localhost", "status": "failed"},
+        {
+            "id": second_try,
+            "label": "Migrate (attempt 2)",
+            "site": "site1.localhost",
+            "status": "running",
+        },
     ]
     # Pruned task logs are omitted; the operation stays readable.
     assert all("tasks" not in site for site in data["sites"])
+
+
+def test_task_logs_report_no_status_for_a_half_pruned_task(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    site_dir = bench_root / "sites" / "site1.localhost"
+    site_dir.mkdir(parents=True)
+    (site_dir / "site_config.json").write_text("{}")
+    client = _client(bench_root)
+    operation = Bench(bench_root).migrations.create_site_migrate("site1.localhost")
+    task_id = "20260101-000004-dddddd"
+    operation.chain = [{"command": "migrate", "task_id": task_id, "site": "site1.localhost"}]
+    operation.store.save(operation)
+    _write_task(bench_root, task_id, status=None)
+
+    response = client.get(f"/api/v1/migrations/{operation.id}")
+
+    assert response.status_code == 200
+    # The entry still links to its log; only the verdict is missing.
+    assert response.get_json()["task_logs"] == [
+        {"id": task_id, "label": "Migrate", "site": "site1.localhost", "status": None}
+    ]
 
 
 def test_detail_reports_a_queued_action_while_the_operation_is_paused(tmp_path: Path) -> None:


### PR DESCRIPTION
Stacked on #342. Only the Tasks and Updates pages change here.

## Tasks
- List rows drop icon tiles for a three-column grid: title + site, centered status badge for non-success states only, timing right.
- Detail: status badge and actions live in the page header; the metadata grid becomes one line beside the site link; step icons are circles with a live spinner.

## Updates
- List reaches task parity: same row grid, badges only for exceptional states, operations titled by the apps they move ("Update central", "Update 3 apps") with the run time in the subtitle.
- Detail redesigned: breadcrumb badge + header refresh replace the title row; the failure alert loses its red fill, orders actions safe-to-destructive, and shows error output through LogView; Sites/Target apps/Skipped patches are collapsible cards in run order with smart open defaults, outcome captions, app logos, and diff-linked revision ranges with applied/planned tooltips.
- Fixed: "Update task" now opens the latest attempt's log after retries, and an in-flight run says "running for …" instead of "took …".

##Screenshots
<img width="1222" height="711" alt="Screenshot 2026-08-01 at 6 08 41 PM" src="https://github.com/user-attachments/assets/cfab2ccb-1c5e-40f1-a24f-322d3aab9cd5" />

<img width="1230" height="835" alt="Screenshot 2026-08-01 at 6 07 33 PM" src="https://github.com/user-attachments/assets/e8e9077d-b317-4649-bb66-87f7cf346637" />

<img width="1232" height="796" alt="Screenshot 2026-08-01 at 6 08 02 PM" src="https://github.com/user-attachments/assets/3f64c1ae-38b5-4ba4-b5e4-248891e818ae" />

<img width="1221" height="760" alt="Screenshot 2026-08-01 at 6 08 27 PM" src="https://github.com/user-attachments/assets/0cd180f3-175b-4420-8914-778726a284b8" />


## Tests
- `updateFormat` title tests extended for the new naming; 35/35 passing.
