### PR TITLE
fix(database): correct the DB analyzer's PostgreSQL diagnostics

### DIFF
--- a/admin/backend/providers/database.py
+++ b/admin/backend/providers/database.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from pathlib import Path
 
 from pilot.config import BenchConfig
@@ -48,7 +48,8 @@ class DatabaseDiagnosticsProvider:
         }
 
     def get_process_list(self, site: str = "") -> list[dict]:
-        return self._call(self._require_server().get_process_list, self._database_for(site))
+        processes = self._call(self._require_server().get_process_list, self._database_for(site))
+        return [asdict(process) for process in processes]
 
     def kill_process(self, process_id: int) -> None:
         self._call(self._require_server().kill_process, process_id)
@@ -58,7 +59,12 @@ class DatabaseDiagnosticsProvider:
         return [asdict(row) for row in rows]
 
     def get_database_size(self, site: str = "") -> dict:
-        return asdict(self._call(self._connection_for(site).get_database_size))
+        size = self._call(self._connection_for(site).get_database_size)
+        # Free space is the server's disk, the same one whatever the scope, but
+        # a site's own user may not be allowed to ask where the server keeps it.
+        if site and size.free_bytes is None and self._db is not None:
+            size = replace(size, free_bytes=self._call(self._db.get_free_disk_bytes))
+        return asdict(size)
 
     def get_table_sizes(self, site: str) -> list[dict]:
         if not site:

--- a/admin/backend/providers/database.py
+++ b/admin/backend/providers/database.py
@@ -60,8 +60,7 @@ class DatabaseDiagnosticsProvider:
 
     def get_database_size(self, site: str = "") -> dict:
         size = self._call(self._connection_for(site).get_database_size)
-        # Free space is the server's disk, the same one whatever the scope, but
-        # a site's own user may not be allowed to ask where the server keeps it.
+        # A site's own user may not be allowed to read the server's data directory.
         if site and size.free_bytes is None and self._db is not None:
             size = replace(size, free_bytes=self._call(self._db.get_free_disk_bytes))
         return asdict(size)

