### PR TITLE
feat(build): allow building selected apps

### DIFF
--- a/pilot/commands/runtime/build.py
+++ b/pilot/commands/runtime/build.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Annotated, ClassVar
 
 from pilot.commands import Arg, Command
@@ -11,7 +11,10 @@ class BuildCommand(Command):
     name: ClassVar[str] = "build"
     help: ClassVar[str] = "Build assets (downloads pre-built if available)."
 
+    apps: Annotated[list[str], Arg(help="Apps to build. Builds every app when omitted.")] = field(
+        default_factory=list
+    )
     force: Annotated[bool, Arg(help="Force a full rebuild, skipping pre-built asset download.")] = False
 
     def run(self) -> None:
-        self.bench.rebuild_assets(force=self.force)
+        self.bench.rebuild_assets(force=self.force, apps=self.apps)

--- a/pilot/core/bench/__init__.py
+++ b/pilot/core/bench/__init__.py
@@ -257,10 +257,10 @@ class Bench:
 
         BenchRuntime(self).rebuild_config()
 
-    def rebuild_assets(self, force: bool = False) -> None:
+    def rebuild_assets(self, apps: list[str] | None = None, force: bool = False) -> None:
         from pilot.core.bench.runtime import BenchRuntime
 
-        BenchRuntime(self).rebuild_assets(force)
+        BenchRuntime(self).rebuild_assets(apps, force)
 
     def install_requirements(self, on_progress: Callable[[str], None] = lambda message: None) -> None:
         from pilot.core.bench.runtime import BenchRuntime

--- a/pilot/core/bench/runtime.py
+++ b/pilot/core/bench/runtime.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, cast
 from pilot.exceptions import BenchError
 
 if TYPE_CHECKING:
+    from pilot.core.app import App
     from pilot.core.bench import Bench
     from pilot.managers.processes.base import ManagedProcessManager
     from pilot.managers.processes.local import ProcessManager
@@ -90,17 +91,28 @@ class BenchRuntime:
         if self.bench.config.production.enabled:
             NginxManager(self.bench).generate_config()
 
-    def rebuild_assets(self, force: bool = False) -> None:
+    def rebuild_assets(self, apps: list[str] | None = None, force: bool = False) -> None:
         from pilot.managers.environment import PythonEnvManager
         from pilot.managers.processes.local import ProcessManager
 
         manager = PythonEnvManager(self.bench)
-        if force:
+        if force and not apps:
             manager.build_assets()
         else:
-            for app in self.bench.apps():
-                manager.build_assets_for_app(app)
+            for app in self.apps_to_build(apps):
+                manager.build_assets_for_app(app, force=force)
         ProcessManager.for_bench(self.bench).reload_workers(web_only=True)
+
+    def apps_to_build(self, names: list[str] | None) -> list["App"]:
+        """Bench apps matching `names`; every app when no names are given."""
+        apps = self.bench.apps()
+        if not names:
+            return apps
+        by_name = {app.config.name: app for app in apps}
+        missing = [name for name in names if name not in by_name]
+        if missing:
+            raise BenchError(f"App(s) not found in bench: {', '.join(missing)}")
+        return [by_name[name] for name in names]
 
     def install_requirements(self, on_progress: Callable[[str], None]) -> None:
         self._install_python_requirements(on_progress)

--- a/pilot/managers/environment.py
+++ b/pilot/managers/environment.py
@@ -212,5 +212,5 @@ class PythonEnvManager:
     def build_assets(self) -> None:
         self._assets.build_assets()
 
-    def build_assets_for_app(self, app: "App") -> None:
-        self._assets.build_assets_for_app(app)
+    def build_assets_for_app(self, app: "App", force: bool = False) -> None:
+        self._assets.build_assets_for_app(app, force=force)

--- a/pilot/managers/python_assets.py
+++ b/pilot/managers/python_assets.py
@@ -34,11 +34,11 @@ class PythonAssetBuilder:
             stream_output=True,
         )
 
-    def build_assets_for_app(self, app: "App") -> None:
+    def build_assets_for_app(self, app: "App", force: bool = False) -> None:
         app_public_dir = app.path / app.config.name / "public"
         dist_dir = app_public_dir / "dist"
 
-        if not git_has_local_changes(app.path):
+        if not force and not git_has_local_changes(app.path):
             if self.try_download_prebuilt_assets(app, app_public_dir, dist_dir):
                 return
             if self.has_prebuilt_assets(dist_dir):

--- a/tests/pilot/commands/test_commands.py
+++ b/tests/pilot/commands/test_commands.py
@@ -620,6 +620,59 @@ def test_build_command_default_uses_prebuilt_per_app(tmp_path: Path) -> None:
         mock_build.assert_not_called()
 
 
+def fake_app(name: str) -> MagicMock:
+    app = MagicMock()
+    app.config.name = name
+    return app
+
+
+def test_build_command_builds_only_named_apps(tmp_path: Path) -> None:
+    from pilot.commands.runtime.build import BuildCommand
+
+    bench = make_bench(tmp_path)
+    bench.create_directories()
+    hrms = fake_app("hrms")
+
+    with (
+        patch("pilot.managers.environment.PythonEnvManager.build_assets_for_app") as mock_build,
+        patch.object(bench, "apps", return_value=[fake_app("frappe"), hrms]),
+    ):
+        BuildCommand(bench, apps=["hrms"]).run()
+        mock_build.assert_called_once_with(hrms, force=False)
+
+
+def test_build_command_named_apps_with_force_skips_prebuilt(tmp_path: Path) -> None:
+    from pilot.commands.runtime.build import BuildCommand
+
+    bench = make_bench(tmp_path)
+    bench.create_directories()
+    hrms = fake_app("hrms")
+
+    with (
+        patch("pilot.managers.environment.PythonEnvManager.build_assets") as mock_build_all,
+        patch("pilot.managers.environment.PythonEnvManager.build_assets_for_app") as mock_build,
+        patch.object(bench, "apps", return_value=[fake_app("frappe"), hrms]),
+    ):
+        BuildCommand(bench, apps=["hrms"], force=True).run()
+        mock_build.assert_called_once_with(hrms, force=True)
+        mock_build_all.assert_not_called()
+
+
+def test_build_command_rejects_unknown_app(tmp_path: Path) -> None:
+    from pilot.commands.runtime.build import BuildCommand
+
+    bench = make_bench(tmp_path)
+    bench.create_directories()
+
+    with (
+        patch("pilot.managers.environment.PythonEnvManager.build_assets_for_app") as mock_build,
+        patch.object(bench, "apps", return_value=[fake_app("frappe")]),
+        pytest.raises(BenchError, match="nope"),
+    ):
+        BuildCommand(bench, apps=["nope"]).run()
+        mock_build.assert_not_called()
+
+
 def test_requirements_skips_app_without_python_setup_files(tmp_path: Path) -> None:
     from pilot.core.bench.runtime import BenchRuntime
 


### PR DESCRIPTION
`pilot build` gains an optional `--apps` filter; with no apps given it keeps building the whole bench.

`--force` now also skips the pre-built asset download for a single app, so `--apps x --force` really rebuilds. Unknown app names fail with a clear error.