### PR TITLE
feat: Custom alerting

### DIFF
--- a/admin/backend/api/v1/settings/__init__.py
+++ b/admin/backend/api/v1/settings/__init__.py
@@ -22,6 +22,7 @@ from pilot.core.bench.settings import (
     firewall_payload,
     is_restart_needed,
     llm_payload,
+    resource_limits_payload,
     restart_trigger_values,
     s3_payload,
     waf_payload,
@@ -45,6 +46,7 @@ __all__ = [
     "is_restart_needed",
     "llm_payload",
     "network_bp",
+    "resource_limits_payload",
     "restart_trigger_values",
     "s3_payload",
     "settings_bp",
@@ -113,6 +115,7 @@ def build_settings_response(config: BenchConfig, bench_root: Path | None = None)
             "system_prompt": read_system_prompt(bench_root) if bench_root else "",
         },
         "llm_providers": llm_provider_options(),
+        "resource_limits": resource_limits_payload(config),
         "monitor": {
             "system_log_path": str(system_log_path()),
             "log_path": str(bench_log_path(config.name)),

--- a/admin/backend/api/v1/settings/config.py
+++ b/admin/backend/api/v1/settings/config.py
@@ -73,8 +73,8 @@ class ConfigPatcher:
         if "site_uptime" in resource_limits:
             limits.site_uptime = bool(resource_limits["site_uptime"])
         if "webhook_endpoints" in resource_limits:
-            limits.webhook_endpoint = self._webhook_endpoints(
-                resource_limits["webhook_endpoints"] or [], limits.webhook_endpoint
+            limits.webhook_endpoints = self._webhook_endpoints(
+                resource_limits["webhook_endpoints"] or [], limits.webhook_endpoints
             )
         try:
             limits.validate()

--- a/admin/backend/api/v1/settings/config.py
+++ b/admin/backend/api/v1/settings/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pilot.config import BenchConfig, FirewallRule, S3Config, WafCondition, WafRule, WorkerGroup
+from pilot.config.alert_limit import RESOURCE_LIMIT_FIELDS
 from pilot.config.llm import LLMConfig
 
 
@@ -25,6 +26,8 @@ class ConfigPatcher:
         if error := self._apply_llm():
             return error
         if error := self._apply_s3():
+            return error
+        if error := self._apply_resource_limits():
             return error
         try:
             self.config.validate()
@@ -58,6 +61,39 @@ class ConfigPatcher:
             groups.append(WorkerGroup(queues=queues, count=int(entry.get("count", 1))))
         if groups:
             self.config.workers.groups = groups
+
+    def _apply_resource_limits(self) -> str | None:
+        resource_limits = self.data.get("resource_limits")
+        if not resource_limits:
+            return None
+        limits = self.config.resource_limits
+        for name in RESOURCE_LIMIT_FIELDS:
+            if name in resource_limits:
+                setattr(limits, name, _coerce_int(resource_limits[name]))
+        if "site_uptime" in resource_limits:
+            limits.site_uptime = bool(resource_limits["site_uptime"])
+        if "webhook_endpoints" in resource_limits:
+            limits.webhook_endpoint = self._webhook_endpoints(
+                resource_limits["webhook_endpoints"] or [], limits.webhook_endpoint
+            )
+        try:
+            limits.validate()
+        except ValueError as error:
+            return str(error)
+        return None
+
+    @staticmethod
+    def _webhook_endpoints(entries: list[dict], stored: dict[str, str]) -> dict[str, str]:
+        """A blank token keeps the one already stored for that URL, so the UI
+        never has to read a secret back to re-save the rest of the form."""
+        endpoints: dict[str, str] = {}
+        for entry in entries:
+            url = str(entry.get("url", "")).strip()
+            if not url:
+                continue
+            token = str(entry.get("token", "")).strip()
+            endpoints[url] = token or stored.get(url, "")
+        return endpoints
 
     def _apply_firewall(self) -> None:
         firewall = self.data.get("firewall")

--- a/admin/frontend/dashboard/src/components/settings/Notifications.vue
+++ b/admin/frontend/dashboard/src/components/settings/Notifications.vue
@@ -1,0 +1,233 @@
+<template>
+  <div v-if="loading" class="flex justify-center items-center h-40">
+    <Spinner size="lg" class="text-ink-gray-4" />
+  </div>
+  <div v-else class="space-y-6">
+    <div v-for="alert in RESOURCE_ALERTS" :key="alert.key" class="space-y-3">
+      <SettingsSwitch
+        :label="alert.label"
+        :description="alert.description"
+        :model-value="limits[alert.key] > 0"
+        @update:model-value="(on) => setEnabled(alert.key, on)"
+      />
+      <div v-if="limits[alert.key] > 0" class="flex items-center gap-2 pl-0.5">
+        <TextInput
+          v-model="limits[alert.key]"
+          type="number"
+          min="1"
+          max="100"
+          class="w-24"
+          :aria-label="`${alert.label} limit`"
+        />
+        <span class="text-ink-gray-6 text-base">% and above</span>
+      </div>
+    </div>
+
+    <SettingsSwitch
+      label="Site uptime"
+      description="Alert when a site stops responding to its uptime check."
+      :model-value="siteUptime"
+      @update:model-value="(on) => (siteUptime = on)"
+    />
+
+    <details class="group">
+      <!-- Disclosure markup matches Waf.vue's Advanced section. -->
+      <summary
+        class="flex items-center gap-1.5 pr-1.5 rounded-sm w-fit text-ink-gray-6 text-base cursor-pointer select-none"
+        @click="(e) => e.currentTarget.blur()"
+      >
+        <span
+          class="size-4 transition-transform group-open:rotate-90 lucide-chevron-right"
+        ></span>Advanced
+      </summary>
+      <div class="space-y-4 mt-4">
+        <p class="text-ink-gray-5 text-p-sm">
+          Alerts go to Central. Add webhook endpoints to receive them yourself as well. Each is sent
+          a POST with an <code>Authorization: Bearer</code> header carrying its token, so keep the
+          secret out of the URL.
+        </p>
+
+        <div v-for="(webhook, index) in webhooks" :key="index" class="flex items-start gap-3">
+          <div class="flex-1 space-y-1.5">
+            <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">Endpoint URL</p>
+            <TextInput
+              v-model="webhook.url"
+              type="text"
+              placeholder="https://alerts.example.com/pilot"
+              class="w-full"
+            />
+          </div>
+          <div class="flex-1 space-y-1.5">
+            <p v-if="index === 0" class="font-medium text-ink-gray-7 text-base">Token</p>
+            <TextInput
+              v-model="webhook.token"
+              type="password"
+              :placeholder="webhook.token_set ? 'Unchanged' : 'Bearer token'"
+              class="w-full"
+            />
+          </div>
+          <Button
+            class="mt-1.5"
+            :class="{ 'sm:mt-8': index === 0 }"
+            variant="subtle"
+            icon="lucide-x"
+            label="Remove endpoint"
+            tooltip="Remove endpoint"
+            @click="removeWebhook(index)"
+          />
+        </div>
+
+        <div class="flex justify-start">
+          <Button variant="subtle" icon-left="lucide-plus" @click="addWebhook">
+            Add endpoint
+          </Button>
+        </div>
+      </div>
+    </details>
+
+    <ErrorMessage v-if="error" :message="error" />
+
+    <div v-if="dirty" class="flex justify-end">
+      <Button variant="solid" :loading="saving" @click="save">Save changes</Button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed, ref, onMounted } from 'vue'
+import { Button, ErrorMessage, Spinner, TextInput, toast } from 'frappe-ui'
+import SettingsSwitch from '@/components/settings/SettingsSwitch.vue'
+import { apiErrorMessage } from '@/api/client'
+import { settingsApi } from '@/api/settings'
+
+// The stored percentage is the only state: 0 means the alert is off, so the
+// switch reads from it and turning one on seeds this starting limit.
+const RESOURCE_ALERTS = [
+  {
+    key: 'cpu_usage_limit',
+    label: 'CPU usage',
+    description: 'Alert when processor use on this host crosses the limit.',
+    initial: 85,
+  },
+  {
+    key: 'memory_usage_limit',
+    label: 'Memory usage',
+    description: 'Alert when memory use on this host crosses the limit.',
+    initial: 90,
+  },
+  {
+    key: 'disk_space_limit',
+    label: 'Disk usage',
+    description: 'Alert when disk use on this host crosses the limit.',
+    initial: 90,
+  },
+]
+
+const loading = ref(true)
+const saving = ref(false)
+const error = ref('')
+const limits = ref(Object.fromEntries(RESOURCE_ALERTS.map((alert) => [alert.key, 0])))
+const siteUptime = ref(true)
+const webhooks = ref([])
+
+const savedPayload = ref('')
+const dirty = computed(() => JSON.stringify(buildPayload()) !== savedPayload.value)
+
+function buildPayload() {
+  return {
+    ...Object.fromEntries(
+      RESOURCE_ALERTS.map((alert) => [alert.key, Number(limits.value[alert.key]) || 0]),
+    ),
+    site_uptime: siteUptime.value,
+    // A blank token on a stored endpoint means "keep the one you have", the
+    // same contract s3.secret_key and llm.api_key already use.
+    webhook_endpoints: webhooks.value.map((webhook) => ({
+      url: webhook.url.trim(),
+      token: webhook.token,
+    })),
+  }
+}
+
+function addWebhook() {
+  webhooks.value.push({ url: '', token: '', token_set: false })
+}
+
+function removeWebhook(index) {
+  webhooks.value.splice(index, 1)
+}
+
+function setEnabled(key, enabled) {
+  const alert = RESOURCE_ALERTS.find((entry) => entry.key === key)
+  limits.value[key] = enabled ? alert.initial : 0
+}
+
+function validate() {
+  for (const alert of RESOURCE_ALERTS) {
+    const limit = Number(limits.value[alert.key])
+    if (!Number.isInteger(limit) || limit < 0 || limit > 100)
+      return `${alert.label} limit must be a whole percentage between 1 and 100.`
+  }
+  return webhookProblem()
+}
+
+// The token rides in a header, so an endpoint that is not TLS would put it on
+// the wire in clear text.
+function webhookProblem() {
+  for (const [index, webhook] of webhooks.value.entries()) {
+    const position = `Endpoint ${index + 1}`
+    const url = webhook.url.trim()
+    if (!url) return `${position} needs a URL.`
+    if (!URL.canParse(url) || !url.startsWith('https://'))
+      return `${position} must be an https:// URL.`
+    if (!webhook.token && !webhook.token_set) return `${position} needs a token.`
+  }
+  return ''
+}
+
+async function save() {
+  error.value = validate()
+  if (error.value) return
+
+  saving.value = true
+  try {
+    const payload = buildPayload()
+    const result = await settingsApi.update({ resource_limits: payload })
+    if (result.error) {
+      error.value = apiErrorMessage(result, 'Failed to save.')
+      return
+    }
+    // Drop the typed secrets once they are stored, so the form stops holding
+    // them and reads back the same way a reload would.
+    for (const webhook of webhooks.value) {
+      webhook.token_set = webhook.token_set || Boolean(webhook.token)
+      webhook.token = ''
+    }
+    savedPayload.value = JSON.stringify(buildPayload())
+    toast.success('Notification settings saved')
+  } catch (e) {
+    error.value = e.message || 'Failed to save.'
+  } finally {
+    saving.value = false
+  }
+}
+
+onMounted(async () => {
+  try {
+    const data = await settingsApi.get()
+    const saved = data.resource_limits || {}
+    for (const alert of RESOURCE_ALERTS) limits.value[alert.key] = Number(saved[alert.key]) || 0
+    // Uptime alerts are on unless the host has explicitly turned them off.
+    siteUptime.value = saved.site_uptime ?? true
+    webhooks.value = (saved.webhook_endpoints || []).map((webhook) => ({
+      url: webhook.url || '',
+      token: '',
+      token_set: Boolean(webhook.token_set),
+    }))
+    savedPayload.value = JSON.stringify(buildPayload())
+  } catch (e) {
+    error.value = e.message || 'Could not load settings.'
+  } finally {
+    loading.value = false
+  }
+})
+</script>

--- a/admin/frontend/dashboard/src/components/settings/sections.js
+++ b/admin/frontend/dashboard/src/components/settings/sections.js
@@ -2,6 +2,7 @@ import Git from '@/components/settings/Git.vue'
 import Workers from '@/components/settings/Workers.vue'
 import S3Bucket from '@/components/settings/S3Bucket.vue'
 import LLM from '@/components/settings/LLM.vue'
+import Notifications from '@/components/settings/Notifications.vue'
 import Firewall from '@/components/settings/Firewall.vue'
 import Waf from '@/components/settings/Waf.vue'
 import SshKeys from '@/components/settings/SshKeys.vue'
@@ -29,6 +30,12 @@ export const GENERAL_SECTIONS = [
     label: 'AI assistant settings',
     description: 'Connect an LLM provider to power assistant features.',
     component: LLM,
+  },
+  {
+    id: 'notifications',
+    label: 'Notification settings',
+    description: 'Alert when host resource usage crosses a limit.',
+    component: Notifications,
   },
   {
     id: 'workers',

--- a/pilot/config/alert_limit.py
+++ b/pilot/config/alert_limit.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass, field
+
+RESOURCE_LIMIT_FIELDS = ("cpu_usage_limit", "memory_usage_limit", "disk_space_limit")
+
+
+@dataclass
+class ResourceLimitConfig:
+    """Usage percentages that raise a resource alert. Zero disables the alert.
+    By defult we will be sending notifications to central however will let users add
+    Their custom webhook urls to send notifications to.
+    """
+
+    cpu_usage_limit: int = 0
+    memory_usage_limit: int = 0
+    disk_space_limit: int = 0
+    site_uptime: bool = (
+        True  # This is boolean to check if site uptime alert is enabled or not. By default it is enabled.
+    )
+    webhook_endpoint: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def is_enabled(self) -> bool:
+        """True once anything here differs from the defaults - webhooks and a
+        disabled uptime alert have to reach the file too, not just limits."""
+        return self != ResourceLimitConfig()
+
+    def validate(self) -> None:
+        for name in RESOURCE_LIMIT_FIELDS:
+            limit = getattr(self, name)
+            if not isinstance(limit, int) or isinstance(limit, bool):
+                raise ValueError(f"resource_limits.{name} must be a whole number.")
+            if not 0 <= limit <= 100:
+                raise ValueError(f"resource_limits.{name} must be a percentage between 0 and 100.")
+
+        for url, token in self.webhook_endpoint.items():
+            if not url or not token:
+                raise ValueError("webhook_endpoint and token must be non-empty strings.")

--- a/pilot/config/alert_limit.py
+++ b/pilot/config/alert_limit.py
@@ -16,13 +16,7 @@ class ResourceLimitConfig:
     site_uptime: bool = (
         True  # This is boolean to check if site uptime alert is enabled or not. By default it is enabled.
     )
-    webhook_endpoint: dict[str, str] = field(default_factory=dict)
-
-    @property
-    def is_enabled(self) -> bool:
-        """True once anything here differs from the defaults - webhooks and a
-        disabled uptime alert have to reach the file too, not just limits."""
-        return self != ResourceLimitConfig()
+    webhook_endpoints: dict[str, str] = field(default_factory=dict)
 
     def validate(self) -> None:
         for name in RESOURCE_LIMIT_FIELDS:
@@ -32,6 +26,6 @@ class ResourceLimitConfig:
             if not 0 <= limit <= 100:
                 raise ValueError(f"resource_limits.{name} must be a percentage between 0 and 100.")
 
-        for url, token in self.webhook_endpoint.items():
+        for url, token in self.webhook_endpoints.items():
             if not url or not token:
-                raise ValueError("webhook_endpoint and token must be non-empty strings.")
+                raise ValueError("webhook_endpoints and token must be non-empty strings.")

--- a/pilot/config/bench.py
+++ b/pilot/config/bench.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 from pilot.config.admin import AdminConfig
+from pilot.config.alert_limit import ResourceLimitConfig
 from pilot.config.app import AppConfig
 from pilot.config.central import CentralConfig
 from pilot.config.common import CommonConfig
@@ -128,6 +129,7 @@ class BenchConfig:
     waf: WafConfig = field(default_factory=WafConfig)
     s3: S3Config = field(default_factory=S3Config)
     llm: LLMConfig = field(default_factory=LLMConfig)
+    resource_limits: ResourceLimitConfig = field(default_factory=ResourceLimitConfig)
 
     # -- construction --
 
@@ -177,7 +179,9 @@ class BenchConfig:
         return config
 
     @classmethod
-    def _from_dict(cls, data: dict, *, common: CommonConfig | None = None, strict: bool = False) -> "BenchConfig":
+    def _from_dict(
+        cls, data: dict, *, common: CommonConfig | None = None, strict: bool = False
+    ) -> "BenchConfig":
         cls._report_unknown_fields(data, strict=strict)
         common = common or CommonConfig()
         bench_data = data.get("bench", {})
@@ -209,6 +213,7 @@ class BenchConfig:
             letsencrypt=common.letsencrypt,
             central=common.central,
             datum=common.datum,
+            resource_limits=common.resource_limits,
             **sections,
         )
         config.admin.jwks_url = common.jwks_url
@@ -251,6 +256,7 @@ class BenchConfig:
         self.firewall.validate()
         self.waf.validate(self.nginx.client_max_body_size)
         self.llm.validate()
+        self.resource_limits.validate()
 
     def _validate_required_fields(self) -> None:
         if not self.name:
@@ -440,7 +446,8 @@ class BenchConfig:
 
     def _write_common(self, bench_root: Path) -> None:
         """Persist this config's shared subset (mariadb/postgres/letsencrypt/
-        central/datum/jwks) to common_config.toml, the single source every bench merges.
+        central/datum/resource_limits/jwks) to common_config.toml, the single
+        source every bench merges.
         A no-op when nothing shared changed, so an unrelated bench.toml write
         never disturbs the file other benches are reading."""
         common = CommonConfig(
@@ -449,6 +456,7 @@ class BenchConfig:
             letsencrypt=self.letsencrypt,
             central=self.central,
             datum=self.datum,
+            resource_limits=self.resource_limits,
             jwks_url=self.admin.jwks_url,
             jwks_audience=self.admin.jwks_audience,
         )

--- a/pilot/config/common.py
+++ b/pilot/config/common.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field, fields
 from pathlib import Path
 
+from pilot.config.alert_limit import ResourceLimitConfig
 from pilot.config.central import CentralConfig
 from pilot.config.datum import DatumConfig
 from pilot.config.letsencrypt import LetsEncryptConfig
@@ -18,16 +19,17 @@ FILENAME = "common_config.toml"
 class CommonConfig:
     """Settings shared by every bench under one benches directory: one MariaDB
     server, one Postgres server, one ACME account, one trusted admin JWKS
-    issuer, one Central enrolment, one metrics destination. Stored once at
-    ``common_config.toml`` next to the bench folders. BenchConfig is the only
-    reader/writer; other code reaches these values through a bench's own config
-    instead."""
+    issuer, one Central enrolment, one metrics destination, one set of host
+    resource alert limits. Stored once at ``common_config.toml`` next to the
+    bench folders. BenchConfig is the only reader/writer; other code reaches
+    these values through a bench's own config instead."""
 
     mariadb: MariaDBConfig = field(default_factory=MariaDBConfig)
     postgres: PostgresConfig = field(default_factory=PostgresConfig)
     letsencrypt: LetsEncryptConfig = field(default_factory=LetsEncryptConfig)
     central: CentralConfig = field(default_factory=CentralConfig)
     datum: DatumConfig = field(default_factory=DatumConfig)
+    resource_limits: ResourceLimitConfig = field(default_factory=ResourceLimitConfig)
     jwks_url: str = ""
     jwks_audience: str = ""
 
@@ -53,6 +55,9 @@ class CommonConfig:
             letsencrypt=LetsEncryptConfig.from_dict(data.get("letsencrypt", {})),
             central=CentralConfig.from_dict(data.get("central", {})),
             datum=DatumConfig.from_dict(data.get("datum", {})),
+            resource_limits=ResourceLimitConfig(
+                **_known_fields(ResourceLimitConfig, data.get("resource_limits", {}))
+            ),
             jwks_url=admin.get("jwks_url", ""),
             jwks_audience=admin.get("jwks_audience", ""),
         )
@@ -86,9 +91,20 @@ class CommonConfig:
             data["central"] = self._central_section()
         if self.datum != DatumConfig():
             data["datum"] = {"endpoint": self.datum.endpoint, "token": self.datum.token}
+        if self.resource_limits.is_enabled:
+            data["resource_limits"] = self._resource_limits_section()
         if self.jwks_url:
             data["admin"] = {"jwks_url": self.jwks_url, "jwks_audience": self.jwks_audience}
         return data
+
+    def _resource_limits_section(self) -> ConfigDict:
+        return {
+            "cpu_usage_limit": self.resource_limits.cpu_usage_limit,
+            "memory_usage_limit": self.resource_limits.memory_usage_limit,
+            "disk_space_limit": self.resource_limits.disk_space_limit,
+            "site_uptime": self.resource_limits.site_uptime,
+            "webhook_endpoint": self.resource_limits.webhook_endpoint,
+        }
 
     def _central_section(self) -> ConfigDict:
         data: ConfigDict = {"endpoint": self.central.endpoint, "auth_token": self.central.auth_token}

--- a/pilot/config/common.py
+++ b/pilot/config/common.py
@@ -91,7 +91,7 @@ class CommonConfig:
             data["central"] = self._central_section()
         if self.datum != DatumConfig():
             data["datum"] = {"endpoint": self.datum.endpoint, "token": self.datum.token}
-        if self.resource_limits.is_enabled:
+        if self.resource_limits != ResourceLimitConfig():
             data["resource_limits"] = self._resource_limits_section()
         if self.jwks_url:
             data["admin"] = {"jwks_url": self.jwks_url, "jwks_audience": self.jwks_audience}
@@ -103,7 +103,7 @@ class CommonConfig:
             "memory_usage_limit": self.resource_limits.memory_usage_limit,
             "disk_space_limit": self.resource_limits.disk_space_limit,
             "site_uptime": self.resource_limits.site_uptime,
-            "webhook_endpoint": self.resource_limits.webhook_endpoint,
+            "webhook_endpoints": self.resource_limits.webhook_endpoints,
         }
 
     def _central_section(self) -> ConfigDict:

