### PR TITLE
fix: run bench Python processes with unbuffered stdout

### DIFF
--- a/pilot/managers/processes/definitions.py
+++ b/pilot/managers/processes/definitions.py
@@ -76,11 +76,15 @@ class ProcessDefinitionBuilder:
             return self.web_definition(dev=True)
         return pd
 
-    def py_memory_env(self) -> dict:
+    def python_env(self) -> dict:
+        """Shared env for Python processes. PYTHONUNBUFFERED keeps stdout unbuffered:
+        every runner captures it into a pipe or log file, where Python would otherwise
+        block-buffer app-code print() until ~8KB accumulates."""
+        env = {"PYTHONUNBUFFERED": "1"}
         arenas = self.bench.config.gunicorn.malloc_arena_max
         if arenas and arenas > 0:
-            return {"MALLOC_ARENA_MAX": str(arenas)}
-        return {}
+            env["MALLOC_ARENA_MAX"] = str(arenas)
+        return env
 
     def web_definition(self, dev: bool = False) -> ProcessDefinition:
         sites = self.bench.sites_path
@@ -101,7 +105,7 @@ class ProcessDefinitionBuilder:
                 name="web",
                 argv=argv,
                 log_file=self.bench.logs_path / "web.log",
-                env={"DEV_SERVER": "1"},
+                env={**self.python_env(), "DEV_SERVER": "1"},
                 working_dir=sites,
             )
         gunicorn = self.bench.env_path / "bin" / "gunicorn"
@@ -110,7 +114,7 @@ class ProcessDefinitionBuilder:
             name="web",
             argv=[str(gunicorn), "-c", "../config/gunicorn.conf.py", "frappe.app:application"],
             log_file=self.bench.logs_path / "web.log",
-            env=self.py_memory_env(),
+            env=self.python_env(),
             working_dir=sites,
             stop_timeout=1600 if companion else None,
         )
@@ -119,7 +123,7 @@ class ProcessDefinitionBuilder:
         if self.bench.config.socketio_backend == "python":
             argv = [str(self.python), "-m", "frappe.realtime.server"]
             working_dir = self.bench.path
-            backend_env = self.py_memory_env()
+            backend_env = self.python_env()
         else:
             argv = ["node", f"{self.bench.apps_path}/frappe/socketio.js"]
             working_dir = self.bench.sites_path
@@ -139,6 +143,7 @@ class ProcessDefinitionBuilder:
             name="watch",
             argv=[str(self.python), "-m", "frappe.utils.bench_helper", "frappe", "watch"],
             log_file=self.bench.logs_path / "watch.log",
+            env=self.python_env(),
             working_dir=self.bench.sites_path,
             critical=False,
         )
@@ -158,7 +163,7 @@ class ProcessDefinitionBuilder:
                 queues,
             ],
             log_file=self.bench.logs_path / "worker_pool.log",
-            env=self.py_memory_env(),
+            env=self.python_env(),
             working_dir=self.bench.sites_path,
         )
 
@@ -179,7 +184,7 @@ class ProcessDefinitionBuilder:
                     queue,
                 ],
                 log_file=self.bench.logs_path / f"worker_{slug}_{i}.log",
-                env=self.py_memory_env(),
+                env=self.python_env(),
                 working_dir=sites,
             )
             for i in range(1, count + 1)
@@ -211,6 +216,7 @@ class ProcessDefinitionBuilder:
             ],
             log_file=self.bench.logs_path / "admin.log",
             env={
+                **self.python_env(),
                 "BENCH_ADMIN_ROOT": str(self.bench.path),
                 "PYTHONPATH": str(root),
                 "MALLOC_ARENA_MAX": "2",
@@ -240,7 +246,7 @@ class ProcessDefinitionBuilder:
                 mode_flag,
             ],
             log_file=self.bench.logs_path / "admin.log",
-            env={"PYTHONPATH": str(root)},
+            env={**self.python_env(), "PYTHONPATH": str(root)},
         )
 
     def admin_frontend_dev_definition(self) -> ProcessDefinition:

--- a/tests/pilot/managers/test_gunicorn.py
+++ b/tests/pilot/managers/test_gunicorn.py
@@ -593,12 +593,42 @@ def test_malloc_arena_max_validation(tmp_path: Path) -> None:
         make_bench(tmp_path, gunicorn=GunicornConfig(malloc_arena_max=-1)).config.validate()
 
 
-def test_py_memory_env_caps_glibc_arenas(tmp_path: Path) -> None:
+def test_python_env_caps_glibc_arenas(tmp_path: Path) -> None:
     bench = make_bench(tmp_path, GunicornConfig(malloc_arena_max=2))
-    assert _definitions(bench).py_memory_env() == {"MALLOC_ARENA_MAX": "2"}
+    assert _definitions(bench).python_env()["MALLOC_ARENA_MAX"] == "2"
 
     bench0 = make_bench(tmp_path, GunicornConfig(malloc_arena_max=0))
-    assert _definitions(bench0).py_memory_env() == {}
+    assert "MALLOC_ARENA_MAX" not in _definitions(bench0).python_env()
+
+
+def test_python_processes_run_unbuffered(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path, GunicornConfig())
+    definitions = _definitions(bench)
+
+    dev = {pd.name: pd for pd in definitions.process_definitions()}
+    prod = {pd.name: pd for pd in definitions.prod_process_definitions()}
+
+    for name in ("web", "watch", "admin"):
+        assert dev[name].env.get("PYTHONUNBUFFERED") == "1", name
+    for name in ("web", "admin"):
+        assert prod[name].env.get("PYTHONUNBUFFERED") == "1", name
+    assert all(
+        pd.env.get("PYTHONUNBUFFERED") == "1" for name, pd in prod.items() if name.startswith("worker")
+    )
+
+    assert "PYTHONUNBUFFERED" not in prod["redis_cache"].env
+    assert dev["web"].env["DEV_SERVER"] == "1"
+
+
+def test_unbuffered_env_reaches_service_units(tmp_path: Path) -> None:
+    from pilot.managers.processes.supervisor import SupervisorRenderer
+    from pilot.managers.processes.systemd import SystemdRenderer
+
+    bench = make_bench(tmp_path, GunicornConfig())
+    web = next(pd for pd in _definitions(bench).prod_process_definitions() if pd.name == "web")
+
+    assert "Environment=PYTHONUNBUFFERED=1" in SystemdRenderer("test-bench").render(web)
+    assert 'PYTHONUNBUFFERED="1"' in SupervisorRenderer("test-bench", bench.logs_path).render(web)
 
 
 def test_max_requests_emitted_when_enabled(tmp_path: Path) -> None:


### PR DESCRIPTION
A `print()` in app code did not reach the terminal or the logs. Python block-buffers stdout when it is not a TTY, and every runner captures it — the dev runner pipes it for prefixed streaming, supervisor and systemd redirect it to `logs/<name>.log`. Output sat in an 8KB buffer until it filled or the process restarted. `stderr` stays line-buffered, which is why framework log lines showed up but app prints did not.

`bench start` has the same defect: honcho spawns with the identical `stdout=PIPE, stderr=STDOUT` and sets nothing.

Widens the shared `py_memory_env()` helper into `python_env()` and sets `PYTHONUNBUFFERED=1` there. All three runners already render `ProcessDefinition.env`, so one helper covers dev, supervisor and systemd. Callers' own keys still take precedence, so `DEV_SERVER`, `PYTHONPATH` and admin's `MALLOC_ARENA_MAX=2` are unchanged. Redis and the node/npm processes are left alone.

Tests cover the env landing on the right definitions and surviving into rendered supervisor and systemd units.
