### PR TITLE
feat(apps): expose SwitchBranchTask via CLI and admin API

### DIFF
--- a/admin/backend/api/v1/apps.py
+++ b/admin/backend/api/v1/apps.py
@@ -15,6 +15,7 @@ from pilot.tasks.fetch_app_updates import FetchAppUpdatesTask
 from pilot.tasks.get_and_install_app import GetAndInstallAppTask
 from pilot.tasks.get_app import GetAppTask
 from pilot.tasks.remove_app import RemoveAppTask
+from pilot.tasks.switch_branch import SwitchBranchTask
 
 apps_bp = Blueprint("apps", __name__)
 marketplace_bp = Blueprint("marketplace", __name__)
@@ -170,6 +171,25 @@ def remove(name: str):
         task_id = RemoveAppTask.queue(Bench(bench_root), name=name)
     except Exception:
         return error_response("app_removal_failed", "Could not start app removal.", 500)
+
+    return accepted_task_response(bench_root, task_id)
+
+
+@apps_bp.post("/<name>/switch-branch")
+def switch_branch(name: str):
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    if not (bench_root / "apps" / name).exists():
+        return error_response("app_not_found", f"App '{name}' not found in bench.", 404)
+
+    data = request.get_json(silent=True)
+    branch = data.get("branch", "") if isinstance(data, dict) else ""
+    if not isinstance(branch, str) or not branch.strip():
+        return error_response("branch_required", "branch is required.", 422)
+
+    try:
+        task_id = SwitchBranchTask.queue(Bench(bench_root), name=name, branch=branch.strip())
+    except Exception:
+        return error_response("branch_switch_failed", "Could not start the branch switch.", 500)
 
     return accepted_task_response(bench_root, task_id)
 

--- a/admin/backend/api/v1/apps.py
+++ b/admin/backend/api/v1/apps.py
@@ -10,7 +10,7 @@ from admin.backend.providers.apps import AppProvider
 from pilot.core.bench import Bench
 from pilot.exceptions import RegistryUnavailableError
 from pilot.internal.git import GitRepo
-from pilot.internal.validators import validate_app_name, validate_repo_url
+from pilot.internal.validators import validate_app_name, validate_branch_name, validate_repo_url
 from pilot.tasks.fetch_app_updates import FetchAppUpdatesTask
 from pilot.tasks.get_and_install_app import GetAndInstallAppTask
 from pilot.tasks.get_app import GetAppTask
@@ -178,16 +178,21 @@ def remove(name: str):
 @apps_bp.post("/<name>/switch-branch")
 def switch_branch(name: str):
     bench_root = Path(current_app.config["BENCH_ROOT"])
-    if not (bench_root / "apps" / name).exists():
+    if error := validate_app_name(name):
+        return error_response("invalid_app", error, 422)
+    if not (bench_root / "apps" / name / ".git").exists():
         return error_response("app_not_found", f"App '{name}' not found in bench.", 404)
 
     data = request.get_json(silent=True)
     branch = data.get("branch", "") if isinstance(data, dict) else ""
     if not isinstance(branch, str) or not branch.strip():
         return error_response("branch_required", "branch is required.", 422)
+    branch = branch.strip()
+    if error := validate_branch_name(branch):
+        return error_response("invalid_branch", error, 422)
 
     try:
-        task_id = SwitchBranchTask.queue(Bench(bench_root), name=name, branch=branch.strip())
+        task_id = SwitchBranchTask.queue(Bench(bench_root), name=name, branch=branch)
     except Exception:
         return error_response("branch_switch_failed", "Could not start the branch switch.", 500)
 

