### PR TITLE
fix: report real storage sizes instead of silent zeros

### DIFF
--- a/admin/backend/providers/storage.py
+++ b/admin/backend/providers/storage.py
@@ -7,18 +7,21 @@ from pathlib import Path
 from pilot.config import BenchConfig
 from pilot.core.bench import Bench
 from pilot.core.database import make_database, site_database_name
+from pilot.core.database.base import StorageComponent
 from pilot.exceptions import CommandError
 from pilot.utils import run_command
 
 _SYSTEM_SCHEMAS = {"mysql", "performance_schema", "information_schema", "sys"}
 
-_SCHEMA_SIZE_QUERY = (
-    "SELECT table_schema, COALESCE(SUM(data_length + index_length), 0) "
-    "FROM information_schema.TABLES GROUP BY table_schema"
-)
-_PG_DATABASE_SIZE_QUERY = (
-    "SELECT datname, pg_database_size(datname) FROM pg_database WHERE datistemplate = false"
-)
+_SIZE_QUERY_BY_ENGINE = {
+    "mariadb": (
+        "SELECT table_schema, COALESCE(SUM(data_length + index_length), 0) "
+        "FROM information_schema.TABLES GROUP BY table_schema"
+    ),
+    "postgres": (
+        "SELECT datname, pg_database_size(datname) FROM pg_database WHERE datistemplate = false"
+    ),
+}
 
 
 @dataclass
@@ -31,14 +34,16 @@ class DatabaseRow:
 
 @dataclass
 class DatabaseBreakdown:
+    """`core_bytes` is whatever the data directory holds beyond the databases
+    and `components`. It is None when that directory cannot be measured from
+    here - a remote server, or PostgreSQL's mode-0700 data directory."""
+
     engine: str
     supported: bool
     used_bytes: int
     binlog_bytes: int
-    core_bytes: int
-    error_log_bytes: int = 0
-    slow_log_bytes: int = 0
-    binlog_index_bytes: int = 0
+    core_bytes: int | None = None
+    components: list[StorageComponent] = field(default_factory=list)
     databases: list[DatabaseRow] = field(default_factory=list)
 
 
@@ -80,10 +85,25 @@ class StorageBreakdown:
 
 @lru_cache(maxsize=256)
 def directory_size_bytes(path: str) -> int:
-    try:
-        return int(run_command(["du", "-sb", path], timeout=10).stdout.split()[0])
-    except (OSError, CommandError, IndexError, ValueError):
+    """`du -sk` reports allocated blocks and is POSIX. GNU-only `-b` fails
+    outright on BSD/macOS, where it used to be swallowed into a silent 0.
+
+    Absent paths are legitimately empty (a site need not have every optional
+    directory). Anything else is a real failure and is left to raise."""
+    if not Path(path).exists():
         return 0
+    return int(run_command(["du", "-sk", path], timeout=10).stdout.split()[0]) * 1024
+
+
+def _data_directory_bytes(path: str | None) -> int | None:
+    """None means "cannot be measured", which is not the same as empty: the
+    server may be remote, and PostgreSQL keeps its data directory at 0700."""
+    if not path:
+        return None
+    try:
+        return directory_size_bytes(path)
+    except (OSError, CommandError, IndexError, ValueError):
+        return None
 
 
 _PRIVATE_SUBDIRS_EXCLUDED_FROM_OTHER = {"files", "backups"}
@@ -117,20 +137,6 @@ def _site_other_entries(site_path: Path) -> list[StorageItem]:
     return entries
 
 
-def _mariadb_variable_file_size(database, variable: str, data_dir: Path) -> int:
-    """Size of the file a MariaDB system variable (e.g. @@log_error) points at."""
-    value = str(database.get_scalar(f"SELECT {variable}") or "")
-    if not value:
-        return 0
-    path = Path(value)
-    if not path.is_absolute():
-        path = data_dir / path
-    try:
-        return path.stat().st_size
-    except OSError:
-        return 0
-
-
 class StorageProvider:
     """Disk usage breakdown for a bench's database engine and bench directories."""
 
@@ -149,57 +155,24 @@ class StorageProvider:
 
     def _database_breakdown(self) -> DatabaseBreakdown:
         engine = self._config.db_type