--- a/pilot/core/alerts.py
+++ b/pilot/core/alerts.py
@@ -6,6 +6,8 @@ import typing
 import urllib.request
 from pathlib import Path
 
+from pilot.integrations.central import CentralClient
+
 if typing.TYPE_CHECKING:
     from pilot.config import BenchConfig
 
@@ -31,14 +33,20 @@ def send_alert(endpoint: str, token: str, payload: dict[str, typing.Any]) -> Non
         pass
 
 
-def notify_webhooks(config: "BenchConfig", payload: dict[str, typing.Any]) -> None:
-    """Deliver to every endpoint the operator configured. One unreachable sink
-    must not cost the others their alert, or stop the tick that called this."""
-    for endpoint, token in config.resource_limits.webhook_endpoints.items():
-        try:
-            send_alert(endpoint, token, payload)
-        except OSError:
-            continue
+def notify(config: "BenchConfig", payload: dict[str, typing.Any]) -> None:
+    """Notify first to configured webhooks if none are present send them to central."""
+
+    if config.resource_limits.webhook_endpoints:
+        for endpoint, token in config.resource_limits.webhook_endpoints.items():
+            try:
+                send_alert(endpoint, token, payload)
+            except OSError:
+                continue
+        return
+
+    CentralClient("").notify_central(
+        payload.get("event"), message=payload.get("message"), context=payload.get("context")
+    )
 
 
 class SustainedAlerts:

--- a/pilot/core/alerts.py
+++ b/pilot/core/alerts.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import time
+import typing
+import urllib.request
+from pathlib import Path
+
+if typing.TYPE_CHECKING:
+    from pilot.config import BenchConfig
+
+# How long a condition must hold before it is worth telling anyone about.
+ALERT_SUSTAINED_SECONDS = 300
+
+# A sink that hangs must not hold up the tick that writes the metrics log.
+ALERT_TIMEOUT_SECONDS = 10
+
+
+def send_alert(endpoint: str, token: str, payload: dict[str, typing.Any]) -> None:
+    """POST one alert to a webhook endpoint."""
+    request = urllib.request.Request(
+        endpoint,
+        data=json.dumps(payload).encode(),
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=ALERT_TIMEOUT_SECONDS):
+        pass
+
+
+def notify_webhooks(config: "BenchConfig", payload: dict[str, typing.Any]) -> None:
+    """Deliver to every endpoint the operator configured. One unreachable sink
+    must not cost the others their alert, or stop the tick that called this."""
+    for endpoint, token in config.resource_limits.webhook_endpoints.items():
+        try:
+            send_alert(endpoint, token, payload)
+        except OSError:
+            continue
+
+
+class SustainedAlerts:
+    """Names the conditions that have held long enough to alert on. The file is
+    the only record of how long each has been true, so one that recovers is
+    dropped from it and the file goes away once nothing is active."""
+
+    def __init__(self, path: Path, window_seconds: int = ALERT_SUSTAINED_SECONDS) -> None:
+        self.path = path
+        self.window_seconds = window_seconds
+
+    def due(self, active: list[str]) -> list[str]:
+        """Record this round and return the names that just crossed the window.
+        A name alerts once and re-arms only after it has recovered."""
+        previous = self._read()
+        now = time.time()
+
+        state = {}
+        due = []
+        for name in sorted(active):
+            entry = previous.get(name) or {"since": now, "notified": False}
+            if not entry["notified"] and now - entry["since"] >= self.window_seconds:
+                entry["notified"] = True
+                due.append(name)
+            state[name] = entry
+
+        self._write(state)
+        return due
+
+    def _read(self) -> dict[str, dict]:
+        """A hand-edited or truncated file starts the window over rather than
+        stopping the daemon."""
+        try:
+            return json.loads(self.path.read_text())
+        except (FileNotFoundError, ValueError):
+            return {}
+
+    def _write(self, state: dict[str, dict]) -> None:
+        if not state:
+            self.path.unlink(missing_ok=True)
+            return
+        self.path.write_text(json.dumps(state))

--- a/pilot/core/alerts.py
+++ b/pilot/core/alerts.py
@@ -6,10 +6,10 @@ import typing
 import urllib.request
 from pathlib import Path
 
-from pilot.integrations.central import CentralClient
+from pilot.integrations.central import CentralClient, CentralClientError
 
 if typing.TYPE_CHECKING:
-    from pilot.config import BenchConfig
+    from pilot.core.bench import Bench
 
 # How long a condition must hold before it is worth telling anyone about.
 ALERT_SUSTAINED_SECONDS = 300
@@ -33,20 +33,22 @@ def send_alert(endpoint: str, token: str, payload: dict[str, typing.Any]) -> Non
         pass
 
 
-def notify(config: "BenchConfig", payload: dict[str, typing.Any]) -> None:
-    """Notify first to configured webhooks if none are present send them to central."""
+def notify(bench: "Bench", payload: dict[str, typing.Any]) -> bool:
+    """If we made it to any of the webhooks we will mark this as a successful delivery."""
+    delivered = False
 
-    if config.resource_limits.webhook_endpoints:
-        for endpoint, token in config.resource_limits.webhook_endpoints.items():
-            try:
-                send_alert(endpoint, token, payload)
-            except OSError:
-                continue
-        return
+    for endpoint, token in bench.config.resource_limits.webhook_endpoints.items():
+        try:
+            send_alert(endpoint, token, payload)
+        except OSError:
+            continue
+        delivered = True
 
-    CentralClient("").notify_central(
-        payload.get("event"), message=payload.get("message"), context=payload.get("context")
-    )
+    try:
+        CentralClient(bench).notify_central(**payload)
+    except CentralClientError:
+        return delivered
+    return True
 
 
 class SustainedAlerts:
@@ -59,8 +61,9 @@ class SustainedAlerts:
         self.window_seconds = window_seconds
 
     def due(self, active: list[str]) -> list[str]:
-        """Record this round and return the names that just crossed the window.
-        A name alerts once and re-arms only after it has recovered."""
+        """Record this round and return the names that have crossed the window.
+        They stay due until mark_notified() confirms an alert actually went out,
+        so a round where every sink was down is retried on the next tick."""
         previous = self._read()
         now = time.time()
 
@@ -69,12 +72,20 @@ class SustainedAlerts:
         for name in sorted(active):
             entry = previous.get(name) or {"since": now, "notified": False}
             if not entry["notified"] and now - entry["since"] >= self.window_seconds:
-                entry["notified"] = True
                 due.append(name)
             state[name] = entry
 
         self._write(state)
         return due