--- a/pilot/commands/apps/switch_branch.py
+++ b/pilot/commands/apps/switch_branch.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Annotated, ClassVar
+
+from pilot.commands import Arg, Command
+from pilot.tasks.switch_branch import SwitchBranchTask
+
+
+@dataclass(kw_only=True)
+class SwitchBranchCommand(Command):
+    name: ClassVar[str] = "switch-branch"
+    help: ClassVar[str] = "Switch an installed app to another git branch."
+
+    app_name: Annotated[str, Arg(help="App name.", metavar="app")]
+    branch: Annotated[str, Arg(help="Git branch to switch to.", metavar="branch")]
+
+    def run(self) -> None:
+        task = SwitchBranchTask(
+            bench=self.bench, bench_root=self.bench.path, name=self.app_name, branch=self.branch
+        )
+        task.run()
+        # Queued runs reload workers via the task's on_success callback;
+        # an inline run has no runner, so reload here.
+        self.bench.reload_workers()

--- a/pilot/core/app/__init__.py
+++ b/pilot/core/app/__init__.py
@@ -275,8 +275,8 @@ class App:
             source = f"branch '{current}'" if current else "a detached commit"
             raise BenchError(
                 f"'{self.config.name}' is already installed from {source}, "
-                f"so this install cannot deliver '{requested}'. Remove the app and "
-                f"add it again to change its branch."
+                f"so this install cannot deliver '{requested}'. Run "
+                f"`pilot switch-branch {self.config.name} {requested}` to change it."
             )
 
     def _skip_already_installed(

--- a/pilot/tasks/switch_branch.py
+++ b/pilot/tasks/switch_branch.py
@@ -13,7 +13,16 @@ class SwitchBranchTask(Task):
     branch: str
 
     def run(self) -> None:
+        from pilot.exceptions import BenchError
+        from pilot.internal.validators import validate_app_name, validate_branch_name
         from pilot.managers.environment import PythonEnvManager
+
+        if error := validate_app_name(self.name):
+            raise BenchError(error)
+        if not self.branch:
+            raise BenchError("Branch is required.")
+        if error := validate_branch_name(self.branch):
+            raise BenchError(error)
 
         app = self.bench.app(self.name)
         previous_branch, previous_sha = app.current_branch, app.head_sha

--- a/tests/admin/backend/api/test_apps_view.py
+++ b/tests/admin/backend/api/test_apps_view.py
@@ -177,6 +177,42 @@ def test_delete_app_404s_when_missing(tmp_path: Path) -> None:
     assert response.status_code == 404
 
 
+def test_switch_branch_queues_the_task(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    _make_cloned_app(bench_root, "suite")
+    client = _client(bench_root)
+
+    with patch(
+        "pilot.internal.tasks.runner.task_workers.wake",
+        return_value=False,
+    ):
+        response = client.post("/api/v1/apps/suite/switch-branch", json={"branch": "version-16-hotfix"})
+
+    body = response.get_json()
+    assert response.status_code == 202
+    assert body["command"] == "switch-branch"
+    assert body["args"] == {"name": "suite", "branch": "version-16-hotfix"}
+
+
+def test_switch_branch_requires_a_branch(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    _make_cloned_app(bench_root, "suite")
+    client = _client(bench_root)
+
+    response = client.post("/api/v1/apps/suite/switch-branch", json={"branch": "   "})
+
+    assert response.status_code == 422
+
+
+def test_switch_branch_404s_when_app_missing(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    client = _client(bench_root)
+
+    response = client.post("/api/v1/apps/suite/switch-branch", json={"branch": "develop"})
+
+    assert response.status_code == 404
+
+
 def test_marketplace_returns_catalog_apps(tmp_path: Path) -> None:
     bench_root = tmp_path / "benches" / "current"
     client = _client(bench_root)

--- a/tests/admin/backend/api/test_apps_view.py
+++ b/tests/admin/backend/api/test_apps_view.py
@@ -204,6 +204,20 @@ def test_switch_branch_requires_a_branch(tmp_path: Path) -> None:
     assert response.status_code == 422
 
 
+def test_switch_branch_rejects_invalid_app_and_branch_names(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    _make_cloned_app(bench_root, "suite")
+    client = _client(bench_root)
+
+    invalid_app = client.post("/api/v1/apps/bad.name/switch-branch", json={"branch": "develop"})
+    invalid_branch = client.post(
+        "/api/v1/apps/suite/switch-branch", json={"branch": "../develop"}
+    )
+
+    assert invalid_app.status_code == 422
+    assert invalid_branch.status_code == 422
+
+
 def test_switch_branch_404s_when_app_missing(tmp_path: Path) -> None:
     bench_root = tmp_path / "benches" / "current"
     client = _client(bench_root)

--- a/tests/pilot/commands/test_switch_branch.py
+++ b/tests/pilot/commands/test_switch_branch.py
@@ -1,0 +1,47 @@
+"""Tests for SwitchBranchCommand.run()."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pilot.commands.apps.switch_branch import SwitchBranchCommand
+from pilot.core.bench import Bench
+from pilot.tasks.switch_branch import SwitchBranchTask
+from tests.pilot.commands.test_commands import make_bench
+
+
+def test_run_drives_the_task_inline_and_reloads_workers(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    cmd = SwitchBranchCommand(bench, app_name="erpnext", branch="version-16-hotfix")
+
+    seen = {}
+
+    def record_task(task):
+        seen["name"] = task.name
+        seen["branch"] = task.branch
+
+    with (
+        patch.object(SwitchBranchTask, "run", autospec=True, side_effect=record_task),
+        patch.object(Bench, "reload_workers") as mock_reload,
+    ):
+        cmd.run()
+
+    assert seen == {"name": "erpnext", "branch": "version-16-hotfix"}
+    mock_reload.assert_called_once()
+
+
+def test_run_skips_worker_reload_when_the_switch_fails(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    cmd = SwitchBranchCommand(bench, app_name="erpnext", branch="gone")
+
+    with (
+        patch.object(SwitchBranchTask, "run", side_effect=SystemExit(1)),
+        patch.object(Bench, "reload_workers") as mock_reload,
+        pytest.raises(SystemExit),
+    ):
+        cmd.run()
+
+    mock_reload.assert_not_called()

--- a/tests/pilot/tasks/test_switch_branch_task.py
+++ b/tests/pilot/tasks/test_switch_branch_task.py
@@ -8,7 +8,7 @@ from unittest.mock import call, patch
 import pytest
 
 from pilot.core.app import App
-from pilot.exceptions import AppValidationError, CommandError
+from pilot.exceptions import AppValidationError, BenchError, CommandError
 from pilot.managers.environment import PythonEnvManager
 from pilot.tasks.switch_branch import SwitchBranchTask
 from tests.pilot.commands.test_commands import make_bench
@@ -29,6 +29,20 @@ def _write_app(bench, fixture: str) -> None:
 
 def _task(bench) -> SwitchBranchTask:
     return SwitchBranchTask(bench=bench, bench_root=bench.path, name="myapp", branch="develop")
+
+
+@pytest.mark.parametrize(
+    ("name", "branch", "message"),
+    [("../myapp", "develop", "App name"), ("myapp", "../develop", "Branch name")],
+)
+def test_switch_branch_rejects_unsafe_arguments(
+    tmp_path: Path, name: str, branch: str, message: str
+) -> None:
+    bench = make_bench(tmp_path)
+    task = SwitchBranchTask(bench=bench, bench_root=bench.path, name=name, branch=branch)
+
+    with pytest.raises(BenchError, match=message):
+        task.run()
 
 
 def test_switch_branch_installs_a_branch_that_validates(tmp_path: Path) -> None:


### PR DESCRIPTION
Stacked on #381.

`SwitchBranchTask` (checkout, validation with rollback to the previous branch, env reinstall, asset rebuild, worker reload) was fully implemented but orphaned — no CLI command or admin route reached it, so changing an installed app's branch meant remove-and-re-add.

This adds `pilot switch-branch <app> <branch>` (runs the task inline and reloads workers itself, since `on_success` callbacks only fire under the task runner) and `POST /api/v1/apps/<name>/switch-branch` (queues the task, returns the task id like the install/remove endpoints). #381's branch-mismatch error now points at the command instead of advising remove-and-re-add. No frontend yet — the admin UI can adopt the endpoint separately.

Tests cover the CLI wiring (inline run + reload, no reload on failure) and the endpoint (202 with command/args, 422 empty branch, 404 unknown app).