### PR TITLE
fix(admin): let the add-app dialog accept a typed branch

### DIFF
--- a/admin/frontend/dashboard/src/components/apps/AddAppFromGithubDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/AddAppFromGithubDialog.vue
@@ -15,6 +15,7 @@ import {
 import { apiErrorMessage } from '@/api/client'
 import { appsApi } from '@/api/apps'
 import { gitApi } from '@/api/git'
+import { branchComboboxOptions } from '@/utils/branchComboboxOptions'
 import { openTaskDetailPage } from '@/utils/taskRoute'
 
 const props = defineProps({
@@ -35,17 +36,11 @@ const fetched = ref(false)
 const fetching = ref(false)
 const branches = ref([])
 const branchOptions = computed(() => branches.value.map((b) => ({ label: b, value: b })))
-const typeableBranchOptions = computed(() => [
-  ...branchOptions.value,
-  {
-    type: 'custom',
-    key: 'use-typed',
-    label: 'Use typed branch',
-    slot: 'use-typed',
-    condition: ({ query }) => Boolean(query.trim()) && !branches.value.includes(query.trim()),
-    onClick: ({ query }) => (branch.value = query.trim()),
-  },
-])
+const manualBranchOptions = computed(() =>
+  branchComboboxOptions(branches.value, branch.value, (typed) => {
+    branch.value = typed
+  }),
+)
 
 const gitStatus = ref(null)
 const gitConnected = computed(() =>
@@ -218,13 +213,16 @@ const submit = async () => {
               v-if="fetched"
               label="Branch"
               v-model="branch"
-              :options="typeableBranchOptions"
+              :options="manualBranchOptions"
               :loading="fetching"
+              trigger="button"
               placeholder="Search or type a branch…"
               emptyText="No matching branch. Type one to use it."
               class="w-40 shrink-0"
             >
-              <template #item-use-typed="{ query }">Use "{{ query }}"</template>
+              <template #item-typed-branch="{ query }">
+                Use branch “{{ query }}”
+              </template>
             </Combobox>
           </div>
         </template>


### PR DESCRIPTION
Stacked on #377.

The add-app dialog's manual-URL branch picker passes `allowCustomValue`, which doesn't exist in frappe-ui 1.0.0-beta.34 — it lands on the `<input>` as an inert DOM attribute, so the promised "Type one to use it" flow silently never commits. This extracts #377's pick-or-type options into a shared `branchComboboxOptions` helper, points both the wizard and the dialog at it, and switches the dialog's manual picker to the same button-trigger custom-row pattern. The connected-GitHub picker stays list-only, as before.

Typed branches still go through `resolveApp`, so an invalid name can't be submitted. Unit tests cover the helper via the existing `node --test` harness; `npm run build` passes.

<img width="2674" height="1664" alt="image" src="https://github.com/user-attachments/assets/2f8b2ae4-c845-4130-b368-d25adea02740" />