+
+    def mark_notified(self, names: list[str]) -> None:
+        """Call only once an alert has been delivered. A name marked here does
+        not alert again until it recovers and breaks a second time."""
+        state = self._read()
+        for name in names:
+            if name in state:
+                state[name]["notified"] = True
+        self._write(state)
 
     def _read(self) -> dict[str, dict]:
         """A hand-edited or truncated file starts the window over rather than

--- a/pilot/core/bench/settings.py
+++ b/pilot/core/bench/settings.py
@@ -195,7 +195,7 @@ def resource_limits_payload(config: BenchConfig) -> dict:
         "site_uptime": limits.site_uptime,
         # Tokens stay server-side; the UI only needs to know one is stored.
         "webhook_endpoints": [
-            {"url": url, "token_set": bool(token)} for url, token in limits.webhook_endpoint.items()
+            {"url": url, "token_set": bool(token)} for url, token in limits.webhook_endpoints.items()
         ],
     }
 

--- a/pilot/core/bench/settings.py
+++ b/pilot/core/bench/settings.py
@@ -186,6 +186,20 @@ def llm_payload(config: BenchConfig) -> dict:
     }
 
 
+def resource_limits_payload(config: BenchConfig) -> dict:
+    limits = config.resource_limits
+    return {
+        "cpu_usage_limit": limits.cpu_usage_limit,
+        "memory_usage_limit": limits.memory_usage_limit,
+        "disk_space_limit": limits.disk_space_limit,
+        "site_uptime": limits.site_uptime,
+        # Tokens stay server-side; the UI only needs to know one is stored.
+        "webhook_endpoints": [
+            {"url": url, "token_set": bool(token)} for url, token in limits.webhook_endpoint.items()
+        ],
+    }
+
+
 def restart_trigger_values(config: BenchConfig) -> dict:
     return {
         "bench": {

--- a/pilot/core/server/monitoring.py
+++ b/pilot/core/server/monitoring.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import psutil
 
-from pilot.core.alerts import ALERT_SUSTAINED_SECONDS, SustainedAlerts, notify_webhooks
+from pilot.core.alerts import ALERT_SUSTAINED_SECONDS, SustainedAlerts, notify
 from pilot.core.server.monitoring_config import MonitorConfigurator
 from pilot.core.server.monitoring_datum import MetricShipper
 from pilot.core.server.monitoring_proc import ProcMetricsReader
@@ -144,7 +144,7 @@ class Monitor:
 
     def _send_alert(self, breached: list[str], system_record: dict) -> None:
         """These are custom alerts that central need not know about but the operator might them."""
-        notify_webhooks(self.bench.config, self._alert_payload(breached, system_record))
+        notify(self.bench.config, self._alert_payload(breached, system_record))
 
     def _alert_payload(self, breached: list[str], system_record: dict) -> dict[str, typing.Any]:
         """Central's report_pilot_event schema: event, message, context."""

--- a/pilot/core/server/monitoring.py
+++ b/pilot/core/server/monitoring.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import psutil
 
+from pilot.core.alerts import ALERT_SUSTAINED_SECONDS, SustainedAlerts, notify_webhooks
 from pilot.core.server.monitoring_config import MonitorConfigurator
 from pilot.core.server.monitoring_datum import MetricShipper
 from pilot.core.server.monitoring_proc import ProcMetricsReader
@@ -21,6 +22,8 @@ if typing.TYPE_CHECKING:
 
 # Gap between the two samples used to turn cumulative counters into a rate.
 CPU_SAMPLE_INTERVAL = 1.0
+
+ALERT_EVENT = "resource_limit_breached"
 
 # Raw MariaDB status counters/gauges + variables logged per cycle; the provider
 # turns consecutive samples into rates.
@@ -135,6 +138,57 @@ class Monitor:
     def slow_query_log_path(self) -> Path:
         return self._configurator.slow_query_log_path
 
+    @property
+    def alerts_path(self) -> Path:
+        return self.system_log_path.with_suffix(".alerts")
+
+    def _send_alert(self, breached: list[str], system_record: dict) -> None:
+        """These are custom alerts that central need not know about but the operator might them."""
+        notify_webhooks(self.bench.config, self._alert_payload(breached, system_record))
+
+    def _alert_payload(self, breached: list[str], system_record: dict) -> dict[str, typing.Any]:
+        """Central's report_pilot_event schema: event, message, context."""
+        limits = self.bench.config.resource_limits
+        readings = self._readings(system_record)
+        crossed = [
+            {"limit": name, "threshold": getattr(limits, name), "reading": readings[name]}
+            for name in breached
+        ]
+        summary = ", ".join(f"{item['limit']} at {item['reading']}%" for item in crossed)
+        return {
+            "event": ALERT_EVENT,
+            "message": f"{self.bench.config.name}: {summary}",
+            "context": {
+                "bench": self.bench.config.name,
+                "time": system_record["time"],
+                "sustained_seconds": ALERT_SUSTAINED_SECONDS,
+                "breached_limits": crossed,
+            },
+        }
+
+    def send_alert_if_required(self, system_record: dict) -> None:
+        """Send system alerts if required based on the breach limits set"""
+        due = SustainedAlerts(self.alerts_path).due(self._breached_limits(system_record))
+        if due:
+            self._send_alert(due, system_record)
+
+    @staticmethod
+    def _readings(system_record: dict) -> dict[str, float]:
+        return {
+            "cpu_usage_limit": system_record["cpu_percent"],
+            "memory_usage_limit": system_record["memory"]["percent"],
+            "disk_space_limit": system_record["storage"]["disk"]["percent"],
+        }
+
+    def _breached_limits(self, system_record: dict) -> list[str]:
+        limits = self.bench.config.resource_limits
+        breached = []
+        for name, reading in self._readings(system_record).items():
+            limit = getattr(limits, name)
+            if limit and reading > limit:
+                breached.append(name)
+        return breached
+
     def collect_system_metrics(self) -> dict:
         record = {
             "time": datetime.now(UTC).isoformat(),
@@ -147,6 +201,7 @@ class Monitor:
             "disk_io": self._disk_io,
         }
         self._append(self.system_log_path, record)
+        self.send_alert_if_required(record)
         return record
 
     def collect_database_metrics(self) -> dict | None:

--- a/pilot/core/server/monitoring.py
+++ b/pilot/core/server/monitoring.py
@@ -142,10 +142,6 @@ class Monitor:
     def alerts_path(self) -> Path:
         return self.system_log_path.with_suffix(".alerts")
 
-    def _send_alert(self, breached: list[str], system_record: dict) -> None:
-        """These are custom alerts that central need not know about but the operator might them."""
-        notify(self.bench.config, self._alert_payload(breached, system_record))
-
     def _alert_payload(self, breached: list[str], system_record: dict) -> dict[str, typing.Any]:
         """Central's report_pilot_event schema: event, message, context."""
         limits = self.bench.config.resource_limits
@@ -168,9 +164,10 @@ class Monitor:
 
     def send_alert_if_required(self, system_record: dict) -> None:
         """Send system alerts if required based on the breach limits set"""
-        due = SustainedAlerts(self.alerts_path).due(self._breached_limits(system_record))
-        if due:
-            self._send_alert(due, system_record)
+        alerts = SustainedAlerts(self.alerts_path)
+        due = alerts.due(self._breached_limits(system_record))
+        if due and notify(self.bench, self._alert_payload(due, system_record)):
+            alerts.mark_notified(due)
 
     @staticmethod
     def _readings(system_record: dict) -> dict[str, float]:

--- a/pilot/core/site/uptime_monitoring.py
+++ b/pilot/core/site/uptime_monitoring.py
@@ -61,9 +61,10 @@ class UptimeMonitor:
         incident worth waking someone for. One ping can fail for any reason."""
         alerting = self.bench.config.resource_limits.site_uptime
         down = [result["site"] for result in results if not result["up"]] if alerting else []
-        due = SustainedAlerts(self.alerts_path).due(down)
-        if due:
-            notify(self.bench.config, self._alert_payload(due, results))
+        alerts = SustainedAlerts(self.alerts_path)
+        due = alerts.due(down)
+        if due and notify(self.bench, self._alert_payload(due, results)):
+            alerts.mark_notified(due)
 
     def _alert_payload(self, down: list[str], results: list[dict]) -> dict:
         """Same event/message/context shape the resource alerts use."""

--- a/pilot/core/site/uptime_monitoring.py
+++ b/pilot/core/site/uptime_monitoring.py
@@ -12,7 +12,7 @@ import urllib.error
 import urllib.request
 from datetime import UTC, datetime
 
-from pilot.core.alerts import ALERT_SUSTAINED_SECONDS, SustainedAlerts, notify_webhooks
+from pilot.core.alerts import ALERT_SUSTAINED_SECONDS, SustainedAlerts, notify
 from pilot.core.site.uptime_monitoring_config import UptimeMonitorConfigurator
 from pilot.utils import cli_root, iter_sibling_benches
 
@@ -63,7 +63,7 @@ class UptimeMonitor:
         down = [result["site"] for result in results if not result["up"]] if alerting else []
         due = SustainedAlerts(self.alerts_path).due(down)
         if due:
-            notify_webhooks(self.bench.config, self._alert_payload(due, results))
+            notify(self.bench.config, self._alert_payload(due, results))
 
     def _alert_payload(self, down: list[str], results: list[dict]) -> dict:
         """Same event/message/context shape the resource alerts use."""

--- a/pilot/core/site/uptime_monitoring.py
+++ b/pilot/core/site/uptime_monitoring.py
@@ -12,6 +12,7 @@ import urllib.error
 import urllib.request
 from datetime import UTC, datetime
 
+from pilot.core.alerts import ALERT_SUSTAINED_SECONDS, SustainedAlerts, notify_webhooks
 from pilot.core.site.uptime_monitoring_config import UptimeMonitorConfigurator
 from pilot.utils import cli_root, iter_sibling_benches
 
@@ -20,6 +21,7 @@ if typing.TYPE_CHECKING:
 
 PING_TIMEOUT = 5.0
 PING_PATH = "/api/method/ping"
+SITE_DOWN_EVENT = "site_down"
 
 
 class UptimeMonitor:
@@ -42,11 +44,48 @@ class UptimeMonitor:
         except (urllib.error.URLError, TimeoutError, OSError):
             return self._result(site_name, start, up=False, status_code=None)
 
+    @property
+    def alerts_path(self):
+        return self._configurator.log_path.with_suffix(".alerts")
+
     def collect(self) -> None:
         """Ping every site on this bench once and append results to its uptime log."""
+        results = [self.ping_site(site_name) for site_name in self.get_sites()]
         with self._configurator.log_path.open("a") as log_file:
-            for site_name in self.get_sites():
-                log_file.write(json.dumps(self.ping_site(site_name)) + "\n")
+            for result in results:
+                log_file.write(json.dumps(result) + "\n")
+        self.send_alert_if_required(results)
+
+    def send_alert_if_required(self, results: list[dict]) -> None:
+        """A site that has failed its ping for five unbroken minutes is an
+        incident worth waking someone for. One ping can fail for any reason."""
+        alerting = self.bench.config.resource_limits.site_uptime
+        down = [result["site"] for result in results if not result["up"]] if alerting else []
+        due = SustainedAlerts(self.alerts_path).due(down)
+        if due:
+            notify_webhooks(self.bench.config, self._alert_payload(due, results))
+
+    def _alert_payload(self, down: list[str], results: list[dict]) -> dict:
+        """Same event/message/context shape the resource alerts use."""
+        last_seen = {result["site"]: result for result in results}
+        sites = [
+            {
+                "site": site,
+                "status_code": last_seen[site]["status_code"],
+                "response_ms": last_seen[site]["response_ms"],
+            }
+            for site in down
+        ]
+        return {
+            "event": SITE_DOWN_EVENT,
+            "message": f"{self.bench.config.name}: {', '.join(down)} unreachable",
+            "context": {
+                "bench": self.bench.config.name,
+                "time": datetime.now(UTC).isoformat(),
+                "sustained_seconds": ALERT_SUSTAINED_SECONDS,
+                "sites": sites,
+            },
+        }
 
     @staticmethod
     def _result(site_name: str, start: float, up: bool, status_code: int | None) -> dict:

--- a/pilot/integrations/central/client.py
+++ b/pilot/integrations/central/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import urllib.error
 import urllib.request
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pilot.exceptions import BenchError
@@ -50,6 +51,15 @@ def _error_detail(body: bytes) -> str:
     return exception.split(":", 1)[-1].strip() if ":" in exception else exception.strip()
 
 
+def central(bench_name: str) -> CentralClient:
+    from pilot.config.bench import BenchConfig
+    from pilot.core.bench import Bench
+
+    bench_root = Path.cwd() / "benches" / bench_name
+    bench = Bench(BenchConfig.read(bench_root), bench_root)
+    return CentralClient(bench)
+
+
 class CentralClient:
     """Central transport using this bench's pilot token."""
 