-        if engine == "mariadb":
-            return self._mariadb_breakdown()
-        if engine == "postgres":
-            return self._postgres_breakdown()
-        return DatabaseBreakdown(
-            engine=engine, supported=False, used_bytes=0, binlog_bytes=0, core_bytes=0
-        )
+        if engine not in _SIZE_QUERY_BY_ENGINE:
+            return DatabaseBreakdown(engine=engine, supported=False, used_bytes=0, binlog_bytes=0)
 
-    def _mariadb_breakdown(self) -> DatabaseBreakdown:
-        from pilot.managers.database.mariadb import MariaDBManager
-
-        data_dir = MariaDBManager(self._config.mariadb).data_dir
-        total_bytes = directory_size_bytes(str(data_dir))
         database = make_database(self._config)
-        databases = self._schema_sizes(database, _SCHEMA_SIZE_QUERY)
-        binlog_bytes = database.get_binlog_status().size_bytes
-        error_log_bytes = _mariadb_variable_file_size(database, "@@log_error", data_dir)
-        slow_log_bytes = _mariadb_variable_file_size(database, "@@slow_query_log_file", data_dir)
-        binlog_index_bytes = _mariadb_variable_file_size(database, "@@log_bin_index", data_dir)
-        schema_bytes = sum(row.bytes for row in databases)
-        core_bytes = max(
-            total_bytes
-            - binlog_bytes
-            - schema_bytes
-            - error_log_bytes
-            - slow_log_bytes
-            - binlog_index_bytes,
-            0,
+        databases = self._schema_sizes(database, _SIZE_QUERY_BY_ENGINE[engine])
+        components = database.get_storage_components()
+        total_bytes = _data_directory_bytes(database.get_data_directory())
+        accounted_bytes = sum(row.bytes for row in databases) + sum(
+            component.bytes for component in components
         )
+        binlog = next((c for c in components if c.key == "binlog"), None)
         return DatabaseBreakdown(
-            engine="mariadb",
+            engine=engine,
             supported=True,
-            used_bytes=total_bytes,
-            binlog_bytes=binlog_bytes,
-            core_bytes=core_bytes,
-            error_log_bytes=error_log_bytes,
-            slow_log_bytes=slow_log_bytes,
-            binlog_index_bytes=binlog_index_bytes,
-            databases=databases,
-        )
-
-    def _postgres_breakdown(self) -> DatabaseBreakdown:
-        database = make_database(self._config)
-        databases = self._schema_sizes(database, _PG_DATABASE_SIZE_QUERY)
-        used_bytes = sum(row.bytes for row in databases)
-        return DatabaseBreakdown(
-            engine="postgres",
-            supported=True,
-            used_bytes=used_bytes,
-            binlog_bytes=0,
-            core_bytes=0,
+            used_bytes=total_bytes if total_bytes is not None else accounted_bytes,
+            binlog_bytes=binlog.bytes if binlog else 0,
+            core_bytes=None if total_bytes is None else max(total_bytes - accounted_bytes, 0),
+            components=components,
             databases=databases,
         )
 

--- a/admin/backend/providers/storage.py
+++ b/admin/backend/providers/storage.py
@@ -146,6 +146,10 @@ class StorageProvider:
         self._bench = Bench(self._config, bench_root)
 
     def get_breakdown(self, disk_total: int, disk_used: int) -> StorageBreakdown:
+        """Measures fresh. The cache exists for the 10s /metrics poll, and it
+        never expires, so leaving it in place pins every directory to its first
+        reading for the life of the process - including on an explicit refresh."""
+        directory_size_bytes.cache_clear()
         return StorageBreakdown(
             disk_total=disk_total,
             disk_used=disk_used,

--- a/admin/frontend/dashboard/src/components/server/DatabaseStorageCard.vue
+++ b/admin/frontend/dashboard/src/components/server/DatabaseStorageCard.vue
@@ -14,49 +14,34 @@ interface Props {
 const props = defineProps<Props>()
 const emit = defineEmits<{ purged: [] }>()
 
-const COLORS = {
+const COLORS: Record<string, string> = {
   binlog: 'amber-7',
+  wal: 'amber-7',
   databases: 'violet-7',
   core: 'cyan-7',
-  errorLog: 'amber-7',
-  slowLog: 'cyan-7',
-  binlogIndex: 'blue-7',
+  error_log: 'orange-7',
+  server_log: 'orange-7',
+  slow_log: 'pink-7',
+  binlog_index: 'blue-7',
 }
 
 const GROUP_SHOWN_COUNT = 3
 
-const groupParts = computed(() => {
-  const schemaBytes = props.data.databases.reduce((sum, row) => sum + row.bytes, 0)
-
-  return [
-    {
-      label: `${props.data.engine} binary log`,
-      bytes: props.data.binlog_bytes,
-      color: COLORS.binlog,
-    },
+const groupParts = computed(() =>
+  [
     {
       label: `${props.data.databases.length} databases`,
-      bytes: schemaBytes,
+      bytes: props.data.databases.reduce((sum, row) => sum + row.bytes, 0),
       color: COLORS.databases,
     },
+    ...props.data.components.map((component) => ({
+      label: `${props.data.engine} ${component.label}`,
+      bytes: component.bytes,
+      color: COLORS[component.key] ?? 'gray-7',
+    })),
     { label: `${props.data.engine} core files`, bytes: props.data.core_bytes, color: COLORS.core },
-    {
-      label: `${props.data.engine} error log`,
-      bytes: props.data.error_log_bytes,
-      color: COLORS.errorLog,
-    },
-    {
-      label: `${props.data.engine} slow log`,
-      bytes: props.data.slow_log_bytes,
-      color: COLORS.slowLog,
-    },
-    {
-      label: `${props.data.engine} binlog indexes`,
-      bytes: props.data.binlog_index_bytes,
-      color: COLORS.binlogIndex,
-    },
-  ].sort((a, b) => b.bytes - a.bytes)
-})
+  ].sort((a, b) => (b.bytes ?? -1) - (a.bytes ?? -1)),
+)
 
 const sortedDatabases = computed(() => [...props.data.databases].sort((a, b) => b.bytes - a.bytes))
 
@@ -72,6 +57,11 @@ const visibleDatabases = computed(() =>
 
 const hiddenCount = computed(() =>
   showAllDatabases.value ? 0 : Math.max(sortedDatabases.value.length - VISIBLE_DATABASE_COUNT, 0),
+)
+
+// Not hiddenCount > 0: that goes to 0 once expanded, taking "Show less" with it.
+const isDatabaseListExpandable = computed(
+  () => sortedDatabases.value.length > VISIBLE_DATABASE_COUNT,
 )
 </script>
 
@@ -134,6 +124,7 @@ const hiddenCount = computed(() =>
       </div>
 
       <button
+        v-if="isDatabaseListExpandable"
         type="button"
         @click="showAllDatabases = !showAllDatabases"
         class="flex items-center gap-2 text-sm text-ink-gray-6 hover:text-ink-gray-8 mt-2"
@@ -146,6 +137,7 @@ const hiddenCount = computed(() =>
       </button>
 
       <BinlogPurgeAlert
+        v-if="data.engine === 'mariadb'"
         :bytes="data.binlog_bytes"
         @purged="emit('purged')"
       />

--- a/pilot/core/database/base.py
+++ b/pilot/core/database/base.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any
 
+from pilot.exceptions import DatabaseError
+
 
 @dataclass
 class QueryResult:
@@ -73,6 +75,16 @@ class BinlogFile:
     modified_ms: int | None  # None when the binlog directory is remote or unreadable
 
 
+@dataclass
+class StorageComponent:
+    """One on-disk artifact the engine keeps alongside the databases. `key`
+    identifies it across engines; `label` names it in the engine's own terms."""
+
+    key: str
+    label: str
+    bytes: int
+
+
 class Database(ABC):
     @abstractmethod
     def execute(self, query: str, read_only: bool = True) -> QueryResult: ...
@@ -120,3 +132,18 @@ class Database(ABC):
 
     def purge_binlogs(self, up_to: str) -> None:
         raise NotImplementedError
+
+    def get_storage_components(self) -> list[StorageComponent]:
+        """Sizes of the engine's own files, excluding the databases."""
+        raise NotImplementedError
+
+    def get_data_directory(self) -> str | None:
+        """Server data directory, or None when the server is not on this host
+        and the path would therefore be meaningless locally."""
+        raise NotImplementedError
+
+    def get_scalar(self, query: str):
+        result = self.execute(query)
+        if not result.rows:
+            raise DatabaseError(f"Query returned no rows: {query}")
+        return result.rows[0][0]

--- a/pilot/core/database/engines/mariadb.py
+++ b/pilot/core/database/engines/mariadb.py
@@ -11,6 +11,7 @@ from pilot.core.database.base import (
     LockWaitRow,
     LockWaitStatus,
     QueryResult,
+    StorageComponent,
     TableSize,
 )
 from pilot.core.database.engines.helpers import (
@@ -323,14 +324,46 @@ class MariaDB(Database):
             raise DatabaseError(f"Unknown binlog file: {up_to}")
         self.execute(f"PURGE BINARY LOGS TO '{up_to}'", read_only=False)
 
+    def get_data_directory(self) -> str | None:
+        if not is_local_host(self._host, self._socket):
+            return None
+        return str(self.get_scalar("SELECT @@datadir"))
+
+    def get_storage_components(self) -> list[StorageComponent]:
+        data_dir = Path(self.get_data_directory() or ".")
+        return [
+            StorageComponent("binlog", "binary log", self.get_binlog_status().size_bytes),
+            StorageComponent(
+                "error_log", "error log", self._variable_file_size("@@log_error", data_dir)
+            ),
+            StorageComponent(
+                "slow_log",
+                "slow query log",
+                self._variable_file_size("@@slow_query_log_file", data_dir),
+            ),
+            StorageComponent(
+                "binlog_index",
+                "binary log index",
+                self._variable_file_size("@@log_bin_index", data_dir),
+            ),
+        ]
+
+    def _variable_file_size(self, variable: str, data_dir: Path) -> int:
+        """Size of the file a system variable points at. Unset variables and
+        unreadable paths both mean "nothing to count here"."""
+        value = str(self.get_scalar(f"SELECT {variable}") or "")
+        if not value:
+            return 0
+        path = Path(value)
+        if not path.is_absolute():
+            path = data_dir / path
+        try:
+            return path.stat().st_size
+        except OSError:
+            return 0
+
     def get_status_value(self, variable: str) -> int:
         result = self.execute(f"SHOW GLOBAL STATUS LIKE '{variable}'")
         if not result.rows:
             raise DatabaseError(f"Unknown status variable: {variable}")
         return int(result.rows[0][1])
-
-    def get_scalar(self, query: str):
-        result = self.execute(query)
-        if not result.rows:
-            raise DatabaseError(f"Query returned no rows: {query}")
-        return result.rows[0][0]

--- a/pilot/core/database/engines/postgres.py
+++ b/pilot/core/database/engines/postgres.py
@@ -8,6 +8,7 @@ from pilot.core.database.base import (
     LockWaitRow,
     LockWaitStatus,
     QueryResult,
+    StorageComponent,
     TableSize,
 )
 from pilot.core.database.engines.helpers import (
@@ -214,12 +215,31 @@ class PostgreSQL(Database):
         ]
 
     def _free_disk_bytes(self) -> int | None:
+        data_directory = self.get_data_directory()
+        return disk_free(data_directory) if data_directory else None
+
+    def get_data_directory(self) -> str | None:
         if not is_local_host(self._host):
             return None
         result = self.execute("SELECT setting FROM pg_settings WHERE name = 'data_directory'")
-        if not result.rows:
-            return None
-        return disk_free(str(result.rows[0][0]))
+        return str(result.rows[0][0]) if result.rows else None
 
-    # No binary log: WAL archiving is configured server-side. Falls back to
-    # Database's default get_binlog_status/get_binlog_files/purge_binlogs.
+    def get_storage_components(self) -> list[StorageComponent]:
+        """PostgreSQL's counterpart to the binary log is the WAL, and it has no
+        separate slow-query log - slow statements go to the server log."""
+        return [
+            StorageComponent("wal", "write-ahead log", self._directory_listing_bytes("waldir")),
+            StorageComponent("server_log", "server log", self._server_log_bytes()),
+        ]
+
+    def _server_log_bytes(self) -> int:
+        """With logging_collector off the server logs to stderr, so there is no
+        log directory of its own to measure."""
+        if str(self.get_scalar("SHOW logging_collector")).lower() not in ("on", "true"):
+            return 0
+        return self._directory_listing_bytes("logdir")
+
+    def _directory_listing_bytes(self, directory: str) -> int:
+        """pg_ls_waldir/pg_ls_logdir report sizes server-side, so they work for
+        a remote host and need no filesystem access from here."""
+        return int(self.get_scalar(f"SELECT COALESCE(SUM(size), 0) FROM pg_ls_{directory}()"))

--- a/tests/admin/backend/providers/test_storage_provider.py
+++ b/tests/admin/backend/providers/test_storage_provider.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from pilot.config import BenchConfig
-from pilot.core.database.base import BinlogStatus, QueryResult
+from pilot.core.database.base import QueryResult, StorageComponent
 
 
 def _write_bench(bench_root: Path, db_type: str = "mariadb") -> None:
@@ -85,39 +85,14 @@ def test_site_storage_splits_private_public_and_backups(tmp_path: Path) -> None:
     assert "backups" not in other_names
 
 
-def test_mariadb_variable_file_size_reads_relative_path(tmp_path: Path) -> None:
-    from admin.backend.providers.storage import _mariadb_variable_file_size
-
-    (tmp_path / "mariadb.err").write_bytes(b"x" * 777)
+def _mock_database(rows: list[list], components: list[StorageComponent], data_dir: str) -> Mock:
     db = Mock()
-    db.get_scalar.return_value = "mariadb.err"
-
-    size = _mariadb_variable_file_size(db, "@@log_error", tmp_path)
-
-    assert size == 777
-    db.get_scalar.assert_called_once_with("SELECT @@log_error")
-
-
-def test_mariadb_variable_file_size_reads_absolute_path(tmp_path: Path) -> None:
-    from admin.backend.providers.storage import _mariadb_variable_file_size
-
-    log_file = tmp_path / "elsewhere.log"
-    log_file.write_bytes(b"x" * 42)
-    db = Mock()
-    db.get_scalar.return_value = str(log_file)
-
-    assert _mariadb_variable_file_size(db, "@@slow_query_log_file", tmp_path) == 42
-
-
-def test_mariadb_variable_file_size_is_zero_when_unset_or_missing(tmp_path: Path) -> None:
-    from admin.backend.providers.storage import _mariadb_variable_file_size
-
-    db = Mock()
-    db.get_scalar.return_value = ""
-    assert _mariadb_variable_file_size(db, "@@slow_query_log_file", tmp_path) == 0
-
-    db.get_scalar.return_value = "does-not-exist.log"
-    assert _mariadb_variable_file_size(db, "@@log_bin_index", tmp_path) == 0
+    db.execute.return_value = QueryResult(
+        columns=["schema", "bytes"], rows=rows, duration_ms=1.0
+    )
+    db.get_storage_components.return_value = components
+    db.get_data_directory.return_value = data_dir
+    return db
 
 
 def test_mariadb_breakdown_shapes_schemas_and_reconciles_core(tmp_path: Path) -> None:
@@ -125,36 +100,96 @@ def test_mariadb_breakdown_shapes_schemas_and_reconciles_core(tmp_path: Path) ->
 
     _write_bench(tmp_path)
     _make_site(tmp_path, "site1.local", "site1_db")
-
-    db = Mock()
-    db.execute.return_value = QueryResult(
-        columns=["table_schema", "bytes"],
-        rows=[["site1_db", 500], ["mysql", 100]],
-        duration_ms=1.0,
-    )
-    db.get_binlog_status.return_value = BinlogStatus(enabled=True, file_count=1, size_bytes=50)
-    db.get_scalar.return_value = ""
+    components = [
+        StorageComponent("binlog", "binary log", 50),
+        StorageComponent("error_log", "error log", 20),
+        StorageComponent("slow_log", "slow query log", 0),
+        StorageComponent("binlog_index", "binary log index", 0),
+    ]
+    db = _mock_database([["site1_db", 500], ["mysql", 100]], components, str(tmp_path))
 
     with (
         patch("admin.backend.providers.storage.make_database", return_value=db),
         patch("admin.backend.providers.storage.directory_size_bytes", return_value=1000),
     ):
-        breakdown = StorageProvider(tmp_path)._mariadb_breakdown()
+        breakdown = StorageProvider(tmp_path)._database_breakdown()
 
     assert breakdown == DatabaseBreakdown(
         engine="mariadb",
         supported=True,
         used_bytes=1000,
         binlog_bytes=50,
-        core_bytes=350,  # 1000 - 50 - (500 + 100)
-        error_log_bytes=0,
-        slow_log_bytes=0,
-        binlog_index_bytes=0,
+        core_bytes=330,  # 1000 - (500 + 100) - (50 + 20)
+        components=components,
         databases=[
             DatabaseRow(schema="site1_db", site="site1.local", system=False, bytes=500),
             DatabaseRow(schema="mysql", site=None, system=True, bytes=100),
         ],
     )
+
+
+def test_postgres_breakdown_reports_wal_and_server_log(tmp_path: Path) -> None:
+    """The engine names its own artifacts; postgres has no binlog, so
+    binlog_bytes stays 0 and the purge alert has nothing to act on."""
+    from admin.backend.providers.storage import StorageProvider
+
+    _write_bench(tmp_path, db_type="postgres")
+    _make_site(tmp_path, "site1.local", "site1_db")
+    components = [
+        StorageComponent("wal", "write-ahead log", 300),
+        StorageComponent("server_log", "server log", 100),
+    ]
+    db = _mock_database([["site1_db", 500], ["postgres", 60]], components, "/pg/data")
+
+    with (
+        patch("admin.backend.providers.storage.make_database", return_value=db),
+        patch("admin.backend.providers.storage.directory_size_bytes", return_value=2000),
+    ):
+        breakdown = StorageProvider(tmp_path)._database_breakdown()
+
+    assert breakdown.engine == "postgres"
+    assert breakdown.supported is True
+    assert breakdown.used_bytes == 2000
+    assert breakdown.binlog_bytes == 0
+    assert breakdown.core_bytes == 1040  # 2000 - (500 + 60) - (300 + 100)
+    assert breakdown.components == components
+    assert [row.site for row in breakdown.databases] == ["site1.local", None]
+
+
+def test_core_bytes_is_unknown_when_the_data_directory_cannot_be_read(tmp_path: Path) -> None:
+    """An unreadable data directory is not an empty one - core_bytes goes None
+    and used_bytes falls back to what was actually measured."""
+    from admin.backend.providers.storage import StorageProvider
+    from pilot.exceptions import CommandError
+
+    _write_bench(tmp_path, db_type="postgres")
+    components = [StorageComponent("wal", "write-ahead log", 300)]
+    db = _mock_database([["postgres", 60]], components, "/pg/data")
+
+    with (
+        patch("admin.backend.providers.storage.make_database", return_value=db),
+        patch(
+            "admin.backend.providers.storage.directory_size_bytes",
+            side_effect=CommandError("Permission denied"),
+        ),
+    ):
+        breakdown = StorageProvider(tmp_path)._database_breakdown()
+
+    assert breakdown.core_bytes is None
+    assert breakdown.used_bytes == 360
+
+
+def test_core_bytes_is_unknown_for_a_remote_database_server(tmp_path: Path) -> None:
+    from admin.backend.providers.storage import StorageProvider
+
+    _write_bench(tmp_path)
+    db = _mock_database([["site1_db", 500]], [StorageComponent("binlog", "binary log", 50)], None)
+
+    with patch("admin.backend.providers.storage.make_database", return_value=db):
+        breakdown = StorageProvider(tmp_path)._database_breakdown()
+
+    assert breakdown.core_bytes is None
+    assert breakdown.used_bytes == 550
 
 
 def test_sqlite_engine_is_not_supported(tmp_path: Path) -> None:
@@ -165,5 +200,16 @@ def test_sqlite_engine_is_not_supported(tmp_path: Path) -> None:
     breakdown = StorageProvider(tmp_path)._database_breakdown()
 
     assert breakdown == DatabaseBreakdown(
-        engine="sqlite", supported=False, used_bytes=0, binlog_bytes=0, core_bytes=0
+        engine="sqlite", supported=False, used_bytes=0, binlog_bytes=0
     )
+
+
+def test_directory_size_bytes_measures_a_real_tree(tmp_path: Path) -> None:
+    """Guards the du flags: GNU-only `-b` fails outright on BSD/macOS, which
+    used to be swallowed into a silent 0."""
+    from admin.backend.providers.storage import directory_size_bytes
+
+    (tmp_path / "payload.bin").write_bytes(b"x" * 40960)
+
+    assert directory_size_bytes(str(tmp_path)) >= 40960
+    assert directory_size_bytes(str(tmp_path / "missing")) == 0

--- a/tests/admin/backend/providers/test_storage_provider.py
+++ b/tests/admin/backend/providers/test_storage_provider.py
@@ -204,6 +204,24 @@ def test_sqlite_engine_is_not_supported(tmp_path: Path) -> None:
     )
 
 
+def test_get_breakdown_remeasures_instead_of_serving_the_cache(tmp_path: Path) -> None:
+    """directory_size_bytes is cached for the /metrics poll and never expires,
+    so a refresh would otherwise report the first reading forever."""
+    from admin.backend.providers.storage import StorageProvider
+
+    _write_bench(tmp_path)
+    _make_app(tmp_path, "frappe", b"a" * 4096)
+    db = _mock_database([["site1_db", 500]], [], str(tmp_path))
+
+    with patch("admin.backend.providers.storage.make_database", return_value=db):
+        provider = StorageProvider(tmp_path)
+        first = provider.get_breakdown(1000, 500).bench.apps_bytes
+        (tmp_path / "apps" / "frappe" / "grew.bin").write_bytes(b"a" * 200_000)
+        second = provider.get_breakdown(1000, 500).bench.apps_bytes
+
+    assert second > first
+
+
 def test_directory_size_bytes_measures_a_real_tree(tmp_path: Path) -> None:
     """Guards the du flags: GNU-only `-b` fails outright on BSD/macOS, which
     used to be swallowed into a silent 0."""

--- a/tests/pilot/core/test_database.py
+++ b/tests/pilot/core/test_database.py
@@ -493,6 +493,78 @@ def test_mariadb_get_binlog_files_empty_when_disabled() -> None:
         assert db.get_binlog_files() == []
 
 
+def test_mariadb_get_storage_components_measures_each_log(tmp_path: Path) -> None:
+    """@@log_error is relative to datadir, @@slow_query_log_file absolute, and
+    @@log_bin_index unset - all three resolve without special-casing."""
+    db = MariaDB(host="localhost", port=3306, user="u", password="p", database="")
+    (tmp_path / "mysql-bin.000001").write_bytes(b"x" * 1024)
+    (tmp_path / "mariadb.err").write_bytes(b"x" * 777)
+    (tmp_path / "slow.log").write_bytes(b"x" * 42)
+    responses = _binlog_responses(tmp_path) | {
+        "@@datadir": (["@@datadir"], [[str(tmp_path)]]),
+        "@@log_error": (["@@log_error"], [["mariadb.err"]]),
+        "@@slow_query_log_file": (["@@slow_query_log_file"], [[str(tmp_path / "slow.log")]]),
+        "@@log_bin_index": (["@@log_bin_index"], [[""]]),
+    }
+
+    with patch.object(MariaDB, "execute", _canned_execute(responses)):
+        components = db.get_storage_components()
+
+    assert {c.key: c.bytes for c in components} == {
+        "binlog": 3072,
+        "error_log": 777,
+        "slow_log": 42,
+        "binlog_index": 0,
+    }
+    assert [c.label for c in components] == [
+        "binary log",
+        "error log",
+        "slow query log",
+        "binary log index",
+    ]
+
+
+def test_mariadb_get_data_directory_is_none_for_a_remote_server() -> None:
+    db = MariaDB(host="db.example.com", port=3306, user="u", password="p", database="")
+    assert db.get_data_directory() is None
+
+
+def test_postgres_get_storage_components_reports_wal_and_server_log() -> None:
+    db = PostgreSQL(host="localhost", port=5432, user="u", password="p", database="d")
+    responses = {
+        "pg_ls_waldir": (["sum"], [[33554432]]),
+        "SHOW logging_collector": (["logging_collector"], [["on"]]),
+        "pg_ls_logdir": (["sum"], [[8192]]),
+    }
+
+    with patch.object(PostgreSQL, "execute", _canned_execute(responses)):
+        components = db.get_storage_components()
+
+    assert [(c.key, c.label, c.bytes) for c in components] == [
+        ("wal", "write-ahead log", 33554432),
+        ("server_log", "server log", 8192),
+    ]
+
+
+def test_postgres_server_log_is_zero_without_the_logging_collector() -> None:
+    """Logging to stderr leaves no log directory for pg_ls_logdir to size."""
+    db = PostgreSQL(host="localhost", port=5432, user="u", password="p", database="d")
+    responses = {
+        "pg_ls_waldir": (["sum"], [[16777216]]),
+        "SHOW logging_collector": (["logging_collector"], [["off"]]),
+    }
+
+    with patch.object(PostgreSQL, "execute", _canned_execute(responses)):
+        components = db.get_storage_components()
+
+    assert {c.key: c.bytes for c in components} == {"wal": 16777216, "server_log": 0}
+
+
+def test_postgres_get_data_directory_is_none_for_a_remote_server() -> None:
+    db = PostgreSQL(host="db.example.com", port=5432, user="u", password="p", database="d")
+    assert db.get_data_directory() is None
+
+
 def test_mariadb_purge_binlogs_issues_purge_for_known_file(tmp_path: Path) -> None:
     db = MariaDB(host="h", port=3306, user="u", password="p", database="")
     calls: list = []


### PR DESCRIPTION
The storage panel showed 0 B for every app, site and log directory on macOS, and rendered five permanently-zero MariaDB rows under PostgreSQL.

**`du -sb` is GNU-only.** BSD/macOS rejects it, `CommandError` was caught, and the failure was returned as `0` — indistinguishable from an empty directory. Now POSIX `du -sk`. Absent paths still return 0 explicitly (a site need not have every optional directory); a command failure raises instead of masquerading as empty.

**PostgreSQL rows were fabricated.** `binlog`/`core`/`error_log`/`slow_log`/`binlog_index` were hardcoded to 0, and the card templated the engine name into MariaDB labels — producing "postgres binlog indexes" for something that does not exist. Each engine now names and measures its own files via `get_storage_components()`:

- PostgreSQL: write-ahead log (`pg_ls_waldir()`), server log (`pg_ls_logdir()`, zero when `logging_collector` is off since there is then no log directory to own). Both size server-side, so they work against a remote host.
- MariaDB: unchanged set, but `_mariadb_variable_file_size` moves out of the admin provider into the engine.

Slow-query log and binlog index have no PostgreSQL counterpart — slow statements go to the same server log — so those two rows are MariaDB-only rather than always-zero.

**`get_data_directory()` returns None for a remote server.** The provider previously measured the local `MariaDBManager` data directory even when the server was elsewhere, reporting a total for the wrong host. `core_bytes` becomes `int | None` — PostgreSQL keeps its data directory at mode 0700, and an unreadable directory is not an empty one, so it renders as an em dash instead of a fabricated 0.

Also: gate the purge alert on MariaDB (on PostgreSQL it mounted and called `binlogs.list()`, which raises `NotImplementedError`), and hide the database list toggle when there is nothing to expand.

## Verified

Against a live PostgreSQL bench — WAL 832.0 MB, 3 databases 233.5 MB, core files 25.7 MB, server log 0 B, apps 3.5 GB, site files 1.7 MB, logs 3.0 MB. Previously every one of those read 0 B except the databases.

`tests/admin/backend/providers/test_storage_provider.py` and `tests/pilot/core/test_database.py` — 76 passed. The two bench-breakdown tests were failing on macOS before this and now pass.