### PR TITLE
fix(ui): Sticky headers blending with dialog

### DIFF
--- a/admin/frontend/dashboard/package-lock.json
+++ b/admin/frontend/dashboard/package-lock.json
@@ -13,7 +13,7 @@
         "@codemirror/lang-sql": "^6.10.0",
         "@codemirror/state": "^6.7.0",
         "@codemirror/view": "^6.43.4",
-        "frappe-ui": "1.0.0-beta.25",
+        "frappe-ui": "1.0.0-beta.34",
         "ky": "^2.0.2",
         "qrcode.vue": "^3.10.0",
         "vue": "^3.5.0",
@@ -2684,6 +2684,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "license": "MIT"
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2795,9 +2801,9 @@
       }
     },
     "node_modules/frappe-ui": {
-      "version": "1.0.0-beta.25",
-      "resolved": "https://registry.npmjs.org/frappe-ui/-/frappe-ui-1.0.0-beta.25.tgz",
-      "integrity": "sha512-RiHl6Nv3vy8ywtQfWG9pvWYiH9aRdhzteXPiF2+Qjsh0owBVnim0ZP6ZE03jhtmaZ5QgrPovZu+rcBTOORWzuA==",
+      "version": "1.0.0-beta.34",
+      "resolved": "https://registry.npmjs.org/frappe-ui/-/frappe-ui-1.0.0-beta.34.tgz",
+      "integrity": "sha512-38E9L2mjz2ayFKuRA692Ao7YSFbotCwTi4gstxskVvb1OgqX/0aCY+NJSrIlCYLLeCtw8+m54D63DKn94KUivA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.0",
@@ -2857,6 +2863,7 @@
         "dayjs": "^1.11.13",
         "dompurify": "^3.4.0",
         "echarts": "^5.6.0",
+        "es-module-lexer": "^1.7.0",
         "feather-icons": "^4.28.0",
         "fuzzysort": "^3.1.0",
         "grid-layout-plus": "^1.1.0",
@@ -2864,6 +2871,7 @@
         "idb-keyval": "^6.2.0",
         "lowlight": "^3.3.0",
         "lucide-static": "^1.16.0",
+        "magic-string": "^0.30.21",
         "marked": "^15.0.12",
         "ora": "5.4.1",
         "prettier": "^3.3.2",
@@ -2880,6 +2888,9 @@
       },
       "bin": {
         "tokens-v2": "tailwind/migrate-tokens-v2.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
         "vue": ">=3.5.0",

--- a/admin/frontend/dashboard/package.json
+++ b/admin/frontend/dashboard/package.json
@@ -15,7 +15,7 @@
     "@codemirror/lang-sql": "^6.10.0",
     "@codemirror/state": "^6.7.0",
     "@codemirror/view": "^6.43.4",
-    "frappe-ui": "1.0.0-beta.25",
+    "frappe-ui": "1.0.0-beta.34",
     "ky": "^2.0.2",
     "qrcode.vue": "^3.10.0",
     "vue": "^3.5.0",

--- a/admin/frontend/dashboard/src/index.css
+++ b/admin/frontend/dashboard/src/index.css
@@ -94,14 +94,14 @@ body {
   animation: fade-in 0.35s var(--ease-out);
 }
 
-/* Ensure frappe-ui dialog overlay sits above the sticky app header */
-.dialog-overlay {
-  z-index: 50;
+#app {
+  isolation: isolate;
 }
 
 /* Dropdown/Menu content teleports to <body> without a z-index; lift it above both
-   the dialog overlay (z-50, so in-dialog menus like bench actions aren't hidden)
-   and the mobile sidebar drawer (z-30, so the sidebar's Bench menu stays usable). */
+   the dialog overlay (z-index: auto, so in-dialog menus like bench actions
+   aren't hidden) and the mobile sidebar drawer (z-30, so the sidebar's Bench
+   menu stays usable). */
 .menu-content {
   z-index: 51;
 }

--- a/admin/frontend/dashboard/src/pages/Activities.vue
+++ b/admin/frontend/dashboard/src/pages/Activities.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { type RouteLocationRaw, useRoute, useRouter } from 'vue-router'
-import { Button, Combobox, Dialog, Dropdown, ErrorMessage, Select, Skeleton } from 'frappe-ui'
+import { Button, Combobox, Dialog, Dropdown, ErrorMessage, Skeleton } from 'frappe-ui'
 import { useActivities } from '@/composables/activities/useActivities'
 import { useSites } from '@/composables/sites/useSites'
 import { commandLabel, relativeTime } from '@/utils/taskFormat'
@@ -143,8 +143,8 @@ const { activities, loading, loadingMore, error, hasMore, load, loadMore } = use
 const { sites, load: loadSites } = useSites()
 
 const siteOptions = computed(() => [
-  { label: 'All sites', value: '', icon: 'lucide-globe' },
-  ...sites.value.map((site) => ({ label: site.name, value: site.name, icon: 'lucide-globe' })),
+  { label: 'All sites', value: '' },
+  ...sites.value.map((site) => ({ label: site.name, value: site.name })),
 ])
 
 const activityTable = computed(() => ({
@@ -205,7 +205,12 @@ onMounted(() => {
     </div>
 
     <div class="flex flex-wrap items-center gap-3 shrink-0 mt-4">
-      <Select v-model="typeFilter" :options="activityTypeOptions" @update:modelValue="reload" />
+      <Combobox
+        v-model="typeFilter"
+        class="w-48"
+        :options="activityTypeOptions"
+        @update:modelValue="reload"
+      />
       <Combobox
         v-if="!siteName"
         v-model="siteFilterModel"


### PR DESCRIPTION

## Before 

- Updating frappe-ui made the dialog look weird 
- Then removed the css that was overriding dialog's z index https://github.com/frappe/pilot/pull/364/changes/212f78ff973acb5b42003a2213aba28192a7f7f8

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/88d4a292-85e4-4e51-ba2a-dc8c46731a3b" />


## Hurdles 

https://github.com/user-attachments/assets/c09d3dca-3ab2-48b6-bb4f-d53563ec436f

## Fix 

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/isolation 

https://github.com/user-attachments/assets/0a0dbae0-52b4-403a-be3e-a54ce66c8a22