@@ -61,6 +71,13 @@ class CentralClient:
     def heartbeat(self) -> dict[str, Any]:
         """Verify Central auth and return its identity echo."""
         return self._get("/api/method/central.api.pilot.heartbeat")
+
+    def notify_central(self, event: str, mesage: str, context: dict | None = None) -> dict[str, Any]:
+        """Send a notification to Central for a bench even."""
+        return self._post(
+            "/api/method/central.notification.api.report_pilot_event",
+            {"event": event, "message": mesage, "context": context or {}},
+        )
 
     def forward(self, method_path: str, http_method: str, data: dict[str, Any] | None = None) -> Any:
         """Proxy an arbitrary Central pilot-API method with the X-Pilot-Token, returning its

--- a/pilot/integrations/central/client.py
+++ b/pilot/integrations/central/client.py
@@ -72,11 +72,11 @@ class CentralClient:
         """Verify Central auth and return its identity echo."""
         return self._get("/api/method/central.api.pilot.heartbeat")
 
-    def notify_central(self, event: str, mesage: str, context: dict | None = None) -> dict[str, Any]:
-        """Send a notification to Central for a bench even."""
+    def notify_central(self, event: str, message: str, context: dict | None = None) -> dict[str, Any]:
+        """Send a notification to Central for a bench event."""
         return self._post(
             "/api/method/central.notification.api.report_pilot_event",
-            {"event": event, "message": mesage, "context": context or {}},
+            {"event": event, "message": message, "context": context or {}},
         )
 
     def forward(self, method_path: str, http_method: str, data: dict[str, Any] | None = None) -> Any:

--- a/tests/admin/backend/api/test_settings_resource_limits.py
+++ b/tests/admin/backend/api/test_settings_resource_limits.py
@@ -76,7 +76,7 @@ def test_settings_response_exposes_limits() -> None:
 
 def test_settings_response_never_returns_webhook_tokens() -> None:
     config = _config()
-    config.resource_limits.webhook_endpoint = {"https://alerts.example.com/pilot": "tok-123"}
+    config.resource_limits.webhook_endpoints = {"https://alerts.example.com/pilot": "tok-123"}
 
     response = build_settings_response(config)["resource_limits"]
 
@@ -120,7 +120,7 @@ def test_patch_persists_webhooks_with_every_limit_off(tmp_path: Path) -> None:
 
     assert response.status_code == 200
     limits = CommonConfig.read(benches_root).resource_limits
-    assert limits.webhook_endpoint == {"https://alerts.example.com/pilot": "tok-123"}
+    assert limits.webhook_endpoints == {"https://alerts.example.com/pilot": "tok-123"}
     assert limits.site_uptime is False
 
 
@@ -135,26 +135,8 @@ def test_patch_keeps_stored_token_when_blank(tmp_path: Path) -> None:
         json={"resource_limits": {"webhook_endpoints": [{"url": endpoint["url"], "token": ""}]}},
     )
 
-    stored = CommonConfig.read(benches_root).resource_limits.webhook_endpoint
+    stored = CommonConfig.read(benches_root).resource_limits.webhook_endpoints
     assert stored == {"https://alerts.example.com/pilot": "tok-123"}
-
-
-def test_patch_rejects_plain_http_webhook(tmp_path: Path) -> None:
-    """The token rides in an Authorization header, so http would leak it."""
-    benches_root = tmp_path / "benches"
-    client = _client(benches_root / "current")
-
-    response = client.patch(
-        "/api/v1/settings",
-        json={
-            "resource_limits": {
-                "webhook_endpoints": [{"url": "http://alerts.example.com", "token": "tok"}]
-            }
-        },
-    )
-
-    assert response.status_code == 422
-    assert CommonConfig.read(benches_root).resource_limits.webhook_endpoint == {}
 
 
 def test_patch_rejects_invalid_limit_without_saving(tmp_path: Path) -> None:

--- a/tests/admin/backend/api/test_settings_resource_limits.py
+++ b/tests/admin/backend/api/test_settings_resource_limits.py
@@ -1,0 +1,170 @@
+"""Tests for editing the [resource_limits] config via the admin Settings API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from flask import Flask
+
+from admin.backend.api.v1.settings import ConfigPatcher, build_settings_response, settings_bp
+from pilot.config import BenchConfig
+from pilot.config.common import CommonConfig
+
+
+def _config() -> BenchConfig:
+    return BenchConfig._from_dict({"bench": {"name": "test-bench", "python": "3.14"}})
+
+
+def _client(bench_root: Path):
+    bench_root.mkdir(parents=True)
+    bench_root.joinpath("bench.toml").write_text(
+        BenchConfig.from_flat(bench_root.name, {"admin_password": "secret"}).dumps()
+    )
+    app = Flask(__name__)
+    app.config["BENCH_ROOT"] = bench_root
+    app.register_blueprint(settings_bp, url_prefix="/api/v1/settings")
+    return app.test_client()
+
+
+def test_patcher_updates_each_limit() -> None:
+    config = _config()
+
+    error = ConfigPatcher(
+        config,
+        {"resource_limits": {"cpu_usage_limit": 85, "memory_usage_limit": 75, "disk_space_limit": "90"}},
+    ).apply()
+
+    assert error is None
+    assert config.resource_limits.cpu_usage_limit == 85
+    assert config.resource_limits.memory_usage_limit == 75
+    assert config.resource_limits.disk_space_limit == 90
+
+
+def test_patcher_leaves_untouched_limits_alone() -> None:
+    config = _config()
+    config.resource_limits.memory_usage_limit = 70
+
+    ConfigPatcher(config, {"resource_limits": {"cpu_usage_limit": 85}}).apply()
+
+    assert config.resource_limits.memory_usage_limit == 70
+
+
+def test_patcher_rejects_out_of_range_percentage() -> None:
+    error = ConfigPatcher(_config(), {"resource_limits": {"cpu_usage_limit": 120}}).apply()
+
+    assert error == "resource_limits.cpu_usage_limit must be a percentage between 0 and 100."
+
+
+def test_patcher_rejects_non_numeric_limit() -> None:
+    error = ConfigPatcher(_config(), {"resource_limits": {"disk_space_limit": "abc"}}).apply()
+
+    assert error == "resource_limits.disk_space_limit must be a whole number."
+
+
+def test_settings_response_exposes_limits() -> None:
+    config = _config()
+    config.resource_limits.cpu_usage_limit = 85
+
+    assert build_settings_response(config)["resource_limits"] == {
+        "cpu_usage_limit": 85,
+        "memory_usage_limit": 0,
+        "disk_space_limit": 0,
+        "site_uptime": True,
+        "webhook_endpoints": [],
+    }
+
+
+def test_settings_response_never_returns_webhook_tokens() -> None:
+    config = _config()
+    config.resource_limits.webhook_endpoint = {"https://alerts.example.com/pilot": "tok-123"}
+
+    response = build_settings_response(config)["resource_limits"]
+
+    assert response["webhook_endpoints"] == [
+        {"url": "https://alerts.example.com/pilot", "token_set": True}
+    ]
+    assert "tok-123" not in str(response)
+
+
+def test_patch_persists_limits_to_common_config(tmp_path: Path) -> None:
+    """Alert limits describe the host, so they belong to every bench on it."""
+    benches_root = tmp_path / "benches"
+    bench_root = benches_root / "current"
+    client = _client(bench_root)
+
+    response = client.patch("/api/v1/settings", json={"resource_limits": {"cpu_usage_limit": 85}})
+
+    assert response.status_code == 200
+    assert CommonConfig.read(benches_root).resource_limits.cpu_usage_limit == 85
+    assert "resource_limits" not in bench_root.joinpath("bench.toml").read_text()
+    assert client.get("/api/v1/settings").get_json()["resource_limits"]["cpu_usage_limit"] == 85
+
+
+def test_patch_persists_webhooks_with_every_limit_off(tmp_path: Path) -> None:
+    """Webhooks and a disabled uptime alert are the whole configuration on a
+    host that only wants delivery changed, so the table still has to be written."""
+    benches_root = tmp_path / "benches"
+    client = _client(benches_root / "current")
+
+    response = client.patch(
+        "/api/v1/settings",
+        json={
+            "resource_limits": {
+                "site_uptime": False,
+                "webhook_endpoints": [
+                    {"url": "https://alerts.example.com/pilot", "token": "tok-123"}
+                ],
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    limits = CommonConfig.read(benches_root).resource_limits
+    assert limits.webhook_endpoint == {"https://alerts.example.com/pilot": "tok-123"}
+    assert limits.site_uptime is False
+
+
+def test_patch_keeps_stored_token_when_blank(tmp_path: Path) -> None:
+    benches_root = tmp_path / "benches"
+    client = _client(benches_root / "current")
+    endpoint = {"url": "https://alerts.example.com/pilot", "token": "tok-123"}
+    client.patch("/api/v1/settings", json={"resource_limits": {"webhook_endpoints": [endpoint]}})
+
+    client.patch(
+        "/api/v1/settings",
+        json={"resource_limits": {"webhook_endpoints": [{"url": endpoint["url"], "token": ""}]}},
+    )
+
+    stored = CommonConfig.read(benches_root).resource_limits.webhook_endpoint
+    assert stored == {"https://alerts.example.com/pilot": "tok-123"}
+
+
+def test_patch_rejects_plain_http_webhook(tmp_path: Path) -> None:
+    """The token rides in an Authorization header, so http would leak it."""
+    benches_root = tmp_path / "benches"
+    client = _client(benches_root / "current")
+
+    response = client.patch(
+        "/api/v1/settings",
+        json={
+            "resource_limits": {
+                "webhook_endpoints": [{"url": "http://alerts.example.com", "token": "tok"}]
+            }
+        },
+    )
+
+    assert response.status_code == 422
+    assert CommonConfig.read(benches_root).resource_limits.webhook_endpoint == {}
+
+
+def test_patch_rejects_invalid_limit_without_saving(tmp_path: Path) -> None:
+    benches_root = tmp_path / "benches"
+    bench_root = benches_root / "current"
+    client = _client(bench_root)
+    client.patch("/api/v1/settings", json={"resource_limits": {"cpu_usage_limit": 85}})
+
+    response = client.patch("/api/v1/settings", json={"resource_limits": {"memory_usage_limit": 120}})
+
+    assert response.status_code == 422
+    assert CommonConfig.read(benches_root).resource_limits.memory_usage_limit == 0
+    assert CommonConfig.read(benches_root).resource_limits.cpu_usage_limit == 85

--- a/tests/pilot/core/test_monitor.py
+++ b/tests/pilot/core/test_monitor.py
@@ -1,6 +1,6 @@
 import json
 import urllib.error
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import PropertyMock, patch
@@ -9,7 +9,7 @@ import psutil
 import pytest
 
 from pilot.config import BenchConfig, MariaDBConfig, RedisConfig, WorkerConfig
-from pilot.core.alerts import ALERT_SUSTAINED_SECONDS, ALERT_TIMEOUT_SECONDS, send_alert
+from pilot.core.alerts import ALERT_SUSTAINED_SECONDS, ALERT_TIMEOUT_SECONDS, notify, send_alert
 from pilot.core.bench import Bench
 from pilot.core.server.monitoring import Monitor, MonitorConfigurator
 from pilot.core.server.monitoring_proc import CPU_STAT_FIELDS
@@ -307,14 +307,24 @@ def _alerting_monitor(tmp_path: Path, **limits: int) -> Monitor:
     # MonitorConfigurator.setup() makes this directory on a real host, and it
     # is patched out here.
     monitor.alerts_path.parent.mkdir(parents=True, exist_ok=True)
-    monitor._sent = []
-
-    def _record_delivered(breached, system_record):
-        monitor._sent.append(breached)
-        return True
-
-    monitor._send_alert = _record_delivered  # type: ignore[method-assign]
+    bench.config.resource_limits.webhook_endpoints = {"https://alerts.example.com": "tok"}
     return monitor
+
+
+@contextmanager
+def _captured_alerts():
+    """Collect what reaches the webhook sink. Central is not enrolled on a bare
+    test config, so notify() falls through to the webhooks alone."""
+    payloads: list[dict] = []
+    with patch(
+        "pilot.core.alerts.send_alert",
+        lambda endpoint, token, payload: payloads.append(payload),
+    ):
+        yield payloads
+
+
+def _breached(payloads: list[dict]) -> list[list[str]]:
+    return [[item["limit"] for item in payload["context"]["breached_limits"]] for payload in payloads]
 
 
 def _system_record(cpu: float = 10.0, memory: float = 10.0, disk: float = 10.0) -> dict:
@@ -329,9 +339,10 @@ def _system_record(cpu: float = 10.0, memory: float = 10.0, disk: float = 10.0) 
 def test_alert_waits_for_the_breach_to_be_sustained(tmp_path: Path) -> None:
     monitor = _alerting_monitor(tmp_path, cpu_usage_limit=80)
 
-    monitor.send_alert_if_required(_system_record(cpu=95.0))
+    with _captured_alerts() as payloads:
+        monitor.send_alert_if_required(_system_record(cpu=95.0))
 
-    assert monitor._sent == []
+    assert payloads == []
     assert list(json.loads(monitor.alerts_path.read_text())) == ["cpu_usage_limit"]
 
 
@@ -340,10 +351,13 @@ def test_alert_fires_once_the_breach_outlives_the_window(tmp_path: Path) -> None
     monitor.send_alert_if_required(_system_record(cpu=95.0))
     _age_alerts(monitor)
 
-    monitor.send_alert_if_required(_system_record(cpu=95.0))
-    monitor.send_alert_if_required(_system_record(cpu=95.0))
+    with _captured_alerts() as payloads:
+        monitor.send_alert_if_required(_system_record(cpu=95.0))
+        monitor.send_alert_if_required(_system_record(cpu=95.0))
 
-    assert monitor._sent == [["cpu_usage_limit"]], "a sustained breach alerts once, not every tick"
+    assert _breached(payloads) == [["cpu_usage_limit"]], (
+        "a sustained breach alerts once, not every tick"
+    )
 
 
 def test_alert_covers_only_the_limits_the_operator_set(tmp_path: Path) -> None:
@@ -352,20 +366,22 @@ def test_alert_covers_only_the_limits_the_operator_set(tmp_path: Path) -> None:
     monitor.send_alert_if_required(_system_record(cpu=95.0, memory=99.0))
     _age_alerts(monitor)
 
-    monitor.send_alert_if_required(_system_record(cpu=95.0, memory=99.0))
+    with _captured_alerts() as payloads:
+        monitor.send_alert_if_required(_system_record(cpu=95.0, memory=99.0))
 
-    assert monitor._sent == [["cpu_usage_limit"]]
+    assert _breached(payloads) == [["cpu_usage_limit"]]
 
 
 def test_recovering_below_the_threshold_clears_the_alerts_file(tmp_path: Path) -> None:
     monitor = _alerting_monitor(tmp_path, cpu_usage_limit=80, disk_space_limit=90)
-    monitor.send_alert_if_required(_system_record(cpu=95.0, disk=95.0))
 
-    monitor.send_alert_if_required(_system_record(cpu=95.0, disk=10.0))
+    with _captured_alerts():
+        monitor.send_alert_if_required(_system_record(cpu=95.0, disk=95.0))
+        monitor.send_alert_if_required(_system_record(cpu=95.0, disk=10.0))
 
-    assert list(json.loads(monitor.alerts_path.read_text())) == ["cpu_usage_limit"]
+        assert list(json.loads(monitor.alerts_path.read_text())) == ["cpu_usage_limit"]
 
-    monitor.send_alert_if_required(_system_record(cpu=10.0, disk=10.0))
+        monitor.send_alert_if_required(_system_record(cpu=10.0, disk=10.0))
 
     assert not monitor.alerts_path.exists(), "nothing breaching means no file to keep"
 
@@ -376,16 +392,18 @@ def test_a_recovered_limit_starts_its_window_over(tmp_path: Path) -> None:
     _age_alerts(monitor)
     monitor.send_alert_if_required(_system_record(cpu=10.0))
 
-    monitor.send_alert_if_required(_system_record(cpu=95.0))
+    with _captured_alerts() as payloads:
+        monitor.send_alert_if_required(_system_record(cpu=95.0))
 
-    assert monitor._sent == [], "the second breach has to sustain on its own before alerting"
+    assert payloads == [], "the second breach has to sustain on its own before alerting"
 
 
 def test_a_corrupt_alerts_file_does_not_stop_the_tick(tmp_path: Path) -> None:
     monitor = _alerting_monitor(tmp_path, cpu_usage_limit=80)
     monitor.alerts_path.write_text("not json")
 
-    monitor.send_alert_if_required(_system_record(cpu=95.0))
+    with _captured_alerts():
+        monitor.send_alert_if_required(_system_record(cpu=95.0))
 
     assert list(json.loads(monitor.alerts_path.read_text())) == ["cpu_usage_limit"]
 
@@ -447,7 +465,6 @@ def test_alert_reaches_every_webhook_even_when_one_is_down(tmp_path: Path) -> No
         "https://down.example.com": "tok-a",
         "https://up.example.com": "tok-b",
     }
-    monitor = _make_monitor(bench)
     reached = []
 
     def fake_send(endpoint, token, payload):
@@ -456,22 +473,22 @@ def test_alert_reaches_every_webhook_even_when_one_is_down(tmp_path: Path) -> No
         reached.append(endpoint)
 
     with patch("pilot.core.alerts.send_alert", fake_send):
-        monitor._send_alert(["cpu_usage_limit"], _system_record(cpu=95.0))
+        delivered = notify(bench, {"event": "x", "message": "m", "context": {}})
 
     assert reached == ["https://up.example.com"]
+    assert delivered is True, "one sink answering is a delivered alert"
 
 
-def test_alert_reaches_the_configured_webhook(tmp_path: Path) -> None:
+def test_an_alert_no_sink_accepted_is_not_delivered(tmp_path: Path) -> None:
+    """The caller marks the condition notified off this, so a round where
+    everything was down must not count."""
     bench = _make_bench(tmp_path / "my-bench")
-    bench.config.resource_limits.cpu_usage_limit = 80
-    bench.config.resource_limits.webhook_endpoints = {"https://up.example.com": "tok"}
-    monitor = _make_monitor(bench)
-    reached = []
+    bench.config.resource_limits.webhook_endpoints = {"https://down.example.com": "tok"}
 
-    with patch(
-        "pilot.core.alerts.send_alert",
-        lambda endpoint, token, payload: reached.append(endpoint),
-    ):
-        monitor._send_alert(["cpu_usage_limit"], _system_record(cpu=95.0))
+    def refuse(endpoint, token, payload):
+        raise urllib.error.URLError("connection refused")
 
-    assert reached == ["https://up.example.com"]
+    with patch("pilot.core.alerts.send_alert", refuse):
+        delivered = notify(bench, {"event": "x", "message": "m", "context": {}})
+
+    assert delivered is False

--- a/tests/pilot/core/test_monitor.py
+++ b/tests/pilot/core/test_monitor.py
@@ -1,4 +1,6 @@
 import json
+import urllib.error
+from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import PropertyMock, patch
@@ -7,6 +9,7 @@ import psutil
 import pytest
 
 from pilot.config import BenchConfig, MariaDBConfig, RedisConfig, WorkerConfig
+from pilot.core.alerts import ALERT_SUSTAINED_SECONDS, ALERT_TIMEOUT_SECONDS, send_alert
 from pilot.core.bench import Bench
 from pilot.core.server.monitoring import Monitor, MonitorConfigurator
 from pilot.core.server.monitoring_proc import CPU_STAT_FIELDS
@@ -294,3 +297,176 @@ def test_collect_application_metrics_marks_a_vanished_process_missing(tmp_path: 
 
     entry = json.loads(app_log.read_text().splitlines()[-1])
     assert entry["processes"] == [{"service": "web", "pid": 4242, "missing": True}]
+
+
+def _alerting_monitor(tmp_path: Path, **limits: int) -> Monitor:
+    bench = _make_bench(tmp_path / "my-bench")
+    for name, value in limits.items():
+        setattr(bench.config.resource_limits, name, value)
+    monitor = _make_monitor(bench)
+    # MonitorConfigurator.setup() makes this directory on a real host, and it
+    # is patched out here.
+    monitor.alerts_path.parent.mkdir(parents=True, exist_ok=True)
+    monitor._sent = []
+    monitor._send_alert = lambda breached, record: monitor._sent.append(breached)  # type: ignore[method-assign]
+    return monitor
+
+
+def _system_record(cpu: float = 10.0, memory: float = 10.0, disk: float = 10.0) -> dict:
+    return {
+        "time": "2026-08-10T12:00:00+00:00",
+        "cpu_percent": cpu,
+        "memory": {"percent": memory},
+        "storage": {"disk": {"percent": disk}},
+    }
+
+
+def test_alert_waits_for_the_breach_to_be_sustained(tmp_path: Path) -> None:
+    monitor = _alerting_monitor(tmp_path, cpu_usage_limit=80)
+
+    monitor.send_alert_if_required(_system_record(cpu=95.0))
+
+    assert monitor._sent == []
+    assert list(json.loads(monitor.alerts_path.read_text())) == ["cpu_usage_limit"]
+
+
+def test_alert_fires_once_the_breach_outlives_the_window(tmp_path: Path) -> None:
+    monitor = _alerting_monitor(tmp_path, cpu_usage_limit=80)
+    monitor.send_alert_if_required(_system_record(cpu=95.0))
+    _age_alerts(monitor)
+
+    monitor.send_alert_if_required(_system_record(cpu=95.0))
+    monitor.send_alert_if_required(_system_record(cpu=95.0))
+
+    assert monitor._sent == [["cpu_usage_limit"]], "a sustained breach alerts once, not every tick"
+
+
+def test_alert_covers_only_the_limits_the_operator_set(tmp_path: Path) -> None:
+    """Memory is over 90% here but has no configured limit, so it is not an alert."""
+    monitor = _alerting_monitor(tmp_path, cpu_usage_limit=80)
+    monitor.send_alert_if_required(_system_record(cpu=95.0, memory=99.0))
+    _age_alerts(monitor)
+
+    monitor.send_alert_if_required(_system_record(cpu=95.0, memory=99.0))
+
+    assert monitor._sent == [["cpu_usage_limit"]]
+
+
+def test_recovering_below_the_threshold_clears_the_alerts_file(tmp_path: Path) -> None:
+    monitor = _alerting_monitor(tmp_path, cpu_usage_limit=80, disk_space_limit=90)
+    monitor.send_alert_if_required(_system_record(cpu=95.0, disk=95.0))
+
+    monitor.send_alert_if_required(_system_record(cpu=95.0, disk=10.0))
+
+    assert list(json.loads(monitor.alerts_path.read_text())) == ["cpu_usage_limit"]
+
+    monitor.send_alert_if_required(_system_record(cpu=10.0, disk=10.0))
+
+    assert not monitor.alerts_path.exists(), "nothing breaching means no file to keep"
+
+
+def test_a_recovered_limit_starts_its_window_over(tmp_path: Path) -> None:
+    monitor = _alerting_monitor(tmp_path, cpu_usage_limit=80)
+    monitor.send_alert_if_required(_system_record(cpu=95.0))
+    _age_alerts(monitor)
+    monitor.send_alert_if_required(_system_record(cpu=10.0))
+
+    monitor.send_alert_if_required(_system_record(cpu=95.0))
+
+    assert monitor._sent == [], "the second breach has to sustain on its own before alerting"
+
+
+def test_a_corrupt_alerts_file_does_not_stop_the_tick(tmp_path: Path) -> None:
+    monitor = _alerting_monitor(tmp_path, cpu_usage_limit=80)
+    monitor.alerts_path.write_text("not json")
+
+    monitor.send_alert_if_required(_system_record(cpu=95.0))
+
+    assert list(json.loads(monitor.alerts_path.read_text())) == ["cpu_usage_limit"]
+
+
+def _age_alerts(monitor: Monitor) -> None:
+    """Push every recorded breach back past the sustain window."""
+    state = json.loads(monitor.alerts_path.read_text())
+    for entry in state.values():
+        entry["since"] -= ALERT_SUSTAINED_SECONDS + 1
+    monitor.alerts_path.write_text(json.dumps(state))
+
+
+def test_alert_body_matches_centrals_event_schema(tmp_path: Path) -> None:
+    """Central's report_pilot_event takes event/message/context, and the webhook
+    sinks get the identical body."""
+    bench = _make_bench(tmp_path / "my-bench")
+    bench.config.resource_limits.cpu_usage_limit = 80
+    monitor = _make_monitor(bench)
+
+    payload = monitor._alert_payload(["cpu_usage_limit"], _system_record(cpu=95.0))
+
+    assert set(payload) == {"event", "message", "context"}
+    assert payload["event"] == "resource_limit_breached"
+    assert payload["message"] == "my-bench: cpu_usage_limit at 95.0%"
+    assert payload["context"]["breached_limits"] == [
+        {"limit": "cpu_usage_limit", "threshold": 80, "reading": 95.0}
+    ]
+    assert payload["context"]["bench"] == "my-bench"
+    json.dumps(payload)
+
+
+def test_send_alert_posts_json_with_a_bearer_token() -> None:
+    captured = {}
+
+    def fake_urlopen(request, timeout=None):
+        captured["url"] = request.full_url
+        captured["method"] = request.get_method()
+        captured["body"] = json.loads(request.data.decode())
+        captured["auth"] = request.get_header("Authorization")
+        captured["type"] = request.get_header("Content-type")
+        captured["timeout"] = timeout
+        return nullcontext()
+
+    with patch("urllib.request.urlopen", fake_urlopen):
+        send_alert("https://alerts.example.com/pilot", "tok-123", {"event": "x", "context": {}})
+
+    assert captured["url"] == "https://alerts.example.com/pilot"
+    assert captured["method"] == "POST", "urllib sends the verb verbatim, so it has to be upper case"
+    assert captured["body"] == {"event": "x", "context": {}}
+    assert captured["auth"] == "Bearer tok-123"
+    assert captured["type"] == "application/json"
+    assert captured["timeout"] == ALERT_TIMEOUT_SECONDS
+
+
+def test_alert_reaches_every_webhook_even_when_one_is_down(tmp_path: Path) -> None:
+    bench = _make_bench(tmp_path / "my-bench")
+    bench.config.resource_limits.cpu_usage_limit = 80
+    bench.config.resource_limits.webhook_endpoints = {
+        "https://down.example.com": "tok-a",
+        "https://up.example.com": "tok-b",
+    }
+    monitor = _make_monitor(bench)
+    reached = []
+
+    def fake_send(endpoint, token, payload):
+        if endpoint == "https://down.example.com":
+            raise urllib.error.URLError("connection refused")
+        reached.append(endpoint)
+
+    with patch("pilot.core.alerts.send_alert", fake_send):
+        monitor._send_alert(["cpu_usage_limit"], _system_record(cpu=95.0))
+
+    assert reached == ["https://up.example.com"]
+
+
+def test_alert_reaches_the_configured_webhook(tmp_path: Path) -> None:
+    bench = _make_bench(tmp_path / "my-bench")
+    bench.config.resource_limits.cpu_usage_limit = 80
+    bench.config.resource_limits.webhook_endpoints = {"https://up.example.com": "tok"}
+    monitor = _make_monitor(bench)
+    reached = []
+
+    with patch(
+        "pilot.core.alerts.send_alert",
+        lambda endpoint, token, payload: reached.append(endpoint),
+    ):
+        monitor._send_alert(["cpu_usage_limit"], _system_record(cpu=95.0))
+
+    assert reached == ["https://up.example.com"]

--- a/tests/pilot/core/test_monitor.py
+++ b/tests/pilot/core/test_monitor.py
@@ -308,7 +308,12 @@ def _alerting_monitor(tmp_path: Path, **limits: int) -> Monitor:
     # is patched out here.
     monitor.alerts_path.parent.mkdir(parents=True, exist_ok=True)
     monitor._sent = []
-    monitor._send_alert = lambda breached, record: monitor._sent.append(breached)  # type: ignore[method-assign]
+
+    def _record_delivered(breached, system_record):
+        monitor._sent.append(breached)
+        return True
+
+    monitor._send_alert = _record_delivered  # type: ignore[method-assign]
     return monitor
 
 

--- a/tests/pilot/core/test_site_uptime_alerts.py
+++ b/tests/pilot/core/test_site_uptime_alerts.py
@@ -1,0 +1,133 @@
+"""Tests for the site-down incident alerts raised by the uptime monitor."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from pilot.config import BenchConfig, MariaDBConfig, RedisConfig, WorkerConfig
+from pilot.core.alerts import ALERT_SUSTAINED_SECONDS
+from pilot.core.bench import Bench
+from pilot.core.site.uptime_monitoring import UptimeMonitor
+
+
+def _monitor(tmp_path: Path, *, alerting: bool = True, webhooks: dict | None = None) -> UptimeMonitor:
+    config = BenchConfig(
+        name="my-bench",
+        python_version="3.14",
+        mariadb=MariaDBConfig(),
+        redis=RedisConfig(),
+        workers=WorkerConfig(),
+    )
+    config.resource_limits.site_uptime = alerting
+    config.resource_limits.webhook_endpoints = webhooks or {"https://alerts.example.com": "tok"}
+    monitor = UptimeMonitor(Bench(config, tmp_path / "my-bench"))
+    monitor.alerts_path.parent.mkdir(parents=True, exist_ok=True)
+    return monitor
+
+
+def _ping(site: str, up: bool) -> dict:
+    return {
+        "time": "2026-08-10T12:00:00+00:00",
+        "site": site,
+        "up": up,
+        "status_code": 200 if up else 502,
+        "response_ms": 12,
+    }
+
+
+def _age_alerts(monitor: UptimeMonitor) -> None:
+    state = json.loads(monitor.alerts_path.read_text())
+    for entry in state.values():
+        entry["since"] -= ALERT_SUSTAINED_SECONDS + 1
+    monitor.alerts_path.write_text(json.dumps(state))
+
+
+def test_a_single_failed_ping_is_not_an_incident(tmp_path: Path) -> None:
+    monitor = _monitor(tmp_path)
+    sent = []
+
+    with patch("pilot.core.alerts.send_alert", lambda *args: sent.append(args)):
+        monitor.send_alert_if_required([_ping("a.test", up=False)])
+
+    assert sent == []
+    assert list(json.loads(monitor.alerts_path.read_text())) == ["a.test"]
+
+
+def test_a_site_down_for_the_whole_window_alerts_once(tmp_path: Path) -> None:
+    monitor = _monitor(tmp_path)
+    monitor.send_alert_if_required([_ping("a.test", up=False)])
+    _age_alerts(monitor)
+    payloads = []
+
+    with patch("pilot.core.alerts.send_alert", lambda endpoint, token, payload: payloads.append(payload)):
+        monitor.send_alert_if_required([_ping("a.test", up=False)])
+        monitor.send_alert_if_required([_ping("a.test", up=False)])
+
+    assert len(payloads) == 1
+    assert payloads[0]["event"] == "site_down"
+    assert payloads[0]["message"] == "my-bench: a.test unreachable"
+    assert payloads[0]["context"]["sites"] == [
+        {"site": "a.test", "status_code": 502, "response_ms": 12}
+    ]
+
+
+def test_only_the_sites_still_down_are_reported(tmp_path: Path) -> None:
+    monitor = _monitor(tmp_path)
+    monitor.send_alert_if_required([_ping("a.test", up=False), _ping("b.test", up=False)])
+    _age_alerts(monitor)
+    payloads = []
+
+    with patch("pilot.core.alerts.send_alert", lambda endpoint, token, payload: payloads.append(payload)):
+        monitor.send_alert_if_required([_ping("a.test", up=False), _ping("b.test", up=True)])
+
+    assert [site["site"] for site in payloads[0]["context"]["sites"]] == ["a.test"]
+    assert list(json.loads(monitor.alerts_path.read_text())) == ["a.test"]
+
+
+def test_every_site_recovering_removes_the_alerts_file(tmp_path: Path) -> None:
+    monitor = _monitor(tmp_path)
+    monitor.send_alert_if_required([_ping("a.test", up=False)])
+
+    monitor.send_alert_if_required([_ping("a.test", up=True)])
+
+    assert not monitor.alerts_path.exists()
+
+
+def test_alerts_go_only_to_the_configured_endpoints(tmp_path: Path) -> None:
+    monitor = _monitor(tmp_path, webhooks={"https://one.test": "a", "https://two.test": "b"})
+    monitor.send_alert_if_required([_ping("a.test", up=False)])
+    _age_alerts(monitor)
+    reached = []
+
+    with patch("pilot.core.alerts.send_alert", lambda endpoint, token, payload: reached.append(endpoint)):
+        monitor.send_alert_if_required([_ping("a.test", up=False)])
+
+    assert reached == ["https://one.test", "https://two.test"]
+
+
+def test_no_alerts_when_uptime_alerting_is_switched_off(tmp_path: Path) -> None:
+    monitor = _monitor(tmp_path, alerting=False)
+    sent = []
+
+    with patch("pilot.core.alerts.send_alert", lambda *args: sent.append(args)):
+        monitor.send_alert_if_required([_ping("a.test", up=False)])
+        _age = monitor.alerts_path.exists()
+        monitor.send_alert_if_required([_ping("a.test", up=False)])
+
+    assert sent == []
+    assert not _age, "a disabled alert keeps no window state to go stale"
+
+
+def test_collect_logs_every_ping_and_then_alerts(tmp_path: Path) -> None:
+    monitor = _monitor(tmp_path)
+    monitor._configurator.log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with (
+        patch.object(UptimeMonitor, "get_sites", return_value=["a.test"]),
+        patch.object(UptimeMonitor, "ping_site", return_value=_ping("a.test", up=False)),
+    ):
+        monitor.collect()
+
+    logged = json.loads(monitor._configurator.log_path.read_text().splitlines()[-1])
+    assert logged["site"] == "a.test"
+    assert list(json.loads(monitor.alerts_path.read_text())) == ["a.test"]

--- a/tests/pilot/core/test_site_uptime_alerts.py
+++ b/tests/pilot/core/test_site_uptime_alerts.py
@@ -66,9 +66,7 @@ def test_a_site_down_for_the_whole_window_alerts_once(tmp_path: Path) -> None:
     assert len(payloads) == 1
     assert payloads[0]["event"] == "site_down"
     assert payloads[0]["message"] == "my-bench: a.test unreachable"
-    assert payloads[0]["context"]["sites"] == [
-        {"site": "a.test", "status_code": 502, "response_ms": 12}
-    ]
+    assert payloads[0]["context"]["sites"] == [{"site": "a.test", "status_code": 502, "response_ms": 12}]
 
 
 def test_only_the_sites_still_down_are_reported(tmp_path: Path) -> None:
@@ -131,3 +129,26 @@ def test_collect_logs_every_ping_and_then_alerts(tmp_path: Path) -> None:
     logged = json.loads(monitor._configurator.log_path.read_text().splitlines()[-1])
     assert logged["site"] == "a.test"
     assert list(json.loads(monitor.alerts_path.read_text())) == ["a.test"]
+
+
+def test_an_undelivered_alert_is_retried_on_the_next_tick(tmp_path: Path) -> None:
+    """Every sink being down is not a delivered alert, so the incident must not
+    be marked notified and silently forgotten."""
+    monitor = _monitor(tmp_path)
+    monitor.send_alert_if_required([_ping("a.test", up=False)])
+    _age_alerts(monitor)
+
+    def refuse(endpoint, token, payload):
+        raise OSError("connection refused")
+
+    with patch("pilot.core.alerts.send_alert", refuse):
+        monitor.send_alert_if_required([_ping("a.test", up=False)])
+
+    assert json.loads(monitor.alerts_path.read_text())["a.test"]["notified"] is False
+
+    delivered = []
+    with patch("pilot.core.alerts.send_alert", lambda endpoint, token, payload: delivered.append(endpoint)):
+        monitor.send_alert_if_required([_ping("a.test", up=False)])
+
+    assert delivered == ["https://alerts.example.com"]
+    assert json.loads(monitor.alerts_path.read_text())["a.test"]["notified"] is True


### PR DESCRIPTION
- Allow users to setup custom alerts for system metrics.
- Allow users to setup alerts for site uptime.
- Notify central and the configured web hooks for the user.
- Once a notification has been sent we will mark the sustained alert as notified.

### System Alerts
```json
{
            "event": ALERT_EVENT,
            "message": f"{self.bench.config.name}: {summary}",
            "context": {
                "bench": self.bench.config.name,
                "time": system_record["time"],
                "sustained_seconds": ALERT_SUSTAINED_SECONDS,
                "breached_limits": crossed
            }
}
```

### Site Down Alerts
```json
{
            "event": SITE_DOWN_EVENT,
            "message": f"{self.bench.config.name}: {', '.join(down)} unreachable",
            "context": {
                "bench": self.bench.config.name,
                "time": datetime.now(UTC).isoformat(),
                "sustained_seconds": ALERT_SUSTAINED_SECONDS,
                "sites": sites
            }
}

```
       