--- a/admin/frontend/dashboard/src/components/common/UsageMeter.vue
+++ b/admin/frontend/dashboard/src/components/common/UsageMeter.vue
@@ -6,6 +6,9 @@ interface UsagePart {
   label: string
   bytes: number | null
   color: string
+  // Set false for a part that belongs in the legend but not the bar, such as
+  // headroom that would otherwise scale every real segment out of sight.
+  inBar?: boolean
 }
 
 interface Props {
@@ -44,7 +47,9 @@ const hiddenCount = computed(() =>
 )
 
 const barParts = computed(() => {
-  const known = formattedParts.value.filter((part) => (part.bytes ?? 0) > 0)
+  const known = formattedParts.value.filter(
+    (part) => part.inBar !== false && (part.bytes ?? 0) > 0,
+  )
   const denominator = props.total ?? known.reduce((sum, part) => sum + (part.bytes ?? 0), 0)
   if (!denominator) return []
   return known.map((part) => ({ ...part, percent: ((part.bytes ?? 0) / denominator) * 100 }))

--- a/admin/frontend/dashboard/src/components/common/UsageMeter.vue
+++ b/admin/frontend/dashboard/src/components/common/UsageMeter.vue
@@ -6,9 +6,7 @@ interface UsagePart {
   label: string
   bytes: number | null
   color: string
-  // Set false for a part that belongs in the legend but not the bar, such as
-  // headroom that would otherwise scale every real segment out of sight.
-  inBar?: boolean
+  inBar?: boolean // false keeps the part in the legend only
 }
 
 interface Props {

--- a/admin/frontend/dashboard/src/components/database/SizeBreakup.vue
+++ b/admin/frontend/dashboard/src/components/database/SizeBreakup.vue
@@ -14,10 +14,14 @@ const props = defineProps({
 
 const COLORS = { data: 'red-7', index: 'cyan-7', claimable: 'amber-7', free: 'gray-2' }
 
+// The bar shows what the database is made of. Disk headroom is orders of
+// magnitude larger, so as a segment it flattens every real part to nothing.
+// It is also the whole server's disk, shared by every database on it, so it is
+// named for the disk rather than reading as an allowance for one site.
 const parts = computed(() => [
   { label: 'Data Size', bytes: props.size.data_bytes, color: COLORS.data },
   { label: 'Index Size', bytes: props.size.index_bytes, color: COLORS.index },
   { label: 'Claimable Space', bytes: props.size.claimable_bytes, color: COLORS.claimable },
-  { label: 'Free Space', bytes: props.size.free_bytes, color: COLORS.free },
+  { label: 'Free on disk', bytes: props.size.free_bytes, color: COLORS.free, inBar: false },
 ])
 </script>

--- a/admin/frontend/dashboard/src/components/database/SizeBreakup.vue
+++ b/admin/frontend/dashboard/src/components/database/SizeBreakup.vue
@@ -14,10 +14,8 @@ const props = defineProps({
 
 const COLORS = { data: 'red-7', index: 'cyan-7', claimable: 'amber-7', free: 'gray-2' }
 
-// The bar shows what the database is made of. Disk headroom is orders of
-// magnitude larger, so as a segment it flattens every real part to nothing.
-// It is also the whole server's disk, shared by every database on it, so it is
-// named for the disk rather than reading as an allowance for one site.
+// Server scope reports one combined size, and free space is the whole
+// server's disk, which would dwarf every other segment.
 const parts = computed(() => {
   const databaseParts =
     props.size.data_bytes == null && props.size.index_bytes == null

--- a/admin/frontend/dashboard/src/components/database/SizeBreakup.vue
+++ b/admin/frontend/dashboard/src/components/database/SizeBreakup.vue
@@ -18,10 +18,22 @@ const COLORS = { data: 'red-7', index: 'cyan-7', claimable: 'amber-7', free: 'gr
 // magnitude larger, so as a segment it flattens every real part to nothing.
 // It is also the whole server's disk, shared by every database on it, so it is
 // named for the disk rather than reading as an allowance for one site.
-const parts = computed(() => [
-  { label: 'Data Size', bytes: props.size.data_bytes, color: COLORS.data },
-  { label: 'Index Size', bytes: props.size.index_bytes, color: COLORS.index },
-  { label: 'Claimable Space', bytes: props.size.claimable_bytes, color: COLORS.claimable },
-  { label: 'Free on disk', bytes: props.size.free_bytes, color: COLORS.free, inBar: false },
-])
+const parts = computed(() => {
+  const databaseParts =
+    props.size.data_bytes == null && props.size.index_bytes == null
+      ? [{ label: 'Database Size', bytes: props.size.total_bytes, color: COLORS.data }]
+      : [
+          { label: 'Data Size', bytes: props.size.data_bytes, color: COLORS.data },
+          { label: 'Index Size', bytes: props.size.index_bytes, color: COLORS.index },
+          {
+            label: 'Claimable Space',
+            bytes: props.size.claimable_bytes,
+            color: COLORS.claimable,
+          },
+        ]
+  return [
+    ...databaseParts,
+    { label: 'Free on disk', bytes: props.size.free_bytes, color: COLORS.free, inBar: false },
+  ]
+})
 </script>

--- a/admin/frontend/dashboard/src/pages/database/Analyzer.vue
+++ b/admin/frontend/dashboard/src/pages/database/Analyzer.vue
@@ -171,7 +171,7 @@
   <Dialog v-model="showKillDialog" :options="{ title: 'Kill database process', size: 'sm' }">
     <template #body-content>
       <p class="text-ink-gray-7 text-sm">
-        Close connection <strong>{{ killTarget?.Id }}</strong> and roll back whatever it is running?
+        Close connection <strong>{{ killTarget?.id }}</strong> and roll back whatever it is running?
         Any bench sharing this server may own it.
       </p>
 
@@ -335,13 +335,13 @@ const purgeError = ref('')
 const processRows = computed(() =>
   processes.value.map((process, index) => ({
     number: index + 1,
-    id: process.Id,
-    state: process.State || '—',
-    time: `${process.Time}s`,
-    user: process.User,
-    host: process.Host || '—',
-    command: process.Command,
-    query: truncateQuery(process.Info),
+    id: process.id,
+    state: process.state || '—',
+    time: formatSeconds(process.duration_seconds),
+    user: process.user || '—',
+    host: process.host || '—',
+    command: process.command || '—',
+    query: truncateQuery(process.query),
     process,
   })),
 )
@@ -377,14 +377,14 @@ const killDetails = computed(() => {
   const process = killTarget.value
   if (!process) return []
   return [
-    { label: 'User', value: process.User },
-    { label: 'Database', value: process.db || '—' },
-    { label: 'State', value: process.Command },
-    { label: 'Running for', value: `${process.Time}s` },
+    { label: 'User', value: process.user || '—' },
+    { label: 'Database', value: process.database || '—' },
+    { label: 'State', value: process.command || '—' },
+    { label: 'Running for', value: formatSeconds(process.duration_seconds) },
   ]
 })
 
-const killQuery = computed(() => killTarget.value?.Info || '')
+const killQuery = computed(() => killTarget.value?.query || '')
 
 const pendingFiles = computed(() =>
   pendingIndex.value < 0 ? [] : binlogs.value.slice(0, pendingIndex.value + 1),
@@ -433,6 +433,10 @@ function truncateQuery(query) {
   return query.length > MAX_QUERY_LENGTH ? `${query.slice(0, MAX_QUERY_LENGTH)}…` : query
 }
 
+function formatSeconds(seconds) {
+  return seconds == null ? '—' : `${Math.round(seconds)}s`
+}
+
 function fileAge(file) {
   return file.modified_ms ? relativeTime(new Date(file.modified_ms).toISOString()) : '—'
 }
@@ -453,10 +457,10 @@ async function kill() {
   killing.value = true
   killError.value = ''
   try {
-    const result = await databaseApi.killProcess(killTarget.value.Id)
+    const result = await databaseApi.killProcess(killTarget.value.id)
     if (result.error) throw new Error(apiErrorMessage(result, 'Could not kill the process.'))
     showKillDialog.value = false
-    toast.success(`Killed process ${killTarget.value.Id}`)
+    toast.success(`Killed process ${killTarget.value.id}`)
     await loadProcesses()
   } catch (e) {
     killError.value = e.message || 'Could not kill the process.'

--- a/admin/frontend/dashboard/src/pages/database/Analyzer.vue
+++ b/admin/frontend/dashboard/src/pages/database/Analyzer.vue
@@ -311,6 +311,10 @@ const lockWaitsLoading = ref(false)
 const lockWaitsError = ref('')
 const autoRefreshLocks = ref(true)
 let lockWaitsTimer = null
+let lockWaitsPollVersion = 0
+let lockWaitsRequest = null
+let lockWaitsRequestSite = null
+let lockWaitsReloadQueued = false
 
 const binlogs = ref([])
 const binlogsLoading = ref(false)
@@ -510,18 +514,45 @@ async function loadProcesses() {
   }
 }
 
-async function loadLockWaits() {
+function loadLockWaits() {
+  if (lockWaitsRequest) {
+    if (lockWaitsRequestSite !== selectedSite.value) lockWaitsReloadQueued = true
+    return lockWaitsRequest
+  }
+  lockWaitsRequest = drainLockWaitsRequests()
+  return lockWaitsRequest
+}
+
+async function drainLockWaitsRequests() {
   lockWaitsLoading.value = true
+  try {
+    do {
+      lockWaitsReloadQueued = false
+      await fetchLockWaits()
+    } while (lockWaitsReloadQueued)
+  } finally {
+    lockWaitsLoading.value = false
+    lockWaitsRequest = null
+    lockWaitsRequestSite = null
+  }
+}
+
+async function fetchLockWaits() {
+  const site = selectedSite.value
+  lockWaitsRequestSite = site
   lockWaitsError.value = ''
   try {
-    const result = await databaseApi.lockWaitRows(selectedSite.value)
+    const result = await databaseApi.lockWaitRows(site)
+    if (site !== selectedSite.value) {
+      lockWaitsReloadQueued = true
+      return
+    }
     if (result?.error)
       throw new Error(apiErrorMessage(result, 'Could not load database lock waits.'))
     lockWaits.value = Array.isArray(result) ? result : []
   } catch (e) {
-    lockWaitsError.value = e.message || 'Could not load database lock waits.'
-  } finally {
-    lockWaitsLoading.value = false
+    if (site !== selectedSite.value) lockWaitsReloadQueued = true
+    else lockWaitsError.value = e.message || 'Could not load database lock waits.'
   }
 }
 
@@ -555,13 +586,21 @@ async function loadBinlogs() {
   }
 }
 
+async function pollLockWaits(version) {
+  await loadLockWaits()
+  if (version !== lockWaitsPollVersion || !autoRefreshLocks.value) return
+  lockWaitsTimer = setTimeout(() => pollLockWaits(version), AUTO_REFRESH_INTERVAL_MS)
+}
+
 function startLockWaitsAutoRefresh() {
   stopLockWaitsAutoRefresh()
-  lockWaitsTimer = setInterval(loadLockWaits, AUTO_REFRESH_INTERVAL_MS)
+  const version = lockWaitsPollVersion
+  lockWaitsTimer = setTimeout(() => pollLockWaits(version), AUTO_REFRESH_INTERVAL_MS)
 }
 
 function stopLockWaitsAutoRefresh() {
-  if (lockWaitsTimer) clearInterval(lockWaitsTimer)
+  lockWaitsPollVersion += 1
+  if (lockWaitsTimer) clearTimeout(lockWaitsTimer)
   lockWaitsTimer = null
 }
 

--- a/pilot/core/database/__init__.py
+++ b/pilot/core/database/__init__.py
@@ -8,6 +8,7 @@ from pilot.core.database.base import (
     BinlogFile,
     BinlogStatus,
     Database,
+    DatabaseProcess,
     DatabaseSize,
     LockWaitRow,
     LockWaitStatus,
@@ -26,6 +27,7 @@ __all__ = [
     "BinlogFile",
     "BinlogStatus",
     "Database",
+    "DatabaseProcess",
     "DatabaseSize",
     "LockWaitRow",
     "LockWaitStatus",
@@ -52,7 +54,7 @@ def make_database(config: "BenchConfig") -> Database:
             port=postgres.port,
             user=postgres.admin_user,
             password=postgres.root_password or "trust_auth",
-            database=postgres.admin_user,
+            database="",
         )
     mariadb = config.mariadb
     return MariaDB(

--- a/pilot/core/database/base.py
+++ b/pilot/core/database/base.py
@@ -60,14 +60,17 @@ class LockWaitRow:
 
 @dataclass
 class DatabaseSize:
-    """Storage breakdown. `claimable_bytes` is space a rebuild would return to
-    the filesystem; `free_bytes` is what the data directory's disk has left.
-    Either is None when the engine or a remote host can't report it."""
+    """Storage breakdown. `total_bytes` carries an exact combined size when an
+    engine cannot split a server-wide total into data and indexes.
+    `claimable_bytes` is space a rebuild would return to the filesystem;
+    `free_bytes` is what the data directory's disk has left. Fields stay None
+    when the engine or a remote host cannot report them."""
 
-    data_bytes: int
-    index_bytes: int
+    data_bytes: int | None
+    index_bytes: int | None
     claimable_bytes: int | None
     free_bytes: int | None
+    total_bytes: int | None = None
 
 
 @dataclass

--- a/pilot/core/database/base.py
+++ b/pilot/core/database/base.py
@@ -17,6 +17,23 @@ class QueryResult:
 
 
 @dataclass
+class DatabaseProcess:
+    """One client connection to the server, in engine-neutral terms. `command`
+    is what the connection is doing (MariaDB's Command, PostgreSQL's state) and
+    `state` the finer step or wait inside it. `duration_seconds` is how long it
+    has been in that state. Fields an engine cannot report stay None."""
+
+    id: int
+    user: str | None
+    host: str | None
+    database: str | None
+    command: str | None
+    state: str | None
+    duration_seconds: float | None
+    query: str | None
+
+
+@dataclass
 class LockWaitStatus:
     current_waits: int
     total_waits: int | None
@@ -103,7 +120,7 @@ class Database(ABC):
     def get_schema(self) -> list[dict]:
         return [{"name": t, "columns": self.get_table_columns(t)} for t in self.get_tables()]
 
-    def get_process_list(self, database: str = "") -> list[dict]:
+    def get_process_list(self, database: str = "") -> list[DatabaseProcess]:
         """`database` narrows the result to one database; empty means server-wide."""
         raise NotImplementedError
 
@@ -146,6 +163,20 @@ class Database(ABC):
         """Server data directory, or None when the server is not on this host
         and the path would therefore be meaningless locally."""
         raise NotImplementedError
+
+    def get_free_disk_bytes(self) -> int | None:
+        """Free space on the disk holding the server's data directory. None
+        when that directory cannot be reached from here - a remote server, or
+        a user without the privilege to ask the server where it is."""
+        import shutil
+
+        directory = self.get_data_directory()
+        if not directory:
+            return None
+        try:
+            return shutil.disk_usage(directory).free
+        except OSError:
+            return None
 
     def get_scalar(self, query: str):
         result = self.execute(query)

--- a/pilot/core/database/base.py
+++ b/pilot/core/database/base.py
@@ -18,10 +18,9 @@ class QueryResult:
 
 @dataclass
 class DatabaseProcess:
-    """One client connection to the server, in engine-neutral terms. `command`
-    is what the connection is doing (MariaDB's Command, PostgreSQL's state) and
-    `state` the finer step or wait inside it. `duration_seconds` is how long it
-    has been in that state. Fields an engine cannot report stay None."""
+    """One client connection. `command` is what it is doing (MariaDB's Command,
+    PostgreSQL's state), `state` the finer step within it, and
+    `duration_seconds` the time spent in that state."""
 
     id: int
     user: str | None
@@ -168,9 +167,8 @@ class Database(ABC):
         raise NotImplementedError
 
     def get_free_disk_bytes(self) -> int | None:
-        """Free space on the disk holding the server's data directory. None
-        when that directory cannot be reached from here - a remote server, or
-        a user without the privilege to ask the server where it is."""
+        """Free space on the disk holding the data directory, or None when that
+        directory cannot be reached from here."""
         import shutil
 
         directory = self.get_data_directory()

--- a/pilot/core/database/engines/helpers.py
+++ b/pilot/core/database/engines/helpers.py
@@ -38,13 +38,3 @@ def file_modified_ms(path: Path) -> int | None:
 
 def is_local_host(host: str, socket: str | None = None) -> bool:
     return bool(socket) or host in ("localhost", "127.0.0.1", "::1", "")
-
-
-def disk_free(path: str) -> int | None:
-    """Best-effort: the data directory may not be readable from this process."""
-    import shutil
-
-    try:
-        return shutil.disk_usage(path).free
-    except OSError:
-        return None

--- a/pilot/core/database/engines/mariadb.py
+++ b/pilot/core/database/engines/mariadb.py
@@ -7,6 +7,7 @@ from pilot.core.database.base import (
     BinlogFile,
     BinlogStatus,
     Database,
+    DatabaseProcess,
     DatabaseSize,
     LockWaitRow,
     LockWaitStatus,
@@ -17,7 +18,6 @@ from pilot.core.database.base import (
 from pilot.core.database.engines.helpers import (
     DEFAULT_CONNECT_TIMEOUT,
     MAX_ROWS,
-    disk_free,
     file_modified_ms,
     is_local_host,
     rows_as_dicts,
@@ -198,11 +198,22 @@ class MariaDB(Database):
         finally:
             conn.close()
 
-    def get_process_list(self, database: str = "") -> list[dict]:
+    def get_process_list(self, database: str = "") -> list[DatabaseProcess]:
         rows = rows_as_dicts(self.execute("SHOW FULL PROCESSLIST"))
-        if not database:
-            return rows
-        return [row for row in rows if row.get("db") == database]
+        return [
+            DatabaseProcess(
+                id=int(row["Id"]),
+                user=row["User"],
+                host=row["Host"],
+                database=row["db"],
+                command=row["Command"],
+                state=row["State"] or None,
+                duration_seconds=float(row["Time"]) if row["Time"] is not None else None,
+                query=row["Info"],
+            )
+            for row in rows
+            if not database or row["db"] == database
+        ]
 
     def get_database_size(self) -> DatabaseSize:
         result = self.execute(
@@ -215,7 +226,7 @@ class MariaDB(Database):
             data_bytes=int(data),
             index_bytes=int(index),
             claimable_bytes=int(claimable),
-            free_bytes=self._free_disk_bytes(),
+            free_bytes=self.get_free_disk_bytes(),
         )
 
     def get_table_sizes(self) -> list[TableSize]:
@@ -241,13 +252,6 @@ class MariaDB(Database):
         if self._database:
             return "table_schema = DATABASE()"
         return "table_schema NOT IN ('information_schema', 'performance_schema', 'mysql', 'sys')"
-
-    def _free_disk_bytes(self) -> int | None:
-        """Only meaningful when the server shares this host - the data directory
-        path means nothing locally for a remote server."""
-        if not is_local_host(self._host, self._socket):
-            return None
-        return disk_free(str(self.get_scalar("SELECT @@datadir")))
 
     def kill_process(self, process_id: int) -> None:
         """Drop a connection and roll back whatever it was running."""

--- a/pilot/core/database/engines/postgres.py
+++ b/pilot/core/database/engines/postgres.py
@@ -134,10 +134,8 @@ class PostgreSQL(Database):
             conn.close()
 
     def get_process_list(self, database: str = "") -> list[DatabaseProcess]:
-        """Only client backends: PostgreSQL's background workers are not
-        connections and cannot be killed. `state_change` gives the same time in
-        the current state that MariaDB reports, and `wait_event` the same finer
-        detail as its State column."""
+        """Only client backends: background workers are not connections and
+        cannot be killed."""
         result = self.execute(
             "SELECT pid, usename, client_addr, client_port, datname, state, wait_event, "
             "EXTRACT(EPOCH FROM (now() - state_change)), query FROM pg_stat_activity "
@@ -148,7 +146,6 @@ class PostgreSQL(Database):
             DatabaseProcess(
                 id=int(row[0]),
                 user=row[1],
-                # A local socket connection has no client address at all.
                 host=f"{row[2]}:{row[3]}" if row[2] else None,
                 database=row[4],
                 command=row[5],

--- a/pilot/core/database/engines/postgres.py
+++ b/pilot/core/database/engines/postgres.py
@@ -190,13 +190,13 @@ class PostgreSQL(Database):
             "WHERE NOT blocked.granted"
         )
         rows = [row for row in result.rows if not database or row[7] == database]
-        tables = self._table_names(rows)
+        tables = self._table_names(database, rows) if database else {}
         return [
             LockWaitRow(
                 id=str(row[0]),
                 type=row[1],
                 mode=row[2],
-                table=tables.get((row[7], row[3])),
+                table=self._relation_name(row[7], row[3], tables),
                 index=None,
                 state=row[4],
                 started=str(row[5]) if row[5] is not None else None,
@@ -207,20 +207,26 @@ class PostgreSQL(Database):
             for row in rows
         ]
 
-    def _table_names(self, rows: list[list]) -> dict[tuple[str, int], str]:
-        """A relation OID only names a table inside its own database, so each
-        database resolves its own. Casting the OID in the connection's catalog
-        named whatever that OID happens to be there, or nothing at all. Names
-        carry their database, the way MariaDB's lock table does."""
-        wanted = {(row[7], row[3]) for row in rows if row[7] and row[3]}
-        names: dict[tuple[str, int], str] = {}
-        for database in {name for name, _ in wanted}:
-            oids = ", ".join(str(int(oid)) for name, oid in wanted if name == database)
-            catalog = self._scoped_to(database).execute(
-                f"SELECT oid, relname FROM pg_class WHERE oid IN ({oids})"
-            )
-            names.update({(database, int(row[0])): f"{database}.{row[1]}" for row in catalog.rows})
-        return names
+    def _table_names(self, database: str, rows: list[list]) -> dict[int, str]:
+        """Resolve relation OIDs only for a selected database. Server-wide
+        lock polling must not open one connection per affected database."""
+        wanted = {int(row[3]) for row in rows if row[3]}
+        if not wanted:
+            return {}
+        oids = ", ".join(str(oid) for oid in wanted)
+        catalog = self._scoped_to(database).execute(
+            "SELECT c.oid, n.nspname, c.relname FROM pg_class c "
+            "JOIN pg_namespace n ON n.oid = c.relnamespace "
+            f"WHERE c.oid IN ({oids})"
+        )
+        return {int(row[0]): f"{database}.{row[1]}.{row[2]}" for row in catalog.rows}
+
+    @staticmethod
+    def _relation_name(database: str | None, oid: int | None, names: dict[int, str]) -> str | None:
+        if not database or not oid:
+            return None
+        relation_oid = int(oid)
+        return names.get(relation_oid, f"{database} (relation OID {relation_oid})")
 
     # `pg_table_size` covers the heap and its TOAST, matching what MariaDB
     # reports as data_length. Reclaimable bloat needs the pgstattuple
@@ -231,21 +237,31 @@ class PostgreSQL(Database):
     )
 
     def get_database_size(self) -> DatabaseSize:
-        """`pg_class` only ever describes the database the connection is bound
-        to, so a server-wide instance asks each database for its own totals."""
-        totals = [self._table_size_totals()] if self._database else self._every_database_totals()
+        """Return an exact split for one database or one combined server total.
+
+        PostgreSQL catalogs cannot split every database's size from one
+        connection. Reconnecting to every database makes this request linear in
+        the number of sites, so server scope uses pg_database_size instead.
+        """
+        data, index = self._table_size_totals() if self._database else (None, None)
         return DatabaseSize(
-            data_bytes=sum(data for data, _ in totals),
-            index_bytes=sum(index for _, index in totals),
+            data_bytes=data,
+            index_bytes=index,
             claimable_bytes=None,
             free_bytes=self.get_free_disk_bytes(),
+            total_bytes=None if self._database else self._server_database_bytes(),
         )
 
-    def _every_database_totals(self) -> list[tuple[int, int]]:
-        names = self.execute(
-            "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate"
+    def _server_database_bytes(self) -> int:
+        result = self.execute(
+            "SELECT COALESCE(SUM(size_bytes), 0), COUNT(*) FILTER (WHERE size_bytes IS NULL) "
+            "FROM (SELECT pg_database_size(datname) AS size_bytes FROM pg_database "
+            "WHERE NOT datistemplate) databases"
         )
-        return [self._scoped_to(str(row[0]))._table_size_totals() for row in names.rows]
+        total, unavailable = result.rows[0] if result.rows else (0, 0)
+        if int(unavailable):
+            raise DatabaseError(f"Could not measure {int(unavailable)} database(s) on this server")
+        return int(total)
 
     def _scoped_to(self, database: str) -> "PostgreSQL":
         return PostgreSQL(

--- a/pilot/core/database/engines/postgres.py
+++ b/pilot/core/database/engines/postgres.py
@@ -4,6 +4,7 @@ import time
 
 from pilot.core.database.base import (
     Database,
+    DatabaseProcess,
     DatabaseSize,
     LockWaitRow,
     LockWaitStatus,
@@ -14,9 +15,7 @@ from pilot.core.database.base import (
 from pilot.core.database.engines.helpers import (
     DEFAULT_CONNECT_TIMEOUT,
     MAX_ROWS,
-    disk_free,
     is_local_host,
-    rows_as_dicts,
     validated_process_id,
 )
 from pilot.exceptions import DatabaseError
@@ -40,6 +39,8 @@ class PostgreSQL(Database):
         self._connect_timeout = connect_timeout
 
     def _connect(self):
+        """Every connection is bound to one database, so a server-wide instance
+        (empty `database`) uses the maintenance database named after its user."""
         try:
             import psycopg2
         except ImportError as exc:
@@ -50,7 +51,7 @@ class PostgreSQL(Database):
                 port=self._port,
                 user=self._user,
                 password=self._password,
-                dbname=self._database,
+                dbname=self._database or self._user,
                 connect_timeout=self._connect_timeout,
             )
         except psycopg2.Error as exc:
@@ -132,17 +133,31 @@ class PostgreSQL(Database):
         finally:
             conn.close()
 
-    def get_process_list(self, database: str = "") -> list[dict]:
-        rows = rows_as_dicts(
-            self.execute(
-                'SELECT pid, usename AS "user", datname AS "database", state, '
-                "EXTRACT(EPOCH FROM (now() - query_start)) AS duration_seconds, query "
-                "FROM pg_stat_activity WHERE pid <> pg_backend_pid()"
-            )
+    def get_process_list(self, database: str = "") -> list[DatabaseProcess]:
+        """Only client backends: PostgreSQL's background workers are not
+        connections and cannot be killed. `state_change` gives the same time in
+        the current state that MariaDB reports, and `wait_event` the same finer
+        detail as its State column."""
+        result = self.execute(
+            "SELECT pid, usename, client_addr, client_port, datname, state, wait_event, "
+            "EXTRACT(EPOCH FROM (now() - state_change)), query FROM pg_stat_activity "
+            "WHERE backend_type = 'client backend' AND pid <> pg_backend_pid()"
         )
-        if not database:
-            return rows
-        return [row for row in rows if row.get("database") == database]
+        rows = [row for row in result.rows if not database or row[4] == database]
+        return [
+            DatabaseProcess(
+                id=int(row[0]),
+                user=row[1],
+                # A local socket connection has no client address at all.
+                host=f"{row[2]}:{row[3]}" if row[2] else None,
+                database=row[4],
+                command=row[5],
+                state=row[6],
+                duration_seconds=float(row[7]) if row[7] is not None else None,
+                query=row[8] or None,
+            )
+            for row in rows
+        ]
 
     def kill_process(self, process_id: int) -> None:
         """pg_terminate_backend reports a missing backend by returning false."""
@@ -168,19 +183,20 @@ class PostgreSQL(Database):
         """PostgreSQL has no lock-index concept and no per-transaction row
         counters, so index/rows_locked/rows_modified are always None."""
         result = self.execute(
-            "SELECT blocked.pid, blocked.locktype, blocked.mode, "
-            "blocked.relation::regclass::text, a.state, a.query_start, a.query, a.datname "
+            "SELECT blocked.pid, blocked.locktype, blocked.mode, blocked.relation, "
+            "a.state, a.query_start, a.query, a.datname "
             "FROM pg_locks blocked "
             "JOIN pg_stat_activity a ON a.pid = blocked.pid "
             "WHERE NOT blocked.granted"
         )
         rows = [row for row in result.rows if not database or row[7] == database]
+        tables = self._table_names(rows)
         return [
             LockWaitRow(
                 id=str(row[0]),
                 type=row[1],
                 mode=row[2],
-                table=row[3],
+                table=tables.get((row[7], row[3])),
                 index=None,
                 state=row[4],
                 started=str(row[5]) if row[5] is not None else None,
@@ -191,6 +207,21 @@ class PostgreSQL(Database):
             for row in rows
         ]
 
+    def _table_names(self, rows: list[list]) -> dict[tuple[str, int], str]:
+        """A relation OID only names a table inside its own database, so each
+        database resolves its own. Casting the OID in the connection's catalog
+        named whatever that OID happens to be there, or nothing at all. Names
+        carry their database, the way MariaDB's lock table does."""
+        wanted = {(row[7], row[3]) for row in rows if row[7] and row[3]}
+        names: dict[tuple[str, int], str] = {}
+        for database in {name for name, _ in wanted}:
+            oids = ", ".join(str(int(oid)) for name, oid in wanted if name == database)
+            catalog = self._scoped_to(database).execute(
+                f"SELECT oid, relname FROM pg_class WHERE oid IN ({oids})"
+            )
+            names.update({(database, int(row[0])): f"{database}.{row[1]}" for row in catalog.rows})
+        return names
+
     # `pg_table_size` covers the heap and its TOAST, matching what MariaDB
     # reports as data_length. Reclaimable bloat needs the pgstattuple
     # extension, so claimable space stays None.
@@ -200,17 +231,34 @@ class PostgreSQL(Database):
     )
 
     def get_database_size(self) -> DatabaseSize:
+        """`pg_class` only ever describes the database the connection is bound
+        to, so a server-wide instance asks each database for its own totals."""
+        totals = [self._table_size_totals()] if self._database else self._every_database_totals()
+        return DatabaseSize(
+            data_bytes=sum(data for data, _ in totals),
+            index_bytes=sum(index for _, index in totals),
+            claimable_bytes=None,
+            free_bytes=self.get_free_disk_bytes(),
+        )
+
+    def _every_database_totals(self) -> list[tuple[int, int]]:
+        names = self.execute(
+            "SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate"
+        )
+        return [self._scoped_to(str(row[0]))._table_size_totals() for row in names.rows]
+
+    def _scoped_to(self, database: str) -> "PostgreSQL":
+        return PostgreSQL(
+            self._host, self._port, self._user, self._password, database, self._connect_timeout
+        )
+
+    def _table_size_totals(self) -> tuple[int, int]:
         result = self.execute(
             "SELECT COALESCE(SUM(pg_table_size(c.oid)), 0), COALESCE(SUM(pg_indexes_size(c.oid)), 0) "
             + self._TABLE_SIZE_SOURCE
         )
         data, index = result.rows[0] if result.rows else (0, 0)
-        return DatabaseSize(
-            data_bytes=int(data),
-            index_bytes=int(index),
-            claimable_bytes=None,
-            free_bytes=self._free_disk_bytes(),
-        )
+        return int(data), int(index)
 
     def get_table_sizes(self) -> list[TableSize]:
         result = self.execute(
@@ -227,10 +275,6 @@ class PostgreSQL(Database):
             )
             for row in result.rows
         ]
-
-    def _free_disk_bytes(self) -> int | None:
-        data_directory = self.get_data_directory()
-        return disk_free(data_directory) if data_directory else None
 
     def get_data_directory(self) -> str | None:
         if not is_local_host(self._host):

--- a/tests/admin/backend/providers/test_database_provider.py
+++ b/tests/admin/backend/providers/test_database_provider.py
@@ -188,9 +188,8 @@ def test_get_database_size_uses_a_connection_bound_to_the_site(tmp_path) -> None
 
 
 def test_site_scoped_size_takes_free_space_from_the_server(tmp_path) -> None:
-    """A site's own database user need not be allowed to ask the server where
-    its data directory is - PostgreSQL hides that setting from non-superusers -
-    but the free space it measures is the same disk whatever the scope."""
+    """PostgreSQL hides the data directory from non-superusers, but the free
+    space it measures is the same disk whatever the scope."""
     from unittest.mock import patch
 
     from pilot.core.database import DatabaseSize

--- a/tests/admin/backend/providers/test_database_provider.py
+++ b/tests/admin/backend/providers/test_database_provider.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 from admin.backend.providers.database import DatabaseDiagnosticsProvider
-from pilot.core.database import BinlogFile, BinlogStatus, LockWaitRow, LockWaitStatus
+from pilot.core.database import BinlogFile, BinlogStatus, DatabaseProcess, LockWaitRow, LockWaitStatus
 
 
 def _provider(db: Mock) -> DatabaseDiagnosticsProvider:
@@ -25,6 +25,35 @@ def test_get_diagnostics_shapes_dataclasses_as_dicts() -> None:
         "lock_waits": {"current_waits": 1, "total_waits": 9, "timeout_seconds": 50},
         "binlog": {"enabled": True, "file_count": 2, "size_bytes": 4096},
     }
+
+
+def test_get_process_list_shapes_processes_as_dicts() -> None:
+    db = Mock()
+    db.get_process_list.return_value = [
+        DatabaseProcess(
+            id=7,
+            user="app",
+            host="localhost:53422",
+            database="mydb",
+            command="Query",
+            state=None,
+            duration_seconds=3.0,
+            query="SELECT 1",
+        )
+    ]
+
+    assert _provider(db).get_process_list() == [
+        {
+            "id": 7,
+            "user": "app",
+            "host": "localhost:53422",
+            "database": "mydb",
+            "command": "Query",
+            "state": None,
+            "duration_seconds": 3.0,
+            "query": "SELECT 1",
+        }
+    ]
 
 
 def test_sqlite_bench_has_no_database_server(tmp_path) -> None:
@@ -155,6 +184,26 @@ def test_get_database_size_uses_a_connection_bound_to_the_site(tmp_path) -> None
         }
 
     make.assert_called_once_with(tmp_path, "shop.local")
+
+
+def test_site_scoped_size_takes_free_space_from_the_server(tmp_path) -> None:
+    """A site's own database user need not be allowed to ask the server where
+    its data directory is - PostgreSQL hides that setting from non-superusers -
+    but the free space it measures is the same disk whatever the scope."""
+    from unittest.mock import patch
+
+    from pilot.core.database import DatabaseSize
+
+    site_db = Mock()
+    site_db.get_database_size.return_value = DatabaseSize(
+        data_bytes=21, index_bytes=27, claimable_bytes=None, free_bytes=None
+    )
+    server = Mock()
+    server.get_free_disk_bytes.return_value = 855949434880
+    provider = DatabaseDiagnosticsProvider(bench_root=tmp_path, database=server)
+
+    with patch("admin.backend.providers.database.make_site_database", return_value=site_db):
+        assert provider.get_database_size("shop.local")["free_bytes"] == 855949434880
 
 
 def test_get_database_size_without_a_site_uses_the_server_connection() -> None:

--- a/tests/admin/backend/providers/test_database_provider.py
+++ b/tests/admin/backend/providers/test_database_provider.py
@@ -181,6 +181,7 @@ def test_get_database_size_uses_a_connection_bound_to_the_site(tmp_path) -> None
             "index_bytes": 27,
             "claimable_bytes": 4,
             "free_bytes": 99,
+            "total_bytes": None,
         }
 
     make.assert_called_once_with(tmp_path, "shop.local")

--- a/tests/pilot/core/test_database.py
+++ b/tests/pilot/core/test_database.py
@@ -780,8 +780,7 @@ def test_postgres_get_process_list_normalises_rows() -> None:
 
 def test_both_engines_report_the_same_process_shape() -> None:
     """The dashboard reads one shape, so neither engine's own column names may
-    reach it - PostgreSQL used to send pid/usename/datname where the page read
-    MariaDB's Id/User/db and rendered an empty table."""
+    reach it."""
     postgres = PostgreSQL(host="h", port=5432, user="u", password="p", database="d")
     mariadb = MariaDB(host="h", port=3306, user="u", password="p", database="")
     mariadb_rows = {"PROCESSLIST": (_MARIADB_PROCESS_COLUMNS, [[7, "app", "h:1", "db", "Query", 3, "", None]])}

--- a/tests/pilot/core/test_database.py
+++ b/tests/pilot/core/test_database.py
@@ -646,20 +646,30 @@ def test_postgres_get_lock_wait_rows_leaves_unsupported_fields_none() -> None:
     responses = {
         "blocked.granted": (
             ["pid", "locktype", "mode", "relation", "state", "query_start", "query", "datname"],
-            [[123, "relation", "RowExclusiveLock", 16385, "active",
-              "2026-01-01 00:00:00", "UPDATE tabDoc SET x=1", "site_one"]],
+            [
+                [
+                    123,
+                    "relation",
+                    "RowExclusiveLock",
+                    16385,
+                    "active",
+                    "2026-01-01 00:00:00",
+                    "UPDATE tabDoc SET x=1",
+                    "site_one",
+                ]
+            ],
         ),
-        "relname FROM pg_class": (["oid", "relname"], [[16385, "tabDoc"]]),
+        "n.nspname": (["oid", "nspname", "relname"], [[16385, "public", "tabDoc"]]),
     }
     with patch.object(PostgreSQL, "execute", _canned_execute(responses)):
-        rows = db.get_lock_wait_rows()
+        rows = db.get_lock_wait_rows("site_one")
 
     assert len(rows) == 1
     row = rows[0]
     assert row.id == "123"
     assert row.type == "relation"
     assert row.mode == "RowExclusiveLock"
-    assert row.table == "site_one.tabDoc"
+    assert row.table == "site_one.public.tabDoc"
     assert row.index is None
     assert row.state == "active"
     assert row.started == "2026-01-01 00:00:00"
@@ -668,10 +678,9 @@ def test_postgres_get_lock_wait_rows_leaves_unsupported_fields_none() -> None:
     assert row.rows_modified is None
 
 
-def test_postgres_lock_wait_tables_resolve_in_their_own_database() -> None:
-    """The same OID names a different table in every database, so resolving it
-    against the connection's own catalog reported another database's table, or
-    a bare number when the OID was not in that catalog at all."""
+def test_postgres_server_wide_lock_waits_do_not_query_every_database() -> None:
+    """The server-wide view refreshes every two seconds, so relation lookup
+    must not open one connection for every database with a wait."""
     from pilot.core.database import QueryResult
 
     db = PostgreSQL(host="h", port=5432, user="u", password="p", database="")
@@ -680,21 +689,42 @@ def test_postgres_lock_wait_tables_resolve_in_their_own_database() -> None:
         [2, "relation", "RowExclusiveLock", 16385, "active", None, "UPDATE", "site_two"],
         [3, "advisory", "ExclusiveLock", None, "active", None, "SELECT", "site_one"],
     ]
-    catalogs = {"site_one": [[16385, "tabItem"]], "site_two": [[16385, "tabCustomer"]]}
-    asked: list[str] = []
 
     def execute(self, query: str, read_only: bool = True) -> QueryResult:
-        if "blocked.granted" in query:
-            return QueryResult(columns=[], rows=locks, duration_ms=0)
-        assert "relname FROM pg_class" in query
-        asked.append(self._database)
-        return QueryResult(columns=[], rows=catalogs[self._database], duration_ms=0)
+        assert "blocked.granted" in query
+        return QueryResult(columns=[], rows=locks, duration_ms=0)
 
     with patch.object(PostgreSQL, "execute", execute):
         rows = db.get_lock_wait_rows()
 
-    assert [row.table for row in rows] == ["site_one.tabItem", "site_two.tabCustomer", None]
-    assert sorted(asked) == ["site_one", "site_two"]
+    assert [row.table for row in rows] == [
+        "site_one (relation OID 16385)",
+        "site_two (relation OID 16385)",
+        None,
+    ]
+
+
+def test_postgres_site_lock_wait_includes_schema_in_relation_name() -> None:
+    """Relation names need the database and schema because PostgreSQL permits
+    the same table name in multiple schemas."""
+    from pilot.core.database import QueryResult
+
+    db = PostgreSQL(host="h", port=5432, user="u", password="p", database="")
+    lock = [1, "relation", "RowExclusiveLock", 16385, "active", None, "UPDATE", "site_one"]
+    asked: list[str] = []
+
+    def execute(self, query: str, read_only: bool = True) -> QueryResult:
+        if "blocked.granted" in query:
+            return QueryResult(columns=[], rows=[lock], duration_ms=0)
+        assert "JOIN pg_namespace" in query
+        asked.append(self._database)
+        return QueryResult(columns=[], rows=[[16385, "archive", "tabItem"]], duration_ms=0)
+
+    with patch.object(PostgreSQL, "execute", execute):
+        rows = db.get_lock_wait_rows("site_one")
+
+    assert rows[0].table == "site_one.archive.tabItem"
+    assert asked == ["site_one"]
 
 
 def test_postgres_lock_waits_ask_no_catalog_when_nothing_is_waiting() -> None:
@@ -777,20 +807,31 @@ def test_postgres_get_database_size_leaves_claimable_space_unknown() -> None:
     assert size.free_bytes is None
 
 
-def test_postgres_server_wide_size_sums_every_database() -> None:
-    """pg_class only ever describes the connected database, so a server-wide
-    connection has to ask each one; it used to report the maintenance
-    database's own size, which is always close to zero."""
+def test_postgres_server_wide_size_uses_one_combined_query() -> None:
+    """A host may have hundreds of databases, so server scope must not open a
+    connection and query pg_class once for every site."""
     db = PostgreSQL(host="h", port=5432, user="u", password="p", database="")
-    responses = {
-        "pg_database": (["datname"], [["site_one"], ["site_two"]]),
-        "pg_table_size": ([], [[1000, 200]]),
-    }
-    with patch.object(PostgreSQL, "execute", _canned_execute(responses)):
+    calls: list = []
+    responses = {"pg_database_size": (["total", "unavailable"], [[2400, 0]])}
+    with patch.object(PostgreSQL, "execute", _canned_execute(responses, calls)):
         size = db.get_database_size()
 
-    assert size.data_bytes == 2000
-    assert size.index_bytes == 400
+    assert size.data_bytes is None
+    assert size.index_bytes is None
+    assert size.total_bytes == 2400
+    assert len(calls) == 1
+    assert "datallowconn" not in calls[0][0]
+
+
+def test_postgres_server_wide_size_fails_if_a_database_cannot_be_measured() -> None:
+    db = PostgreSQL(host="h", port=5432, user="u", password="p", database="")
+    responses = {"pg_database_size": (["total", "unavailable"], [[2400, 1]])}
+
+    with (
+        patch.object(PostgreSQL, "execute", _canned_execute(responses)),
+        pytest.raises(DatabaseError, match="1 database"),
+    ):
+        db.get_database_size()
 
 
 def test_postgres_get_table_sizes_reports_per_relation() -> None:

--- a/tests/pilot/core/test_database.py
+++ b/tests/pilot/core/test_database.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import asdict
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,7 @@ import pytest
 
 from pilot.config import BenchConfig, MariaDBConfig, PostgresConfig, RedisConfig, WorkerConfig, WorkerGroup
 from pilot.core.database import (
+    DatabaseProcess,
     MariaDB,
     PostgreSQL,
     SQLite,
@@ -268,19 +270,31 @@ def _canned_execute(responses: dict, calls: list | None = None):
     return execute
 
 
-def test_mariadb_get_process_list_maps_rows_to_dicts() -> None:
+_MARIADB_PROCESS_COLUMNS = ["Id", "User", "Host", "db", "Command", "Time", "State", "Info"]
+
+
+def test_mariadb_get_process_list_normalises_rows() -> None:
     db = MariaDB(host="h", port=3306, user="u", password="p", database="")
     responses = {
         "PROCESSLIST": (
-            ["Id", "User", "db", "Command", "Time", "State", "Info"],
-            [[7, "app", "mydb", "Query", 3, "Sending data", "SELECT 1"]],
+            _MARIADB_PROCESS_COLUMNS,
+            [[7, "app", "localhost:53422", "mydb", "Query", 3, "Sending data", "SELECT 1"]],
         )
     }
     with patch.object(MariaDB, "execute", _canned_execute(responses)):
         processes = db.get_process_list()
 
     assert processes == [
-        {"Id": 7, "User": "app", "db": "mydb", "Command": "Query", "Time": 3, "State": "Sending data", "Info": "SELECT 1"}
+        DatabaseProcess(
+            id=7,
+            user="app",
+            host="localhost:53422",
+            database="mydb",
+            command="Query",
+            state="Sending data",
+            duration_seconds=3.0,
+            query="SELECT 1",
+        )
     ]
 
 
@@ -288,18 +302,20 @@ def test_mariadb_get_process_list_filters_by_database() -> None:
     db = MariaDB(host="h", port=3306, user="u", password="p", database="")
     responses = {
         "PROCESSLIST": (
-            ["Id", "User", "db", "Command", "Time", "State", "Info"],
+            _MARIADB_PROCESS_COLUMNS,
             [
-                [7, "app", "site_one", "Query", 3, "Sending data", "SELECT 1"],
-                [8, "app", "site_two", "Query", 1, "Sending data", "SELECT 2"],
-                [9, "root", None, "Sleep", 0, "", None],
+                [7, "app", "h:1", "site_one", "Query", 3, "Sending data", "SELECT 1"],
+                [8, "app", "h:2", "site_two", "Query", 1, "Sending data", "SELECT 2"],
+                [9, "root", "h:3", None, "Sleep", 0, "", None],
             ],
         )
     }
     with patch.object(MariaDB, "execute", _canned_execute(responses)):
-        assert [p["Id"] for p in db.get_process_list("site_one")] == [7]
+        assert [p.id for p in db.get_process_list("site_one")] == [7]
         # No database means server-wide, including connections with no database.
-        assert [p["Id"] for p in db.get_process_list()] == [7, 8, 9]
+        assert [p.id for p in db.get_process_list()] == [7, 8, 9]
+        # An idle connection reports no state of its own.
+        assert db.get_process_list()[2].state is None
 
 
 def test_mariadb_kill_process_issues_kill_connection() -> None:
@@ -630,9 +646,10 @@ def test_postgres_get_lock_wait_rows_leaves_unsupported_fields_none() -> None:
     responses = {
         "blocked.granted": (
             ["pid", "locktype", "mode", "relation", "state", "query_start", "query", "datname"],
-            [[123, "relation", "RowExclusiveLock", "tabDoc", "active",
+            [[123, "relation", "RowExclusiveLock", 16385, "active",
               "2026-01-01 00:00:00", "UPDATE tabDoc SET x=1", "site_one"]],
-        )
+        ),
+        "relname FROM pg_class": (["oid", "relname"], [[16385, "tabDoc"]]),
     }
     with patch.object(PostgreSQL, "execute", _canned_execute(responses)):
         rows = db.get_lock_wait_rows()
@@ -642,7 +659,7 @@ def test_postgres_get_lock_wait_rows_leaves_unsupported_fields_none() -> None:
     assert row.id == "123"
     assert row.type == "relation"
     assert row.mode == "RowExclusiveLock"
-    assert row.table == "tabDoc"
+    assert row.table == "site_one.tabDoc"
     assert row.index is None
     assert row.state == "active"
     assert row.started == "2026-01-01 00:00:00"
@@ -651,23 +668,100 @@ def test_postgres_get_lock_wait_rows_leaves_unsupported_fields_none() -> None:
     assert row.rows_modified is None
 
 
+def test_postgres_lock_wait_tables_resolve_in_their_own_database() -> None:
+    """The same OID names a different table in every database, so resolving it
+    against the connection's own catalog reported another database's table, or
+    a bare number when the OID was not in that catalog at all."""
+    from pilot.core.database import QueryResult
+
+    db = PostgreSQL(host="h", port=5432, user="u", password="p", database="")
+    locks = [
+        [1, "relation", "RowExclusiveLock", 16385, "active", None, "UPDATE", "site_one"],
+        [2, "relation", "RowExclusiveLock", 16385, "active", None, "UPDATE", "site_two"],
+        [3, "advisory", "ExclusiveLock", None, "active", None, "SELECT", "site_one"],
+    ]
+    catalogs = {"site_one": [[16385, "tabItem"]], "site_two": [[16385, "tabCustomer"]]}
+    asked: list[str] = []
+
+    def execute(self, query: str, read_only: bool = True) -> QueryResult:
+        if "blocked.granted" in query:
+            return QueryResult(columns=[], rows=locks, duration_ms=0)
+        assert "relname FROM pg_class" in query
+        asked.append(self._database)
+        return QueryResult(columns=[], rows=catalogs[self._database], duration_ms=0)
+
+    with patch.object(PostgreSQL, "execute", execute):
+        rows = db.get_lock_wait_rows()
+
+    assert [row.table for row in rows] == ["site_one.tabItem", "site_two.tabCustomer", None]
+    assert sorted(asked) == ["site_one", "site_two"]
+
+
+def test_postgres_lock_waits_ask_no_catalog_when_nothing_is_waiting() -> None:
+    """Locks auto-refresh every couple of seconds, so the common empty case
+    must not open a connection per database."""
+    db = PostgreSQL(host="h", port=5432, user="u", password="p", database="")
+    with patch.object(PostgreSQL, "execute", _canned_execute({"blocked.granted": ([], [])})):
+        assert db.get_lock_wait_rows() == []
+
+
 def test_postgres_diagnostics_filter_by_database() -> None:
     db = PostgreSQL(host="h", port=5432, user="u", password="p", database="d")
     lock_rows = (
         ["pid", "locktype", "mode", "relation", "state", "query_start", "query", "datname"],
         [
-            [1, "relation", "RowExclusiveLock", "t", "active", None, None, "site_one"],
-            [2, "relation", "RowExclusiveLock", "t", "active", None, None, "site_two"],
+            [1, "advisory", "ExclusiveLock", None, "active", None, None, "site_one"],
+            [2, "advisory", "ExclusiveLock", None, "active", None, None, "site_two"],
         ],
-    )
-    processes = (
-        ["pid", "user", "database", "state", "duration_seconds", "query"],
-        [[1, "app", "site_one", "active", 1, "SELECT 1"], [2, "app", "site_two", "active", 1, "SELECT 2"]],
     )
     with patch.object(PostgreSQL, "execute", _canned_execute({"blocked.granted": lock_rows})):
         assert [r.id for r in db.get_lock_wait_rows("site_one")] == ["1"]
-    with patch.object(PostgreSQL, "execute", _canned_execute({"pg_stat_activity": processes})):
-        assert [p["pid"] for p in db.get_process_list("site_two")] == [2]
+    with patch.object(PostgreSQL, "execute", _canned_execute({"pg_stat_activity": _POSTGRES_PROCESSES})):
+        assert [p.id for p in db.get_process_list("site_two")] == [2]
+
+
+_POSTGRES_PROCESSES = (
+    ["pid", "usename", "client_addr", "client_port", "datname", "state", "wait_event", "seconds", "query"],
+    [
+        [1, "app", "10.0.0.4", 53422, "site_one", "active", None, 3.4, "SELECT 1"],
+        [2, "app", None, -1, "site_two", "idle", "ClientRead", 12.0, "SELECT 2"],
+    ],
+)
+
+
+def test_postgres_get_process_list_normalises_rows() -> None:
+    db = PostgreSQL(host="h", port=5432, user="u", password="p", database="d")
+    with patch.object(PostgreSQL, "execute", _canned_execute({"pg_stat_activity": _POSTGRES_PROCESSES})):
+        processes = db.get_process_list()
+
+    assert processes[0] == DatabaseProcess(
+        id=1,
+        user="app",
+        host="10.0.0.4:53422",
+        database="site_one",
+        command="active",
+        state=None,
+        duration_seconds=3.4,
+        query="SELECT 1",
+    )
+    # A connection over the local socket has no client address to report.
+    assert processes[1].host is None
+
+
+def test_both_engines_report_the_same_process_shape() -> None:
+    """The dashboard reads one shape, so neither engine's own column names may
+    reach it - PostgreSQL used to send pid/usename/datname where the page read
+    MariaDB's Id/User/db and rendered an empty table."""
+    postgres = PostgreSQL(host="h", port=5432, user="u", password="p", database="d")
+    mariadb = MariaDB(host="h", port=3306, user="u", password="p", database="")
+    mariadb_rows = {"PROCESSLIST": (_MARIADB_PROCESS_COLUMNS, [[7, "app", "h:1", "db", "Query", 3, "", None]])}
+
+    with patch.object(PostgreSQL, "execute", _canned_execute({"pg_stat_activity": _POSTGRES_PROCESSES})):
+        from_postgres = postgres.get_process_list()[0]
+    with patch.object(MariaDB, "execute", _canned_execute(mariadb_rows)):
+        from_mariadb = mariadb.get_process_list()[0]
+
+    assert asdict(from_postgres).keys() == asdict(from_mariadb).keys()
 
 
 def test_postgres_get_database_size_leaves_claimable_space_unknown() -> None:
@@ -681,6 +775,22 @@ def test_postgres_get_database_size_leaves_claimable_space_unknown() -> None:
     # Reclaimable bloat needs the pgstattuple extension; remote host has no readable datadir.
     assert size.claimable_bytes is None
     assert size.free_bytes is None
+
+
+def test_postgres_server_wide_size_sums_every_database() -> None:
+    """pg_class only ever describes the connected database, so a server-wide
+    connection has to ask each one; it used to report the maintenance
+    database's own size, which is always close to zero."""
+    db = PostgreSQL(host="h", port=5432, user="u", password="p", database="")
+    responses = {
+        "pg_database": (["datname"], [["site_one"], ["site_two"]]),
+        "pg_table_size": ([], [[1000, 200]]),
+    }
+    with patch.object(PostgreSQL, "execute", _canned_execute(responses)):
+        size = db.get_database_size()
+
+    assert size.data_bytes == 2000
+    assert size.index_bytes == 400
 
 
 def test_postgres_get_table_sizes_reports_per_relation() -> None:
@@ -721,9 +831,11 @@ def test_make_database_returns_mariadb_for_mariadb_bench() -> None:
     assert isinstance(db, MariaDB)
 
 
-def test_make_database_returns_postgres_for_postgres_bench() -> None:
+def test_make_database_returns_a_server_wide_postgres_for_postgres_bench() -> None:
     db = make_database(_bench_config("postgres"))
     assert isinstance(db, PostgreSQL)
+    # No database means server-wide, the same signal MariaDB uses.
+    assert db._database == ""
 
 
 def test_make_database_raises_for_sqlite_bench() -> None:


### PR DESCRIPTION
The database analyzer assumed MariaDB response shapes. PostgreSQL then showed blank processes, incomplete storage, missing free space, and incorrect lock relation names.

- Process rows now use one `DatabaseProcess` shape for both engines. PostgreSQL lists only client backends because background workers cannot be killed.
- Server-wide PostgreSQL size now uses `pg_database_size` in one query. It includes offline databases and avoids one connection per database.
- Site-scoped PostgreSQL size keeps the exact data and index split. Server scope shows one accurate combined database size.
- Site-scoped free space falls back to the server connection when the site user cannot read `data_directory`.
- Server-wide lock rows keep the database and relation OID without extra connections. Site scope resolves the full database, schema, and relation name.
- Lock polling waits for each request to finish. It also reloads the current site when the scope changes during a request.
- The size bar excludes disk headroom because that value hid the database segments.

Validation:

- `91` focused database tests pass.
- Ruff and mypy checks pass.
- The dashboard production build passes.
- Live read-only checks pass against a local PostgreSQL bench.

<img width="3168" height="1708" alt="Database analyzer" src="https://github.com/user-attachments/assets/a3b3418f-ed19-4c37-96af-e244061080d2" />
