### PR TITLE
fix(migration): auto-revert when the update phase fails

### DIFF
--- a/pilot/core/bench/migration/operation.py
+++ b/pilot/core/bench/migration/operation.py
@@ -15,7 +15,7 @@ from pilot.core.bench.migration.state import (
     get_state,
     validate_transition,
 )
-from pilot.exceptions import BenchError, MigrateError
+from pilot.exceptions import AppValidationError, BenchError, MigrateError
 
 if TYPE_CHECKING:
     from pilot.core.bench import Bench
@@ -215,6 +215,10 @@ class MigrationOperation:
                 "output_excerpt": getattr(error, "output", "") or "",
             }
             self._enter_needs_attention("updating", None)
+            if isinstance(error, AppValidationError):
+                # Validation runs before anything is installed and before any
+                # site is migrated, so going back is a checkout. No user call needed.
+                self._transition("reverting_apps")
             raise
         self.apps_updated = True
         self._transition("migrating")

--- a/pilot/core/bench/migration/operation.py
+++ b/pilot/core/bench/migration/operation.py
@@ -15,7 +15,7 @@ from pilot.core.bench.migration.state import (
     get_state,
     validate_transition,
 )
-from pilot.exceptions import AppValidationError, BenchError, MigrateError
+from pilot.exceptions import BenchError, MigrateError
 
 if TYPE_CHECKING:
     from pilot.core.bench import Bench
@@ -215,10 +215,10 @@ class MigrationOperation:
                 "output_excerpt": getattr(error, "output", "") or "",
             }
             self._enter_needs_attention("updating", None)
-            if isinstance(error, AppValidationError):
-                # Validation runs before anything is installed and before any
-                # site is migrated, so going back is a checkout. No user call needed.
-                self._transition("reverting_apps")
+            # Nothing in this phase writes to a site database, so whatever failed
+            # here - a fetch, a check, an install, a build - leaves the sites
+            # untouched and going back is a checkout. No user call needed.
+            self._transition("reverting_apps")
             raise
         self.apps_updated = True
         self._transition("migrating")

--- a/pilot/tasks/update.py
+++ b/pilot/tasks/update.py
@@ -19,6 +19,8 @@ class UpdateTask(Task):
             operation.update_apps(on_step=self.step, on_progress=self.report)
         except Exception:
             self.step_failed()
+            if operation.state == "reverting_apps":
+                operation.enqueue_next(handoff_from=operation.chain[-1]["task_id"])
             sys.exit(1)
         operation.enqueue_next(handoff_from=operation.chain[-1]["task_id"])
 

--- a/tests/pilot/core/test_migration_operation.py
+++ b/tests/pilot/core/test_migration_operation.py
@@ -455,6 +455,80 @@ def test_update_apps_checks_out_the_pin_captured_at_create_time(tmp_path: Path) 
     }
 
 
+def test_update_failure_arms_the_revert_chain_without_the_user(tmp_path: Path) -> None:
+    """Nothing in the update phase touches a site database, so a failure there
+    reverts on its own instead of parking on needs_attention."""
+    from pilot.exceptions import AppValidationError
+
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+    mock_bench._update_apps.side_effect = AppValidationError("hooks.py is missing app_name")
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    operation = MigrationStore(mock_bench)._create(
+        "update",
+        apps=[AppRevision("frappe", "1111111")],
+        apps_filter=None,
+        sites=[],
+    )
+    operation.state = get_state("updating")
+
+    with pytest.raises(AppValidationError):
+        operation.update_apps()
+
+    assert operation.state == "reverting_apps"
+    assert operation.diagnosis["message"] == "hooks.py is missing app_name"
+
+    with patch("pilot.tasks.revert_apps.RevertAppsTask.queue", return_value="task-201") as queue:
+        assert operation.enqueue_next() == "task-201"
+
+    assert queue.called
+
+
+def test_update_failure_after_the_install_step_also_auto_reverts(tmp_path: Path) -> None:
+    """A build or install failure is as database-safe as a validation failure."""
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+    mock_bench._rebuild_assets.side_effect = MigrateError("yarn build failed")
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    operation = MigrationStore(mock_bench)._create(
+        "update",
+        apps=[AppRevision("frappe", "1111111")],
+        apps_filter=None,
+        sites=[],
+    )
+    operation.state = get_state("updating")
+
+    with pytest.raises(MigrateError):
+        operation.update_apps()
+
+    assert operation.state == "reverting_apps"
+    assert operation.apps_updated is False
+
+
+def test_migrate_failure_still_waits_for_the_user(tmp_path: Path) -> None:
+    """The database is touched by then, so recovery stays an explicit decision."""
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+    site_mock = MagicMock()
+    site_mock.path = tmp_path / "sites" / "site1.localhost"
+    site_mock.migrate.side_effect = MigrateError("patch failed", output="")
+    mock_bench.site.return_value = site_mock
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    operation = MigrationStore(mock_bench).create_site_migrate("site1.localhost")
+    operation.state = get_state("migrating")
+
+    with pytest.raises(MigrateError):
+        operation.migrate_site("site1.localhost")
+
+    assert operation.state == "needs_attention"
+
+
 def test_backup_failure_restores_every_sites_original_settings(tmp_path: Path) -> None:
     mock_bench = MagicMock()
     mock_bench.path = tmp_path
@@ -482,6 +556,10 @@ def test_backup_failure_restores_every_sites_original_settings(tmp_path: Path) -
     operation.back_up_site("one.local")
     with pytest.raises(RuntimeError, match="dump failed"):
         operation.back_up_site("two.local")
+
+    # Nothing has changed yet, so there is nothing to revert - the user gets to
+    # fix the disk and retry instead.
+    assert operation.state == "needs_attention"
 
     for name, scheduler in (("one.local", 1), ("two.local", 0)):
         sites[name].set_maintenance_settings.assert_called_with(


### PR DESCRIPTION
App fetches, validation checks, installs and asset builds all run before the first site migration, so a failure there leaves every site database untouched. Going back is just a checkout, which means there is nothing for the user to decide.

The operation now records its diagnosis and transitions straight into the revert chain; the failed update task enqueues it before exiting, so the bench lands back on the previous revisions unattended. The diagnosis is kept rather than cleared the way a manual revert does, so the UI still shows what failed.

Backup and migrate failures are unchanged — the first has nothing to revert, the second has touched the database.