### PR TITLE
fix(git): prune temp packs left by a killed fetch

### DIFF
--- a/pilot/core/app/repository.py
+++ b/pilot/core/app/repository.py
@@ -204,6 +204,7 @@ class AppRepository:
             return
 
         self._sync_remote_url()
+        self.repo.prune_stale_temp_packs()
         cmd = [
             "git",
             "-c",
@@ -246,6 +247,7 @@ class AppRepository:
     def checkout_pinned_target(self, pin: RevisionPin) -> None:
         if pin.kind == "tag":
             self._sync_remote_url()
+            self.repo.prune_stale_temp_packs()
             run_command(["git", "-C", str(self.app.path), "fetch", *self.depth_flags, "origin", pin.ref])
             self._checkout_pinned_ref("FETCH_HEAD")
         else:
@@ -254,6 +256,7 @@ class AppRepository:
     def checkout_pinned_commit(self, sha: str) -> None:
         """Check out a specific commit SHA, staying on the app's configured branch."""
         self._sync_remote_url()
+        self.repo.prune_stale_temp_packs()
         try:
             run_command(["git", "-C", str(self.app.path), "fetch", *self.depth_flags, "origin", sha])
             self._checkout_pinned_ref("FETCH_HEAD")

--- a/pilot/core/registry_cache.py
+++ b/pilot/core/registry_cache.py
@@ -11,6 +11,7 @@ import time
 from pathlib import Path
 
 from pilot.exceptions import CommandError, RegistryUnavailableError
+from pilot.internal.git import GitRepo
 from pilot.managers.cron import CronManager
 from pilot.utils import run_command
 
@@ -137,6 +138,7 @@ class RegistryCache:
             )
             if remote_head == local_head:
                 return
+            GitRepo(self.path).prune_stale_temp_packs()
             run_command(["git", "-C", str(self.path), "fetch", "--depth", "1", "origin", "HEAD"])
             run_command(["git", "-C", str(self.path), "reset", "--hard", "FETCH_HEAD"])
         except CommandError:

--- a/pilot/internal/git.py
+++ b/pilot/internal/git.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import contextlib
 import subprocess
+import time
 from pathlib import Path
+
+_STALE_TEMP_FILE_SECONDS = 24 * 60 * 60
 
 
 class GitRepo:
@@ -76,7 +80,22 @@ class GitRepo:
 
     def fetch(self, *refspecs: str, timeout: float | None = None) -> bool:
         """Best-effort fetch from origin; returns False instead of raising on failure."""
+        self.prune_stale_temp_packs()
         return self._run("fetch", "origin", *refspecs, "--quiet", timeout=timeout).returncode == 0
+
+    def prune_stale_temp_packs(self) -> None:
+        """Drop pack files left behind by a fetch that was killed mid-transfer.
+
+        A killed process runs no cleanup of its own, so this happens on the way
+        into the next fetch rather than on the way out of the last one. The
+        one-day floor is git's own staleness rule for these files, which keeps
+        it clear of a fetch running right now.
+        """
+        cutoff = time.time() - _STALE_TEMP_FILE_SECONDS
+        for temp_file in self.path.glob(".git/objects/pack/tmp_*"):
+            with contextlib.suppress(OSError):
+                if temp_file.stat().st_mtime < cutoff:
+                    temp_file.unlink()
 
     def abort_merge_rebase(self) -> None:
         """Best-effort cleanup of an in-progress merge/rebase, e.g. before switching branches."""

--- a/tests/pilot/internal/test_git.py
+++ b/tests/pilot/internal/test_git.py
@@ -96,3 +96,32 @@ def test_has_commit_and_is_ancestor_relate_two_commits(tmp_path: Path) -> None:
     assert repo.is_ancestor(second, first) is False
     # A commit this clone has never seen can't be related either way.
     assert repo.is_ancestor("0" * 40, second) is False
+
+
+def test_prune_stale_temp_packs_spares_recent_files_and_real_packs(tmp_path: Path) -> None:
+    """Only a killed fetch's leftovers go; a fetch in flight and real packs stay."""
+    import os
+    import time
+
+    repo_path = _init_repo(tmp_path / "repo")
+    _commit(repo_path)
+    pack_dir = repo_path / ".git" / "objects" / "pack"
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    stale = pack_dir / "tmp_pack_abandoned"
+    in_flight = pack_dir / "tmp_pack_running"
+    real_pack = pack_dir / "pack-1234.pack"
+    for path in (stale, in_flight, real_pack):
+        path.write_text("x")
+    two_days_ago = time.time() - 2 * 24 * 60 * 60
+    os.utime(stale, (two_days_ago, two_days_ago))
+    os.utime(real_pack, (two_days_ago, two_days_ago))
+
+    GitRepo(repo_path).prune_stale_temp_packs()
+
+    assert not stale.exists()
+    assert in_flight.exists()
+    assert real_pack.exists()
+
+
+def test_prune_stale_temp_packs_is_quiet_on_a_missing_repo(tmp_path: Path) -> None:
+    GitRepo(tmp_path / "nope").prune_stale_temp_packs()


### PR DESCRIPTION
A fetch killed mid-transfer (SIGKILL, OOM, full disk) leaves its `tmp_pack_*` files in `.git/objects/pack` forever.

- Git's auto-gc counts loose objects and real packs — these are neither, so it declines exactly when they pile up.
- One bench reached 103 of them, 28.8 GiB, and filled its pool. Real packed data in that repo: 20 MiB.
- `GitRepo.prune_stale_temp_packs()` clears them on the way *into* the next fetch — a killed process runs no cleanup of its own, but the next fetch always runs.
- One-day floor is git's own staleness rule for these files, so a fetch in flight is never touched.
- Wired into `GitRepo.fetch`, the three `AppRepository` fetch paths (branch update, pinned tag, pinned commit), and the registry cache refresh.