### PR TITLE
fix: Unblock app updates that frappe itself tolerates

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ See [Admin UI](docs/admin-ui.md) and [Admin API](docs/admin-api.md).
 - [Commands](docs/commands.md)
 - [Configuration](docs/configuration.md)
 - [App Dependencies](docs/app-dependencies.md)
+- [App Validation](docs/app-validation.md)
 - [Tasks](docs/tasks.md)
 - [Admin API](docs/admin-api.md)
 - [Admin UI](docs/admin-ui.md)

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -228,7 +228,7 @@
             <div class="flex shrink-0 items-center gap-2 font-mono text-xs text-ink-gray-6">
               <span>{{ shortSha(app.sha) }}</span>
               <span class="lucide-arrow-right size-3.5 text-ink-gray-4" aria-hidden="true" />
-              <span :class="app.updated_sha ? 'text-ink-green-7' : 'text-ink-gray-5'">
+              <span :class="revisionClass(app)" :title="revisionTitle(app)">
                 {{ shortSha(app.updated_sha || app.target_sha) }}
               </span>
               <a
@@ -429,6 +429,16 @@ const doSkip = () => {
 const badgeTone = (tone) => (tone === 'orange' ? 'amber' : tone)
 const countLabel = (count = 0, noun) => `${count} ${noun}${count === 1 ? '' : 's'}`
 const shortSha = (sha) => sha?.slice(0, 7) || '—'
+
+const revisionClass = (app) => {
+  if (op.value?.apps_updated) return 'text-ink-green-7'
+  return app.updated_sha ? 'text-ink-amber-7' : 'text-ink-gray-5'
+}
+const revisionTitle = (app) => {
+  if (op.value?.apps_updated) return 'Updated'
+  if (app.updated_sha) return 'Checked out, but the update did not finish'
+  return 'Not updated yet'
+}
 
 onMounted(async () => {
   loading.value = true

--- a/docs/app-validation.md
+++ b/docs/app-validation.md
@@ -1,0 +1,55 @@
+# App Validation
+
+`App.validate` is the gate an app passes before pilot installs or builds it. Install, `update` and `switch-branch` all
+call it, so an app that has moved revision is held to the same standard as a new one. Checks read the app's source and
+never run it.
+
+Each check lives in `pilot/core/app/validator/` as one class.
+
+| Check | Catches |
+| --- | --- |
+| `RepoStructureCheck` | Missing files pilot expects: the module directory, `hooks.py`, `pyproject.toml` |
+| `VersionSpecifiersCheck` | PEP 440 specifiers uv/pip would refuse, such as `>=20.19 <21` with the comma missing |
+| `SymlinkCheck` | Symlinks resolving outside the app |
+| `SyntaxCheck` | Any Python file that fails to parse |
+| `HooksCheck` | Hook values of the wrong shape, and dotted paths naming code that does not exist |
+| `FixturesCheck` | Fixture files that fail to parse, since frappe imports them during migrate |
+| `DependencyDeclarationsCheck` | Dependency requirements in `hooks.py` and `pyproject.toml` that disagree or are malformed |
+| `FrappeCompatibilityCheck` | A declared frappe version range the bench does not satisfy |
+| `DependencyResolutionCheck` | Dependencies that cannot resolve against what every other app on the bench requires |
+| `ImportCheck` | Module-scope imports that resolve nowhere on the bench |
+
+## Blocking and advisory findings
+
+Almost every finding is blocking: the check raises `AppValidationError`, and the install or update stops before anything
+is installed or built.
+
+A finding is advisory only where frappe itself catches the same failure and carries on. Blocking there would strand a
+bench on a defect in an upstream app the operator cannot patch, while allowing it costs nothing frappe was not already
+prepared to lose. Advisory findings are returned as warnings and reported by the calling task.
+
+One case qualifies today:
+
+- **A stale `scheduler_events` path.** frappe's `insert_single_event()` resolves each scheduler path with `get_attr()`,
+  catches the failure, warns, and skips the job. The migrate completes and the job is simply never registered.
+
+Every other hook is fatal, including the hooks that only fail long after an update finishes. `boot_session`, `on_login`,
+`on_session_creation`, `auth_hooks` and `clear_cache` all reach a bare `get_attr()`, so allowing one through would trade
+a blocked update for a Desk or login outage. The rule is fatal by default: a hook added later blocks unless someone
+shows its consumer catches.
+
+## What `ImportCheck` will not judge
+
+Imports inside functions and `try` blocks are skipped, being lazy and often deliberately optional. What remains are
+module-scope imports, which must resolve whenever the module loads.
+
+Files only a developer runs are skipped by location: `test_*.py`, `conftest.py`, and anything under a `tests/` or
+`benchmarks/` directory. Their imports come from dev extras a plain install never provides, and no request or migrate
+loads them. Location is the only thing that excuses an import — declaring a package under
+`[project.optional-dependencies]` does not, because the extra is never installed and the import would still fail on the
+first request that loads the module.
+
+## Limits
+
+`HooksCheck` resolves a dotted path to a name that exists on disk, not to code that works. It cannot see a wrong
+signature, and stops at the first attribute, so `module.Class.method` is checked only as far as `Class`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,13 +57,12 @@ directory that `bench.apps()` scans to decide what to update, reinstall and cons
 half-installed app never reaches a site.
 
 `App.validate` runs every check, and is the only gate: install, `update` and `switch-branch` all use it, so an app that
-has moved revision is held to the same standard as a new one. `pilot.core.app.validator` holds one class per check,
-each raising `AppValidationError` with the fix. See [App Dependencies](app-dependencies.md) for what apps must declare
-and how conflicts between them are resolved.
+has moved revision is held to the same standard as a new one. `pilot.core.app.validator` holds one class per check. A
+check raises `AppValidationError` with the fix, or returns advisory findings the calling task reports as warnings. See
+[App Validation](app-validation.md) for what each check catches and which findings block, and
+[App Dependencies](app-dependencies.md) for what apps must declare and how conflicts between them are resolved.
 
-Checks read the app's source, never run it. Hooks validation resolves each dotted path to a name that exists on disk -
-not to code that works: it cannot see a wrong signature, and stops at the first attribute, so `module.Class.method`
-is checked only as far as `Class`.
+Checks read the app's source, never run it.
 
 Every app must ship `pyproject.toml` with a `[tool.bench.frappe-dependencies]` table pinning the frappe versions it
 supports, and the declared ranges are compared against the versions actually installed.

--- a/pilot/core/app/__init__.py
+++ b/pilot/core/app/__init__.py
@@ -275,7 +275,8 @@ class App:
                 self.checkout_commit(commit)
             dependencies = self._install_dependencies(on_progress) if install_dependencies else []
             if self.is_staged:
-                self.validate()
+                for warning in self.validate():
+                    on_progress(f"Warning: {warning}")
             self.promote()
         except BenchError:
             self._undo_clone(existing_clone)
@@ -336,10 +337,10 @@ class App:
 
         return AppDependencyInstaller(self.bench, self).install(on_progress)
 
-    def validate(self) -> None:
+    def validate(self) -> list[str]:
         from pilot.core.app.validator import Validator
 
-        Validator(self).validate()
+        return Validator(self).validate()
 
     def _install_into_environment(self) -> None:
         from pilot.managers.environment import PythonEnvManager

--- a/pilot/core/app/validator/base.py
+++ b/pilot/core/app/validator/base.py
@@ -11,9 +11,13 @@ if typing.TYPE_CHECKING:
 
 
 class ValidationCheck(typing.Protocol):
-    """A single check run against a cloned app before it's installed."""
+    """A single check run against a cloned app before it's installed.
 
-    def run(self, app: "App") -> None: ...
+    Raises AppValidationError to block; returns any non-blocking findings as
+    warnings for the caller to surface.
+    """
+
+    def run(self, app: "App") -> list[str] | None: ...
 
 
 def module_path(app: "App") -> Path:

--- a/pilot/core/app/validator/hooks.py
+++ b/pilot/core/app/validator/hooks.py
@@ -35,8 +35,7 @@ _DICT_HOOKS = frozenset(
     ]
 )
 
-# Hooks whose leaf strings are dotted paths frappe resolves with get_attr(). A
-# stale path fails when the hook fires - often mid-migrate.
+# Hooks whose leaf strings are dotted paths frappe resolves with get_attr().
 _PATH_HOOKS = frozenset(
     [
         "additional_timeline_content",
@@ -82,6 +81,23 @@ _PATH_HOOKS = frozenset(
     ]
 )
 
+# The subset frappe resolves eagerly during install, migrate, build, or uninstall,
+# with a bare get_attr() and no guard - a stale path there aborts the operation
+# pilot is running. Every other path hook resolves lazily on a runtime action, and
+# frappe skips a scheduler_events path it cannot import instead of failing migrate.
+_BLOCKING_PATH_HOOKS = frozenset(
+    [
+        "after_build",
+        "after_install",
+        "after_migrate",
+        "after_sync",
+        "after_uninstall",
+        "before_install",
+        "before_migrate",
+        "before_uninstall",
+    ]
+)
+
 
 # Shapes a dict hook definitely isn't. A name or a call may still evaluate to a
 # dict at import time, so those are left alone rather than guessed at.
@@ -93,33 +109,44 @@ class HooksCheck:
 
     Only documented hooks are inspected; app-specific hook names are left alone.
     SyntaxCheck guarantees hooks.py parses first.
+
+    A stale path only blocks when frappe would abort on it. The rest are returned
+    as warnings: refusing to update over them would strand a bench on a defect in
+    an upstream app the operator cannot patch.
     """
 
-    def run(self, app: "App") -> None:
+    def run(self, app: "App") -> list[str]:
         hooks_path = module_path(app) / "hooks.py"
         if not hooks_path.is_file():
-            return  # RepoStructureCheck owns this when it runs; updates skip it
+            return []  # RepoStructureCheck owns this when it runs; updates skip it
         tree = ast.parse(hooks_path.read_text())
 
-        problems = []
+        blocking, advisory = [], []
         for name, value in _hook_assignments(tree):
             if name in _DICT_HOOKS and isinstance(value, _NOT_A_DICT):
-                problems.append(f"line {value.lineno}: {name} must be a dict")
+                blocking.append(f"line {value.lineno}: {name} must be a dict")
                 continue
             if name not in _PATH_HOOKS:
                 continue
             for path, lineno in _string_values(value):
                 error = _path_error(app, path)
                 if error:
-                    problems.append(f"line {lineno}: {name} -> {path}: {error}")
+                    problem = f"line {lineno}: {name} -> {path}: {error}"
+                    (blocking if name in _BLOCKING_PATH_HOOKS else advisory).append(problem)
 
-        if problems:
-            raise AppValidationError(
-                f"'{app.config.name}' has invalid hooks in {app.module_name}/hooks.py:\n"
-                + "\n".join(f"  {problem}" for problem in problems)
-                + "\nPoint each path at code that exists (or drop the hook). Hook shapes: "
-                "https://docs.frappe.io/framework/user/en/python-api/hooks"
-            )
+        if blocking:
+            raise AppValidationError(_blocking_message(app, blocking))
+        location = f"{app.module_name}/hooks.py"
+        return [f"'{app.config.name}' has a stale hook in {location}: {problem}" for problem in advisory]
+
+
+def _blocking_message(app: "App", problems: list[str]) -> str:
+    return (
+        f"'{app.config.name}' has invalid hooks in {app.module_name}/hooks.py:\n"
+        + "\n".join(f"  {problem}" for problem in problems)
+        + "\nPoint each path at code that exists (or drop the hook). Hook shapes: "
+        "https://docs.frappe.io/framework/user/en/python-api/hooks"
+    )
 
 
 def _hook_assignments(tree: ast.Module) -> list[tuple[str, ast.expr]]:

--- a/pilot/core/app/validator/hooks.py
+++ b/pilot/core/app/validator/hooks.py
@@ -121,7 +121,8 @@ class HooksCheck:
             return []  # RepoStructureCheck owns this when it runs; updates skip it
         tree = ast.parse(hooks_path.read_text())
 
-        blocking, advisory = [], []
+        blocking: list[str] = []
+        advisory: list[str] = []
         for name, value in _hook_assignments(tree):
             if name in _DICT_HOOKS and isinstance(value, _NOT_A_DICT):
                 blocking.append(f"line {value.lineno}: {name} must be a dict")

--- a/pilot/core/app/validator/hooks.py
+++ b/pilot/core/app/validator/hooks.py
@@ -81,22 +81,12 @@ _PATH_HOOKS = frozenset(
     ]
 )
 
-# The subset frappe resolves eagerly during install, migrate, build, or uninstall,
-# with a bare get_attr() and no guard - a stale path there aborts the operation
-# pilot is running. Every other path hook resolves lazily on a runtime action, and
-# frappe skips a scheduler_events path it cannot import instead of failing migrate.
-_BLOCKING_PATH_HOOKS = frozenset(
-    [
-        "after_build",
-        "after_install",
-        "after_migrate",
-        "after_sync",
-        "after_uninstall",
-        "before_install",
-        "before_migrate",
-        "before_uninstall",
-    ]
-)
+# The only hook whose consumer catches a path it cannot import: frappe's
+# insert_single_event() warns and skips the job, so a stale one never fails an
+# install or a migrate. Every other path hook reaches an unguarded get_attr() -
+# mid-migrate, on login, or when Desk boots - and a failure there is worse than a
+# blocked update, so anything not listed here stays fatal.
+_ADVISORY_PATH_HOOKS = frozenset(["scheduler_events"])
 
 
 # Shapes a dict hook definitely isn't. A name or a call may still evaluate to a
@@ -110,9 +100,9 @@ class HooksCheck:
     Only documented hooks are inspected; app-specific hook names are left alone.
     SyntaxCheck guarantees hooks.py parses first.
 
-    A stale path only blocks when frappe would abort on it. The rest are returned
-    as warnings: refusing to update over them would strand a bench on a defect in
-    an upstream app the operator cannot patch.
+    Stale paths are fatal by default. Only a hook whose consumer is known to catch
+    the failure comes back as a warning, so refusing to update never hinges on a
+    defect frappe itself tolerates.
     """
 
     def run(self, app: "App") -> list[str]:
@@ -133,7 +123,7 @@ class HooksCheck:
                 error = _path_error(app, path)
                 if error:
                     problem = f"line {lineno}: {name} -> {path}: {error}"
-                    (blocking if name in _BLOCKING_PATH_HOOKS else advisory).append(problem)
+                    (advisory if name in _ADVISORY_PATH_HOOKS else blocking).append(problem)
 
         if blocking:
             raise AppValidationError(_blocking_message(app, blocking))

--- a/pilot/core/app/validator/imports.py
+++ b/pilot/core/app/validator/imports.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import ast
-import re
 import sys
 import typing
 from collections.abc import Iterable, Iterator
@@ -20,10 +19,8 @@ if typing.TYPE_CHECKING:
     from pilot.core.app import App
 
 
-def _distribution_name(requirement: str) -> str:
-    """The PEP 503 normalized project name heading a requirement string."""
-    name = re.split(r"[<>=!~;\[\s]", requirement, maxsplit=1)[0]
-    return re.sub(r"[-_.]+", "-", name).lower()
+# Directories whose contents only ever run from a developer's shell.
+_DEVELOPER_DIRECTORIES = frozenset(["tests", "benchmarks"])
 
 
 class ImportCheck:
@@ -36,7 +33,6 @@ class ImportCheck:
         locations = self._imported_module_locations(app)
         unresolved = self._get_on_disk_resolver(app).unresolved(locations)
         unresolved = self._get_missing_from_bench_env(app, unresolved)
-        unresolved = self._drop_declared_extras(app, unresolved)
         if not unresolved:
             return  # everything imported is already on the bench - nothing to install
 
@@ -76,29 +72,6 @@ class ImportCheck:
 
         missing = unimportable_modules(python, candidates)
         return [name for name in unresolved if name not in candidates or name in missing]
-
-    @staticmethod
-    def _drop_declared_extras(app: "App", unresolved: list[str]) -> list[str]:
-        """Ignore imports an optional-dependency group declares.
-
-        Installing an app never pulls its extras, so those imports cannot resolve -
-        but a declared extra is an optional feature, not a broken import. The
-        _is_test_file skip covers the same ground for undeclared test-only imports,
-        and only where the file is named like a test.
-        """
-        project = (read_pyproject(app) or {}).get("project", {})
-        extras = project.get("optional-dependencies", {}) if isinstance(project, dict) else {}
-        if not isinstance(extras, dict):
-            return unresolved  # VersionSpecifiersCheck reports the bad table
-
-        declared = {
-            _distribution_name(requirement)
-            for group in extras.values()
-            if isinstance(group, list)
-            for requirement in group
-            if isinstance(requirement, str)
-        }
-        return [name for name in unresolved if _distribution_name(name.split(".", 1)[0]) not in declared]
 
     @staticmethod
     def _dependency_paths(app: "App") -> list[Path]:
@@ -145,9 +118,9 @@ class ImportCheck:
         stdlib = sys.stdlib_module_names
         locations: dict[str, list[str]] = {}
         for path in python_files(app):
-            if self._is_test_file(path):
-                continue
             relpath = path.relative_to(app.path)
+            if self._is_developer_only(relpath):
+                continue
             for module, lineno in self._file_imported_modules(app, path):
                 if module.split(".", 1)[0] in stdlib:
                     continue
@@ -158,10 +131,16 @@ class ImportCheck:
         return locations
 
     @staticmethod
-    def _is_test_file(path: Path) -> bool:
-        # Test-only imports (responses, time_machine, ...) come from dev extras
-        # a plain pip install never provides, so they'd always fail to resolve.
-        return path.name.startswith("test_") or path.name == "conftest.py"
+    def _is_developer_only(relpath: Path) -> bool:
+        """Files only a developer runs, keyed off location rather than the imports
+        themselves. Their imports (responses, pyperf, time_machine, ...) come from
+        dev extras a plain install never provides, so they'd always fail to resolve,
+        and no request or migrate ever loads them. A module-scope import anywhere
+        else has to resolve however the app declares the package.
+        """
+        if relpath.name.startswith("test_") or relpath.name == "conftest.py":
+            return True
+        return bool(_DEVELOPER_DIRECTORIES.intersection(relpath.parts[:-1]))
 
     def _file_imported_modules(self, app: "App", path: Path) -> list[tuple[str, int]]:
         try:

--- a/pilot/core/app/validator/imports.py
+++ b/pilot/core/app/validator/imports.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import re
 import sys
 import typing
 from collections.abc import Iterable, Iterator
@@ -19,6 +20,12 @@ if typing.TYPE_CHECKING:
     from pilot.core.app import App
 
 
+def _distribution_name(requirement: str) -> str:
+    """The PEP 503 normalized project name heading a requirement string."""
+    name = re.split(r"[<>=!~;\[\s]", requirement, maxsplit=1)[0]
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
 class ImportCheck:
     """Validates imports in a throwaway venv without executing app modules."""
 
@@ -29,6 +36,7 @@ class ImportCheck:
         locations = self._imported_module_locations(app)
         unresolved = self._get_on_disk_resolver(app).unresolved(locations)
         unresolved = self._get_missing_from_bench_env(app, unresolved)
+        unresolved = self._drop_declared_extras(app, unresolved)
         if not unresolved:
             return  # everything imported is already on the bench - nothing to install
 
@@ -68,6 +76,29 @@ class ImportCheck:
 
         missing = unimportable_modules(python, candidates)
         return [name for name in unresolved if name not in candidates or name in missing]
+
+    @staticmethod
+    def _drop_declared_extras(app: "App", unresolved: list[str]) -> list[str]:
+        """Ignore imports an optional-dependency group declares.
+
+        Installing an app never pulls its extras, so those imports cannot resolve -
+        but a declared extra is an optional feature, not a broken import. The
+        _is_test_file skip covers the same ground for undeclared test-only imports,
+        and only where the file is named like a test.
+        """
+        project = (read_pyproject(app) or {}).get("project", {})
+        extras = project.get("optional-dependencies", {}) if isinstance(project, dict) else {}
+        if not isinstance(extras, dict):
+            return unresolved  # VersionSpecifiersCheck reports the bad table
+
+        declared = {
+            _distribution_name(requirement)
+            for group in extras.values()
+            if isinstance(group, list)
+            for requirement in group
+            if isinstance(requirement, str)
+        }
+        return [name for name in unresolved if _distribution_name(name.split(".", 1)[0]) not in declared]
 
     @staticmethod
     def _dependency_paths(app: "App") -> list[Path]:

--- a/pilot/core/app/validator/validator.py
+++ b/pilot/core/app/validator/validator.py
@@ -25,9 +25,11 @@ class Validator:
         self.app = app
         self.checks = checks or _all_checks()
 
-    def validate(self) -> None:
+    def validate(self) -> list[str]:
+        warnings = []
         for check in self.checks:
-            check.run(self.app)
+            warnings += check.run(self.app) or []
+        return warnings
 
 
 def _all_checks() -> list["ValidationCheck"]:

--- a/pilot/core/bench/migration/operation.py
+++ b/pilot/core/bench/migration/operation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import importlib
 import json
 from collections.abc import Callable
@@ -206,9 +207,13 @@ class MigrationOperation:
             self.bench._update_apps(filter_set, on_progress, pins)
             self.bench._reinstall_apps(filter_set, on_progress)
             self.bench._rebuild_assets(filter_set, on_progress)
-            for revision in self.apps:
-                revision.updated_sha = self.bench.app(revision.name).installed_hash
+            self._record_installed_shas()
         except Exception as error:
+            # The checkout lands before the phase can fail, so read the tree back
+            # rather than leave the record pointing at a revision that is gone.
+            # Bookkeeping must not mask the failure being reported.
+            with contextlib.suppress(Exception):
+                self._record_installed_shas()
             self.diagnosis = {
                 "phase": "update",
                 "message": str(error),
@@ -392,6 +397,11 @@ class MigrationOperation:
             self._transition("backing_up")
         else:
             self._transition("updating" if self.apps else "migrating")
+
+    def _record_installed_shas(self) -> None:
+        """Point every revision at what is checked out right now."""
+        for revision in self.apps:
+            revision.updated_sha = self.bench.app(revision.name).installed_hash
 
     def _enter_needs_attention(self, phase: str, site: str | None) -> None:
         self.return_state = phase

--- a/pilot/core/bench/update.py
+++ b/pilot/core/bench/update.py
@@ -47,7 +47,8 @@ class BenchUpdater:
         # installed or built yet, and reverting is a checkout.
         for app in updated:
             on_progress(f"Validating {app.config.name}...")
-            app.validate()
+            for warning in app.validate():
+                on_progress(f"Warning: {warning}")
 
     @staticmethod
     def _follows_its_branch(app: "App", live_lookup: bool) -> bool:

--- a/pilot/tasks/switch_branch.py
+++ b/pilot/tasks/switch_branch.py
@@ -55,7 +55,8 @@ class SwitchBranchTask(Task):
         from pilot.exceptions import BenchError
 
         try:
-            app.validate()
+            for warning in app.validate():
+                self.report(f"Warning: {warning}")
         except BenchError:
             if previous_branch:
                 app.switch_branch(previous_branch)

--- a/tests/pilot/core/test_app_install.py
+++ b/tests/pilot/core/test_app_install.py
@@ -99,9 +99,14 @@ def test_install_stages_an_already_cloned_app_instead_of_re_cloning(tmp_path: Pa
         raise AssertionError("an app already in apps/ must not be re-cloned")
 
     validated_at = []
+
+    def record_validation(self: App) -> list[str]:
+        validated_at.append(self.path)
+        return []
+
     with (
         patch.object(AppRepository, "clone", unexpected_clone),
-        patch.object(App, "validate", lambda self: validated_at.append(self.path)),
+        patch.object(App, "validate", record_validation),
         patch.object(App, "_install_into_environment"),
         patch.object(App, "_build_assets_via_env_manager"),
     ):

--- a/tests/pilot/core/test_app_validator.py
+++ b/tests/pilot/core/test_app_validator.py
@@ -337,10 +337,10 @@ def test_hooks_fails_when_path_points_at_missing_submodule(tmp_path: Path) -> No
         HooksCheck().run(app)
 
 
-def test_hooks_warns_instead_of_failing_for_a_lazily_resolved_hook(tmp_path: Path) -> None:
-    """frappe skips a scheduler_events path it cannot import rather than failing the
-    migrate, so blocking an update over one strands the bench on an upstream defect
-    the operator cannot patch."""
+def test_hooks_warns_instead_of_failing_for_a_stale_scheduler_event(tmp_path: Path) -> None:
+    """frappe's insert_single_event() catches a scheduler path it cannot import and
+    skips the job, so blocking an update over one strands the bench on an upstream
+    defect the operator cannot patch."""
     app = _make_hooks_app(
         tmp_path,
         'scheduler_events = {"daily": ["myapp.tasks.cleanup_old_syncs"]}\n',
@@ -353,9 +353,21 @@ def test_hooks_warns_instead_of_failing_for_a_lazily_resolved_hook(tmp_path: Pat
     assert "cleanup_old_syncs" in warnings[0]
 
 
-def test_hooks_still_fails_for_a_hook_frappe_resolves_eagerly(tmp_path: Path) -> None:
-    """A stale after_migrate aborts the migrate itself, so it stays fatal alongside
-    an advisory one - and the advisory problem stays out of the failure."""
+@pytest.mark.parametrize(
+    "hook",
+    ["boot_session", "on_login", "on_session_creation", "auth_hooks", "clear_cache"],
+)
+def test_hooks_still_fails_for_a_hook_frappe_resolves_unguarded(tmp_path: Path, hook: str) -> None:
+    """frappe reaches these through a bare get_attr() - on boot, at login, or during
+    a migrate's cache clear. Letting an update through would trade a blocked update
+    for a Desk or login outage, so only proven-guarded hooks may be advisory."""
+    app = _make_hooks_app(tmp_path / hook, f'{hook} = "myapp.tasks.missing"\n', tasks="")
+
+    with pytest.raises(AppValidationError, match="missing"):
+        HooksCheck().run(app)
+
+
+def test_hooks_keeps_an_advisory_problem_out_of_a_blocking_failure(tmp_path: Path) -> None:
     app = _make_hooks_app(
         tmp_path,
         'scheduler_events = {"daily": ["myapp.tasks.cleanup_old_syncs"]}\n'
@@ -370,9 +382,9 @@ def test_hooks_still_fails_for_a_hook_frappe_resolves_eagerly(tmp_path: Path) ->
 
 
 def test_hooks_fails_when_path_walks_into_a_non_package_directory(tmp_path: Path) -> None:
-    app = _make_hooks_app(tmp_path, 'after_install = "myapp.public.js.after_install"\n')
+    app = _make_hooks_app(tmp_path, 'on_login = "myapp.public.js.on_login"\n')
     (app.path / "myapp" / "public").mkdir()
-    with pytest.raises(AppValidationError, match=r"no module 'myapp\.public\.js\.after_install'"):
+    with pytest.raises(AppValidationError, match=r"no module 'myapp\.public\.js\.on_login'"):
         HooksCheck().run(app)
 
 
@@ -437,9 +449,10 @@ def test_hooks_reads_jenv_style_alias_paths(tmp_path: Path) -> None:
     app = _make_hooks_app(
         tmp_path, 'jinja = {"methods": ["shout:myapp.utils.shout"]}\n', utils="def whisper():\n    pass\n"
     )
-    assert "'utils' has no 'shout'" in HooksCheck().run(app)[0]
+    with pytest.raises(AppValidationError, match="'utils' has no 'shout'"):
+        HooksCheck().run(app)
     (app.path / "myapp" / "utils.py").write_text("def shout():\n    pass\n")
-    assert HooksCheck().run(app) == []
+    HooksCheck().run(app)
 
 
 def _make_frappe_at(bench_root: Path, version: str) -> None:
@@ -612,30 +625,28 @@ def test_import_check_resolves_external_package_published_under_different_dist_n
     ImportCheck().run(app)
 
 
-def test_import_check_allows_an_import_declared_as_an_optional_dependency(tmp_path: Path) -> None:
-    """Installing an app never pulls its extras, so a dev-only import cannot resolve -
-    blocking on one would refuse an update over an optional feature. The file is not
-    named like a test, so the _is_test_file skip does not cover it."""
+@pytest.mark.parametrize(
+    "relpath",
+    ["myapp/tests/microbenchmarks/run_benchmarks.py", "myapp/benchmarks/profile_it.py"],
+)
+def test_import_check_skips_files_only_a_developer_runs(tmp_path: Path, relpath: str) -> None:
+    """A dev extra a plain install never provides cannot resolve, and nothing loads
+    these files at request or migrate time. The filename rule alone missed them -
+    frappe's tests/microbenchmarks/run_benchmarks.py imports pyperf."""
     _make_fake_frappe(tmp_path)
     app = _make_app(
         tmp_path,
         "myapp",
-        (
-            '[project]\nname = "myapp"\nversion = "0.0.1"\ndependencies = ["frappe"]\n\n'
-            "[project.optional-dependencies]\n"
-            'dev = ["py_perf==2.8.1"]\n\n'
-            f"{_SETUPTOOLS_BUILD}"
-        ),
-        {
-            "myapp/hooks.py": "app_name = 'myapp'\n",
-            "myapp/benchmarks/run_benchmarks.py": "import py_perf\n",
-        },
+        f'[project]\nname = "myapp"\nversion = "0.0.1"\ndependencies = ["frappe"]\n\n{_SETUPTOOLS_BUILD}',
+        {"myapp/hooks.py": "app_name = 'myapp'\n", relpath: "import definitely_missing_package_xyz\n"},
     )
     ImportCheck().run(app)
 
 
-def test_import_check_still_fails_for_a_module_no_group_declares(tmp_path: Path) -> None:
-    """The extras skip is scoped to declared names, not a blanket bypass."""
+def test_import_check_fails_for_a_runtime_module_scope_import_of_an_extra(tmp_path: Path) -> None:
+    """Declaring a package as an extra does not make an unconditional import safe:
+    the extra is never installed, so the first request loading this controller would
+    raise ModuleNotFoundError. Only the file's location may excuse an import."""
     _make_fake_frappe(tmp_path)
     app = _make_app(
         tmp_path,
@@ -643,12 +654,12 @@ def test_import_check_still_fails_for_a_module_no_group_declares(tmp_path: Path)
         (
             '[project]\nname = "myapp"\nversion = "0.0.1"\ndependencies = ["frappe"]\n\n'
             "[project.optional-dependencies]\n"
-            'dev = ["py_perf==2.8.1"]\n\n'
+            'dev = ["definitely-missing-package-xyz==1.0"]\n\n'
             f"{_SETUPTOOLS_BUILD}"
         ),
         {
             "myapp/hooks.py": "app_name = 'myapp'\n",
-            "myapp/utils.py": "import definitely_missing_package_xyz\n",
+            "myapp/controllers/todo.py": "import definitely_missing_package_xyz\n",
         },
     )
     with pytest.raises(AppValidationError, match="definitely_missing_package_xyz"):

--- a/tests/pilot/core/test_app_validator.py
+++ b/tests/pilot/core/test_app_validator.py
@@ -337,10 +337,42 @@ def test_hooks_fails_when_path_points_at_missing_submodule(tmp_path: Path) -> No
         HooksCheck().run(app)
 
 
+def test_hooks_warns_instead_of_failing_for_a_lazily_resolved_hook(tmp_path: Path) -> None:
+    """frappe skips a scheduler_events path it cannot import rather than failing the
+    migrate, so blocking an update over one strands the bench on an upstream defect
+    the operator cannot patch."""
+    app = _make_hooks_app(
+        tmp_path,
+        'scheduler_events = {"daily": ["myapp.tasks.cleanup_old_syncs"]}\n',
+        tasks="def sync():\n    pass\n",
+    )
+
+    warnings = HooksCheck().run(app)
+
+    assert len(warnings) == 1
+    assert "cleanup_old_syncs" in warnings[0]
+
+
+def test_hooks_still_fails_for_a_hook_frappe_resolves_eagerly(tmp_path: Path) -> None:
+    """A stale after_migrate aborts the migrate itself, so it stays fatal alongside
+    an advisory one - and the advisory problem stays out of the failure."""
+    app = _make_hooks_app(
+        tmp_path,
+        'scheduler_events = {"daily": ["myapp.tasks.cleanup_old_syncs"]}\n'
+        'after_migrate = "myapp.tasks.missing_migrate"\n',
+        tasks="def sync():\n    pass\n",
+    )
+
+    with pytest.raises(AppValidationError, match="missing_migrate") as failure:
+        HooksCheck().run(app)
+
+    assert "cleanup_old_syncs" not in str(failure.value)
+
+
 def test_hooks_fails_when_path_walks_into_a_non_package_directory(tmp_path: Path) -> None:
-    app = _make_hooks_app(tmp_path, 'on_login = "myapp.public.js.on_login"\n')
+    app = _make_hooks_app(tmp_path, 'after_install = "myapp.public.js.after_install"\n')
     (app.path / "myapp" / "public").mkdir()
-    with pytest.raises(AppValidationError, match=r"no module 'myapp\.public\.js\.on_login'"):
+    with pytest.raises(AppValidationError, match=r"no module 'myapp\.public\.js\.after_install'"):
         HooksCheck().run(app)
 
 
@@ -405,10 +437,9 @@ def test_hooks_reads_jenv_style_alias_paths(tmp_path: Path) -> None:
     app = _make_hooks_app(
         tmp_path, 'jinja = {"methods": ["shout:myapp.utils.shout"]}\n', utils="def whisper():\n    pass\n"
     )
-    with pytest.raises(AppValidationError, match="'utils' has no 'shout'"):
-        HooksCheck().run(app)
+    assert "'utils' has no 'shout'" in HooksCheck().run(app)[0]
     (app.path / "myapp" / "utils.py").write_text("def shout():\n    pass\n")
-    HooksCheck().run(app)
+    assert HooksCheck().run(app) == []
 
 
 def _make_frappe_at(bench_root: Path, version: str) -> None:
@@ -579,6 +610,49 @@ def test_import_check_resolves_external_package_published_under_different_dist_n
         },
     )
     ImportCheck().run(app)
+
+
+def test_import_check_allows_an_import_declared_as_an_optional_dependency(tmp_path: Path) -> None:
+    """Installing an app never pulls its extras, so a dev-only import cannot resolve -
+    blocking on one would refuse an update over an optional feature. The file is not
+    named like a test, so the _is_test_file skip does not cover it."""
+    _make_fake_frappe(tmp_path)
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        (
+            '[project]\nname = "myapp"\nversion = "0.0.1"\ndependencies = ["frappe"]\n\n'
+            "[project.optional-dependencies]\n"
+            'dev = ["py_perf==2.8.1"]\n\n'
+            f"{_SETUPTOOLS_BUILD}"
+        ),
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/benchmarks/run_benchmarks.py": "import py_perf\n",
+        },
+    )
+    ImportCheck().run(app)
+
+
+def test_import_check_still_fails_for_a_module_no_group_declares(tmp_path: Path) -> None:
+    """The extras skip is scoped to declared names, not a blanket bypass."""
+    _make_fake_frappe(tmp_path)
+    app = _make_app(
+        tmp_path,
+        "myapp",
+        (
+            '[project]\nname = "myapp"\nversion = "0.0.1"\ndependencies = ["frappe"]\n\n'
+            "[project.optional-dependencies]\n"
+            'dev = ["py_perf==2.8.1"]\n\n'
+            f"{_SETUPTOOLS_BUILD}"
+        ),
+        {
+            "myapp/hooks.py": "app_name = 'myapp'\n",
+            "myapp/utils.py": "import definitely_missing_package_xyz\n",
+        },
+    )
+    with pytest.raises(AppValidationError, match="definitely_missing_package_xyz"):
+        ImportCheck().run(app)
 
 
 def _modules_for(app: App, relpath: str, source: str) -> set[str]:

--- a/tests/pilot/core/test_core.py
+++ b/tests/pilot/core/test_core.py
@@ -427,8 +427,12 @@ def test_app_install_checks_out_the_pinned_commit_before_validating(tmp_path: Pa
     app = App(AppConfig(name="myapp", repo=str(remote), branch="master"), bench)
     seen_at_validation = {}
 
+    def record_validation(self: App) -> list[str]:
+        seen_at_validation.update(sha=self.installed_hash)
+        return []
+
     with (
-        patch.object(App, "validate", lambda self: seen_at_validation.update(sha=self.installed_hash)),
+        patch.object(App, "validate", record_validation),
         patch.object(App, "_install_into_environment"),
         patch.object(App, "_build_assets_via_env_manager"),
     ):

--- a/tests/pilot/core/test_migration_operation.py
+++ b/tests/pilot/core/test_migration_operation.py
@@ -423,6 +423,59 @@ def test_update_records_the_new_app_revision(tmp_path: Path) -> None:
     assert operation.state == "completed"
 
 
+def test_update_failure_records_the_revision_left_on_disk(tmp_path: Path) -> None:
+    """The checkout lands before the phase can fail, so a needs_attention record has
+    to report the tree as it now is - not the revision the update started from."""
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+    mock_bench.app.return_value.installed_hash = "2222222"
+    mock_bench._update_apps.side_effect = RuntimeError("validation failed after checkout")
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    operation = MigrationStore(mock_bench)._create(
+        "update",
+        apps=[AppRevision("frappe", "1111111")],
+        apps_filter=None,
+        sites=[],
+    )
+    operation.state = get_state("updating")
+
+    with pytest.raises(RuntimeError):
+        operation.update_apps()
+
+    assert operation.apps[0].updated_sha == "2222222"
+    assert operation.state == "needs_attention"
+    # Still false, so retry re-runs the update step instead of skipping to migrate.
+    assert operation.apps_updated is False
+
+
+def test_update_failure_reports_the_original_error_when_the_tree_cannot_be_read(
+    tmp_path: Path,
+) -> None:
+    """Recording the checked-out revision must not mask the failure being diagnosed."""
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+    mock_bench._update_apps.side_effect = RuntimeError("the real failure")
+    mock_bench.app.side_effect = BenchError("app is gone")
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    operation = MigrationStore(mock_bench)._create(
+        "update",
+        apps=[AppRevision("frappe", "1111111")],
+        apps_filter=None,
+        sites=[],
+    )
+    operation.state = get_state("updating")
+
+    with pytest.raises(RuntimeError, match="the real failure"):
+        operation.update_apps()
+
+    assert operation.apps[0].updated_sha is None
+    assert operation.state == "needs_attention"
+
+
 def test_update_apps_checks_out_the_pin_captured_at_create_time(tmp_path: Path) -> None:
     """update_apps() must deploy exactly what was captured at create time, never
     re-resolve a marketplace/branch target that may have moved on since."""


### PR DESCRIPTION
App validation treated every finding as fatal, so a bench could not be updated over a defect in an upstream app the operator cannot patch. Updating frappe to `fc7afba` is blocked twice over, by conditions frappe itself tolerates.

**One hook becomes advisory, not all of them.** Only `scheduler_events`, because frappe's `insert_single_event()` catches a path it cannot import, warns, and skips the job. Every other hook stays fatal — `boot_session`, `on_login`, `on_session_creation`, `auth_hooks` and `clear_cache` all reach a bare `get_attr()`, so allowing one through would trade a blocked update for a Desk or login outage. Fatal by default: a hook added later blocks unless someone shows its consumer catches.

**`ImportCheck` skips one more kind of file.** It already excused dev-only imports by location (`test_*.py`, `conftest.py`); that now covers `tests/` and `benchmarks/` directories too, which is what frappe's `tests/microbenchmarks/run_benchmarks.py` needed. Location stays the only thing that excuses an import — a module-scope import in a runtime module is still fatal however the package is declared.

**A failed update records where the tree actually is.** `update_apps()` checks out before it can fail, but recorded SHAs only on success, so `needs_attention` advertised the pre-update revision. `apps_updated` still marks a completed phase, so retry is unaffected.

New: [docs/app-validation.md](docs/app-validation.md) — what each check catches, and which findings block.

## Verification

The bench that reproduced this updates end to end, both sites migrated. `uv run pytest tests/pilot` is 1578 passed, with 6 pre-existing failures unchanged. Every unguarded hook above is covered as blocking; the import tests take the same missing module through `tests/` (passes) and `controllers/` (fails).