### PR TITLE
feat(admin): accept a custom frappe branch in the setup wizard

### DIFF
--- a/admin/frontend/dashboard/src/composables/setup/useSetup.ts
+++ b/admin/frontend/dashboard/src/composables/setup/useSetup.ts
@@ -3,6 +3,7 @@ import { ref, computed, watch, onMounted } from 'vue'
 import { useSetupHandoff } from '@/composables/setup/useSetupHandoff'
 import { apiErrorMessage } from '@/api/client'
 import { setupApi } from '@/api/setup'
+import { branchComboboxOptions } from '@/utils/branchComboboxOptions'
 import { generateRandomPassword } from '@/utils/randomPassword'
 
 // Static dropdown options
@@ -79,29 +80,11 @@ export const useSetup = () => {
   const dbPortPlaceholder = computed(() => (dbType.value === 'mariadb' ? '3306' : '5432'))
   const resolvedDbUser = computed(() => dbUser.value || rootUserPlaceholder.value)
 
-  const branchOptions = computed(() => {
-    const selected = appBranch.value
-    const isKnown = availableBranches.value.includes(selected)
-    const options = availableBranches.value.map((branch) => ({ label: branch, value: branch }))
-    if (selected && !isKnown) options.unshift({ label: selected, value: selected })
-    return [
-      ...options,
-      {
-        type: 'custom',
-        key: 'typed-branch',
-        label: 'Use typed branch',
-        slot: 'typed-branch',
-        condition: ({ query }) => {
-          const typed = query.trim()
-          return Boolean(typed) && !options.some((option) => option.value === typed)
-        },
-        onClick: ({ query }) => {
-          const typed = query.trim()
-          if (typed) appBranch.value = typed
-        },
-      },
-    ]
-  })
+  const branchOptions = computed(() =>
+    branchComboboxOptions(availableBranches.value, appBranch.value, (typed) => {
+      appBranch.value = typed
+    }),
+  )
 
   // Steps
   const stepSequence = computed(() => ['database', 'customize'])

--- a/admin/frontend/dashboard/src/composables/setup/useSetup.ts
+++ b/admin/frontend/dashboard/src/composables/setup/useSetup.ts
@@ -83,7 +83,24 @@ export const useSetup = () => {
     const selected = appBranch.value
     const isKnown = availableBranches.value.includes(selected)
     const options = availableBranches.value.map((branch) => ({ label: branch, value: branch }))
-    return selected && !isKnown ? [{ label: selected, value: selected }, ...options] : options
+    if (selected && !isKnown) options.unshift({ label: selected, value: selected })
+    return [
+      ...options,
+      {
+        type: 'custom',
+        key: 'typed-branch',
+        label: 'Use typed branch',
+        slot: 'typed-branch',
+        condition: ({ query }) => {
+          const typed = query.trim()
+          return Boolean(typed) && !options.some((option) => option.value === typed)
+        },
+        onClick: ({ query }) => {
+          const typed = query.trim()
+          if (typed) appBranch.value = typed
+        },
+      },
+    ]
   })
 
   // Steps

--- a/admin/frontend/dashboard/src/composables/setup/useSetup.ts
+++ b/admin/frontend/dashboard/src/composables/setup/useSetup.ts
@@ -2,6 +2,7 @@ import { ref, computed, watch, onMounted } from 'vue'
 
 import { useSetupHandoff } from '@/composables/setup/useSetupHandoff'
 import { apiErrorMessage } from '@/api/client'
+import { gitApi } from '@/api/git'
 import { setupApi } from '@/api/setup'
 import { branchComboboxOptions } from '@/utils/branchComboboxOptions'
 import { generateRandomPassword } from '@/utils/randomPassword'
