### PR TITLE
fix(validator): skip files in tests directories

### DIFF
--- a/pilot/core/app/validator/imports.py
+++ b/pilot/core/app/validator/imports.py
@@ -114,9 +114,9 @@ class ImportCheck:
         stdlib = sys.stdlib_module_names
         locations: dict[str, list[str]] = {}
         for path in python_files(app):
-            if self._is_test_file(path):
-                continue
             relpath = path.relative_to(app.path)
+            if self._is_test_file(relpath):
+                continue
             for module, lineno in self._file_imported_modules(app, path):
                 if module.split(".", 1)[0] in stdlib:
                     continue
@@ -127,10 +127,12 @@ class ImportCheck:
         return locations
 
     @staticmethod
-    def _is_test_file(path: Path) -> bool:
+    def _is_test_file(relpath: Path) -> bool:
         # Test-only imports (responses, time_machine, ...) come from dev extras
         # a plain pip install never provides, so they'd always fail to resolve.
-        return path.name.startswith("test_") or path.name == "conftest.py"
+        if "tests" in relpath.parts[:-1]:
+            return True
+        return relpath.name.startswith("test_") or relpath.name == "conftest.py"
 
     def _file_imported_modules(self, app: "App", path: Path) -> list[tuple[str, int]]:
         try:

--- a/tests/pilot/core/test_app_validator.py
+++ b/tests/pilot/core/test_app_validator.py
@@ -701,6 +701,8 @@ def test_import_check_skips_test_files(tmp_path: Path) -> None:
             "myapp/hooks.py": "",
             "myapp/test_utils.py": "import dev_only_dependency\n",
             "myapp/conftest.py": "import dev_only_dependency\n",
+            "myapp/tests/helpers.py": "import dev_only_dependency\n",
+            "myapp/module/tests/fixtures.py": "import dev_only_dependency\n",
         },
     )
     check = ImportCheck()


### PR DESCRIPTION
The import check skipped only files with a `test_` prefix or the name `conftest.py`. Files in a `tests` directory were not skipped, so their dev-only imports failed to resolve.

`_is_test_file` now also skips any file in a `tests` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)