@@ -49,6 +50,8 @@ export const useSetup = () => {
   const dbPassword = ref('')
   const appRepo = ref('https://github.com/frappe/frappe')
   const appBranch = ref('develop')
+  const validatingFramework = ref(false)
+  const resolvedFramework = ref<{ repo: string; branch: string } | null>(null)
 
   const localAvailable = computed(() =>
     dbType.value === 'postgres' ? postgresLocalAvailable.value : mariadbLocalAvailable.value,
@@ -85,6 +88,12 @@ export const useSetup = () => {
       appBranch.value = typed
     }),
   )
+  const frameworkIsValid = computed(() => {
+    const resolved = resolvedFramework.value
+    return Boolean(
+      resolved?.repo === appRepo.value.trim() && resolved?.branch === appBranch.value.trim(),
+    )
+  })
 
   // Steps
   const stepSequence = computed(() => ['database', 'customize'])
@@ -191,6 +200,52 @@ export const useSetup = () => {
   }
 
   // Validation
+  let frameworkRequest = 0
+
+  const validateFramework = async (repo: string, branch: string) => {
+    const request = ++frameworkRequest
+    validatingFramework.value = true
+    resolvedFramework.value = null
+    errorMessage.value = ''
+    try {
+      const result = await gitApi.resolve(repo, branch)
+      if (
+        request !== frameworkRequest ||
+        repo !== appRepo.value.trim() ||
+        branch !== appBranch.value.trim()
+      )
+        return false
+      if (!result.name) {
+        errorMessage.value = apiErrorMessage(result, 'Could not validate the Frappe branch.')
+        return false
+      }
+      if (result.name !== 'frappe') {
+        errorMessage.value = 'The repository does not contain the Frappe app.'
+        return false
+      }
+      resolvedFramework.value = { repo, branch }
+      return true
+    } catch (error) {
+      if (request === frameworkRequest) {
+        errorMessage.value = error.message || 'Could not validate the Frappe branch.'
+      }
+      return false
+    } finally {
+      if (request === frameworkRequest) validatingFramework.value = false
+    }
+  }
+
+  watch([currentStep, appRepo, appBranch], ([step, repo, branch]) => {
+    frameworkRequest += 1
+    validatingFramework.value = false
+    resolvedFramework.value = null
+    if (step !== 'customize') return
+    errorMessage.value = ''
+    const selectedRepo = repo.trim()
+    const selectedBranch = branch.trim()
+    if (selectedRepo && selectedBranch) validateFramework(selectedRepo, selectedBranch)
+  })
+
   const validateDatabaseStep = async () => {
     if (dbMode.value !== 'external') return null
     const databaseName = dbType.value === 'postgres' ? 'PostgreSQL' : 'MariaDB'
@@ -249,8 +304,8 @@ export const useSetup = () => {
   const buildPayload = () => {
     const base = {
       db_type: dbType.value,
-      app_repo: appRepo.value,
-      app_branch: appBranch.value,
+      app_repo: appRepo.value.trim(),
+      app_branch: appBranch.value.trim(),
     }
     if (dbMode.value === 'existing_local') {
       return { ...base, db_mode: 'existing_local' }
@@ -289,8 +344,14 @@ export const useSetup = () => {
   }
 
   const startSetup = async () => {
+    const repo = appRepo.value.trim()
+    const branch = appBranch.value.trim()
     isSubmitting.value = true
+    errorMessage.value = ''
     try {
+      if (!repo) throw new Error('Frappe repository is required.')
+      if (!branch) throw new Error('Frappe branch is required.')
+      if (!(await validateFramework(repo, branch))) return
       await saveConfig()
       const result = await setupApi.start()
       if (result.error) throw new Error(apiErrorMessage(result, 'Failed to start setup.'))
@@ -347,6 +408,8 @@ export const useSetup = () => {
     rootUserPlaceholder,
     dbTypeOptions: DB_TYPE_OPTIONS,
     branchOptions,
+    validatingFramework,
+    frameworkIsValid,
     stepSequence,
     stepNumber,
     isConfiguring,

--- a/admin/frontend/dashboard/src/pages/setup/Setup.vue
+++ b/admin/frontend/dashboard/src/pages/setup/Setup.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import {
   Button,
+  Combobox,
   Select,
   TextInput,
   FormLabel,
@@ -116,7 +117,17 @@ const {
 
         <!-- Customize -->
         <div v-show="currentStep === 'customize'" class="flex flex-col gap-4">
-          <Select label="Frappe branch" v-model="appBranch" :options="branchOptions" />
+          <Combobox
+            label="Frappe branch"
+            v-model="appBranch"
+            :options="branchOptions"
+            trigger="button"
+            placeholder="Search or type a branch…"
+          >
+            <template #item-typed-branch="{ query }">
+              Use branch “{{ query }}”
+            </template>
+          </Combobox>
           <TextInput label="Frappe repository" v-model="appRepo" />
           <ErrorMessage v-show="errorMessage" :message="errorMessage" />
         </div>

--- a/admin/frontend/dashboard/src/pages/setup/Setup.vue
+++ b/admin/frontend/dashboard/src/pages/setup/Setup.vue
@@ -37,6 +37,8 @@ const {
   rootUserPlaceholder,
   dbTypeOptions,
   branchOptions,
+  validatingFramework,
+  frameworkIsValid,
   stepSequence,
   stepNumber,
   isConfiguring,
@@ -129,7 +131,17 @@ const {
             </template>
           </Combobox>
           <TextInput label="Frappe repository" v-model="appRepo" />
-          <ErrorMessage v-show="errorMessage" :message="errorMessage" />
+          <ErrorMessage v-if="errorMessage" :message="errorMessage" />
+          <p v-else-if="validatingFramework" class="text-ink-gray-5 text-sm">
+            Checking repository…
+          </p>
+          <p
+            v-else-if="frameworkIsValid"
+            class="flex items-center gap-1 text-ink-green-7 text-sm"
+          >
+            <span class="size-3.5 shrink-0 lucide-check"></span>
+            Found frappe
+          </p>
         </div>
 
         <!-- Installing -->
@@ -256,6 +268,7 @@ const {
           v-show="isConfiguring && currentStep !== 'database' && isLastConfigStep"
           variant="solid"
           :loading="isSubmitting"
+          :disabled="!frameworkIsValid"
           class="flex-1"
           @click="startSetup"
         >

--- a/admin/frontend/dashboard/src/utils/branchComboboxOptions.test.ts
+++ b/admin/frontend/dashboard/src/utils/branchComboboxOptions.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { branchComboboxOptions } from './branchComboboxOptions.ts'
+
+const BRANCHES = ['version-16', 'develop']
+
+const lastRow = (options) => options.at(-1)
+
+test('maps branches and appends the typed-branch row', () => {
+  const options = branchComboboxOptions(BRANCHES, 'develop', () => {})
+  assert.deepEqual(
+    options.slice(0, -1),
+    BRANCHES.map((name) => ({ label: name, value: name })),
+  )
+  assert.equal(lastRow(options).type, 'custom')
+  assert.equal(lastRow(options).slot, 'typed-branch')
+})
+
+test('restores a saved custom branch as the first option', () => {
+  const options = branchComboboxOptions(BRANCHES, 'my-fork-feature', () => {})
+  assert.deepEqual(options[0], { label: 'my-fork-feature', value: 'my-fork-feature' })
+  assert.equal(options.length, BRANCHES.length + 2)
+})
+
+test('shows the typed-branch row only for a new non-empty query', () => {
+  const { condition } = lastRow(branchComboboxOptions(BRANCHES, 'my-fork-feature', () => {}))
+  assert.equal(condition({ query: '' }), false)
+  assert.equal(condition({ query: '   ' }), false)
+  assert.equal(condition({ query: 'develop' }), false)
+  assert.equal(condition({ query: ' my-fork-feature ' }), false)
+  assert.equal(condition({ query: 'hotfix-1' }), true)
+})
+
+test('commits the trimmed query from the typed-branch row', () => {
+  const picked = []
+  const { onClick } = lastRow(
+    branchComboboxOptions(BRANCHES, 'develop', (branch) => picked.push(branch)),
+  )
+  onClick({ query: ' hotfix-1 ' })
+  onClick({ query: '   ' })
+  assert.deepEqual(picked, ['hotfix-1'])
+})

--- a/admin/frontend/dashboard/src/utils/branchComboboxOptions.ts
+++ b/admin/frontend/dashboard/src/utils/branchComboboxOptions.ts
@@ -1,0 +1,23 @@
+export const branchComboboxOptions = (branchNames, selected, onPick) => {
+  const options = branchNames.map((name) => ({ label: name, value: name }))
+  if (selected && !branchNames.includes(selected)) {
+    options.unshift({ label: selected, value: selected })
+  }
+  return [
+    ...options,
+    {
+      type: 'custom',
+      key: 'typed-branch',
+      label: 'Use typed branch',
+      slot: 'typed-branch',
+      condition: ({ query }) => {
+        const typed = query.trim()
+        return Boolean(typed) && !options.some((option) => option.value === typed)
+      },
+      onClick: ({ query }) => {
+        const typed = query.trim()
+        if (typed) onPick(typed)
+      },
+    },
+  ]
+}

--- a/docs/admin-ui.md
+++ b/docs/admin-ui.md
@@ -53,6 +53,10 @@ The update-status button is opt-in per route through `meta.showUpdateStatus`.
 
 The UI should treat task ids as the handle for long work.
 
+## Setup
+
+The Frappe branch picker lists the branches reported by the repository. Type a different full branch name and select `Use branch` to choose it. `Set up bench` saves the selection before setup starts. The wizard restores a saved custom branch even when the repository list does not contain it.
+
 ## Settings
 
 Settings screens edit `bench.toml` through the backend. The frontend should not know how to rewrite TOML or infer production side effects.

--- a/tests/admin/backend/api/test_git_view.py
+++ b/tests/admin/backend/api/test_git_view.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from pilot.config import BenchConfig
-from pilot.integrations.git import GitAuthError
+from pilot.integrations.git import BranchNotFoundError, GitAuthError
 
 
 def _client(bench_root: Path, password: str = "secret"):
@@ -154,6 +154,27 @@ def test_repository_resolutions_returns_the_resolved_app(tmp_path: Path) -> None
     assert response.status_code == 200
     assert body == {"name": "suite", "description": "A suite app"}
     assert "ok" not in body
+
+
+def test_repository_resolutions_rejects_an_unknown_branch(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    client = _client(bench_root)
+
+    with (
+        patch("admin.backend.api.v1.git.provider_for_repo", return_value=Mock()),
+        patch(
+            "admin.backend.api.v1.git.resolve_app_name_from_repo",
+            side_effect=BranchNotFoundError("'missing' is not a branch of this repository."),
+        ),
+    ):
+        response = client.post(
+            "/api/v1/git/repository-resolutions",
+            json={"repo": "https://github.com/frappe/frappe", "branch": "missing"},
+        )
+
+    error = response.get_json()["error"]
+    assert response.status_code == 422
+    assert error["code"] == "branch_not_found"
 
 
 def test_repository_resolutions_requires_a_repo(tmp_path: Path) -> None:


### PR DESCRIPTION
The wizard's Frappe branch field only offered the hardcoded `FRAMEWORK_BRANCHES`, while the repo URL next to it is editable — point it at a fork and the branch you need isn't selectable. The field is now a frappe-ui Combobox (button trigger): the curated list stays as suggestions, and typing anything else offers `Use branch "…"` via the library's custom-row pattern. The typed value flows through the existing `app_branch` payload unchanged.

Button trigger over the default input trigger: the search box always opens empty, whereas the input trigger puts the caret in the committed label and typing without clearing builds names like `version-16my-feature`.

Verified in-browser against a stubbed setup API: curated pick, free-text commit by click and by Enter, and a saved custom branch reappearing as the selected option.

<img width="2672" height="1664" alt="image" src="https://github.com/user-attachments/assets/f7adca3f-6a9c-4e0f-8553-927944fad5aa" />