### PR TITLE
feat(mariadb): View and tune MariaDB variables

### DIFF
--- a/admin/backend/api/v1/databases.py
+++ b/admin/backend/api/v1/databases.py
@@ -9,10 +9,12 @@ from flask.typing import ResponseReturnValue
 from admin.backend.api.responses import accepted_task_response, error_response
 from admin.backend.api.v1.benches.support import guard_bench_management
 from pilot.core.bench import Bench
+from pilot.core.database.configurations import DatabaseConfigurations
 from pilot.core.database.quick_actions import DatabaseQuickActions
 from pilot.exceptions import DatabaseError, TaskConflictError
 from pilot.tasks.restart_database import RestartDatabaseTask
 from pilot.tasks.set_innodb_buffer_pool_size import SetInnoDBBufferPoolSizeTask
+from pilot.tasks.set_mariadb_configuration import SetMariaDBConfigurationTask
 from pilot.tasks.set_max_database_connections import SetMaxDatabaseConnectionsTask
 from pilot.tasks.set_performance_schema import SetPerformanceSchemaTask
 
@@ -26,6 +28,10 @@ def _bench() -> Bench:
 
 def _quick_actions() -> DatabaseQuickActions:
     return DatabaseQuickActions(_bench().config)
+
+
+def _configurations() -> DatabaseConfigurations:
+    return DatabaseConfigurations(_bench().config)
 
 
 @database_bp.get("/sites")
@@ -115,6 +121,64 @@ def get_quick_actions():
         return error_response("quick_actions_unavailable", str(exc), 422)
     except Exception:
         return error_response("quick_actions_unavailable", "Could not read quick actions.", 500)
+
+
+@database_bp.get("/configurations")
+def get_database_configurations():
+    try:
+        return jsonify(_configurations().snapshot())
+    except DatabaseError as exc:
+        return error_response("database_configurations_unavailable", str(exc), 422)
+    except Exception:
+        return error_response(
+            "database_configurations_unavailable",
+            "Could not read database configurations.",
+            500,
+        )
+
+
+@database_bp.post("/configurations/<variable>")
+def set_database_configuration(variable: str):
+    forbidden = guard_bench_management()
+    if forbidden is not None:
+        return forbidden
+
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict) or set(data) != {"value"}:
+        return error_response(
+            "invalid_database_configuration",
+            "The request must contain exactly one value field.",
+            422,
+        )
+
+    try:
+        configurations = _configurations()
+        change = configurations.prepare_change(variable, data["value"])
+        if not change["changed"]:
+            return error_response(
+                "database_configuration_unchanged",
+                f"MariaDB variable '{variable}' already has the requested value.",
+                409,
+            )
+        bench = _bench()
+        task_id = SetMariaDBConfigurationTask.queue(
+            bench,
+            variable=variable,
+            value_json=json.dumps(change["value"], separators=(",", ":")),
+            idempotency_key=request.headers.get("Idempotency-Key"),
+            resource_key=_DATABASE_RESOURCE_KEY,
+        )
+        return accepted_task_response(bench.path, task_id)
+    except ValueError as exc:
+        return error_response("invalid_database_configuration", str(exc), 422)
+    except (DatabaseError, TaskConflictError) as exc:
+        return error_response("database_configuration_unavailable", str(exc), 409)
+    except Exception:
+        return error_response(
+            "database_configuration_failed",
+            "Could not queue the database configuration change.",
+            500,
+        )
 
 
 @database_bp.post("/quick-actions/restart")

--- a/admin/backend/api/v1/databases.py
+++ b/admin/backend/api/v1/databases.py
@@ -9,7 +9,10 @@ from flask.typing import ResponseReturnValue
 from admin.backend.api.responses import accepted_task_response, error_response
 from admin.backend.api.v1.benches.support import guard_bench_management
 from pilot.core.bench import Bench
-from pilot.core.database.configurations import DatabaseConfigurations
+from pilot.core.database.configurations import (
+    DatabaseConfigurationChange,
+    DatabaseConfigurations,
+)
 from pilot.core.database.quick_actions import DatabaseQuickActions
 from pilot.exceptions import DatabaseError, TaskConflictError
 from pilot.tasks.restart_database import RestartDatabaseTask
@@ -32,6 +35,53 @@ def _quick_actions() -> DatabaseQuickActions:
 
 def _configurations() -> DatabaseConfigurations:
     return DatabaseConfigurations(_bench().config)
+
+
+def _queue_configuration_change(
+    bench: Bench,
+    change: DatabaseConfigurationChange,
+    idempotency_key: str | None,
+) -> str:
+    action = change["action"]
+    if action == "configuration":
+        return SetMariaDBConfigurationTask.queue(
+            bench,
+            variable=change["name"],
+            value_json=json.dumps(change["value"], separators=(",", ":")),
+            idempotency_key=idempotency_key,
+            resource_key=_DATABASE_RESOURCE_KEY,
+        )
+    if action == "performance_schema":
+        enabled = change["value"]
+        if type(enabled) is not bool:
+            raise ValueError("Performance Schema must be either enabled or disabled.")
+        return SetPerformanceSchemaTask.queue(
+            bench,
+            state="enabled" if enabled else "disabled",
+            idempotency_key=idempotency_key,
+            resource_key=_DATABASE_RESOURCE_KEY,
+        )
+    if action == "innodb_buffer_pool_size":
+        size_mb = change["value"]
+        if type(size_mb) is not int:
+            raise ValueError("InnoDB Buffer Pool size must be a whole number.")
+        return SetInnoDBBufferPoolSizeTask.queue(
+            bench,
+            size_mb=size_mb,
+            idempotency_key=idempotency_key,
+            resource_key=_DATABASE_RESOURCE_KEY,
+        )
+    if action == "max_connections":
+        max_connections = change["value"]
+        if type(max_connections) is not int:
+            raise ValueError("Maximum connections must be a whole number.")
+        return SetMaxDatabaseConnectionsTask.queue(
+            bench,
+            max_connections=max_connections,
+            idempotency_key=idempotency_key,
+            resource_key=_DATABASE_RESOURCE_KEY,
+        )
+    raise ValueError(f"Unknown database configuration action '{action}'.")
 
 
 @database_bp.get("/sites")
@@ -161,12 +211,10 @@ def set_database_configuration(variable: str):
                 409,
             )
         bench = _bench()
-        task_id = SetMariaDBConfigurationTask.queue(
+        task_id = _queue_configuration_change(
             bench,
-            variable=variable,
-            value_json=json.dumps(change["value"], separators=(",", ":")),
-            idempotency_key=request.headers.get("Idempotency-Key"),
-            resource_key=_DATABASE_RESOURCE_KEY,
+            change,
+            request.headers.get("Idempotency-Key"),
         )
         return accepted_task_response(bench.path, task_id)
     except ValueError as exc:

--- a/admin/frontend/dashboard/src/api/database.js
+++ b/admin/frontend/dashboard/src/api/database.js
@@ -40,6 +40,17 @@ export const databaseApi = {
       request.post("database/binlogs/purge", { json: { up_to: upTo } }).json(),
   },
 
+  configurations: {
+    list: () => request.get("database/configurations").json(),
+    set: (variable, value, idempotencyKey) =>
+      request
+        .post(`database/configurations/${encodeURIComponent(variable)}`, {
+          json: { value },
+          headers: { "Idempotency-Key": idempotencyKey },
+        })
+        .json(),
+  },
+
   quickActions: {
     capabilities: () => request.get("database/quick-actions").json(),
     restart: (idempotencyKey) =>

--- a/admin/frontend/dashboard/src/components/settings/Database.vue
+++ b/admin/frontend/dashboard/src/components/settings/Database.vue
@@ -1,10 +1,32 @@
 <template>
-  <SettingsSectionRows v-model:open-section="openSection" :sections="sections" />
+  <component v-if="openSection" :is="openSection.component" />
+
+  <template v-else>
+    <section>
+      <h4 class="mb-1 font-medium text-ink-gray-6">Database actions</h4>
+      <DatabaseQuickActions />
+    </section>
+
+    <div class="mt-6 border-t border-outline-alpha-gray-1">
+      <SettingsRow
+        as="button"
+        interactive
+        :label="configurationSection.label"
+        :description="configurationSection.description"
+        @click="openSection = configurationSection"
+        class="!ps-0"
+      >
+        <span class="size-4 text-ink-gray-5 lucide-chevron-right" aria-hidden="true" />
+      </SettingsRow>
+    </div>
+  </template>
 </template>
 
 <script setup>
-import SettingsSectionRows from '@/components/settings/SettingsSectionRows.vue'
-import { DATABASE_SECTIONS as sections } from '@/components/settings/sections'
+import DatabaseQuickActions from '@/components/settings/DatabaseQuickActions.vue'
+import SettingsRow from '@/components/settings/SettingsRow.vue'
+import { DATABASE_SECTIONS } from '@/components/settings/sections'
 
 const openSection = defineModel('openSection')
+const configurationSection = DATABASE_SECTIONS.find((section) => section.id === 'configurations')
 </script>

--- a/admin/frontend/dashboard/src/components/settings/Database.vue
+++ b/admin/frontend/dashboard/src/components/settings/Database.vue
@@ -7,7 +7,7 @@
       <DatabaseQuickActions />
     </section>
 
-    <div class="mt-6 border-t border-outline-alpha-gray-1">
+    <div class="mt-2 border-t rounded border-outline-alpha-gray-1">
       <SettingsRow
         as="button"
         interactive

--- a/admin/frontend/dashboard/src/components/settings/DatabaseConfigurations.vue
+++ b/admin/frontend/dashboard/src/components/settings/DatabaseConfigurations.vue
@@ -90,52 +90,59 @@
     </template>
   </div>
 
-  <Dialog v-model="editorOpen" :options="editorOptions">
-    <template #body-content>
-      <div v-if="editing" class="space-y-4">
-        <div
-          v-if="editing.value_type === 'boolean'"
-          class="flex items-center justify-between gap-4"
-        >
-          <p class="font-medium text-ink-gray-8 text-base">Enabled</p>
-          <Switch
-            class="[&_[data-slot='label']]:sr-only [&>div]:!gap-x-0 [&>div]:!py-0"
-            :label="editing.name"
-            :model-value="Boolean(draftValue)"
-            @update:model-value="(value) => (draftValue = value)"
-          />
-        </div>
-        <FormControl
-          v-else
-          v-model.number="draftValue"
-          type="number"
-          :label="inputLabel"
-          :min="editing.min"
-          :max="editing.max"
-          :step="editing.step || 1"
-          autocomplete="off"
+  <Dialog
+    v-model="editorOpen"
+    :title="editing ? `Update ${editing.name}` : 'Update database configuration'"
+    size="sm"
+  >
+    <div v-if="editing && editor" class="space-y-4">
+      <div v-if="editor.value_type === 'boolean'" class="flex items-center justify-between gap-4">
+        <p class="font-medium text-ink-gray-8 text-base">Enabled</p>
+        <Switch
+          class="[&_[data-slot='label']]:sr-only [&>div]:!gap-x-0 [&>div]:!py-0"
+          :label="editing.name"
+          :model-value="Boolean(draftValue)"
+          @update:model-value="(value) => (draftValue = value)"
         />
-
-        <p v-if="editing.value_type === 'integer'" class="text-ink-gray-6 text-sm">
-          Allowed: {{ formatConstraint(editing.min, editing.unit) }} to
-          {{ formatConstraint(editing.max, editing.unit) }}
-        </p>
-        <ErrorMessage v-if="validationError" :message="validationError" />
-        <ErrorMessage v-if="saveError" :message="saveError" />
-
-        <div class="flex justify-end gap-2">
-          <Button variant="ghost" :disabled="saving" @click="editorOpen = false"> Cancel </Button>
-          <Button
-            variant="solid"
-            :loading="saving"
-            :disabled="Boolean(validationError) || unchanged"
-            @click="save"
-          >
-            Update
-          </Button>
-        </div>
       </div>
-    </template>
+      <FormControl
+        v-else
+        v-model.number="draftValue"
+        type="number"
+        :label="inputLabel"
+        :min="editor.min"
+        :max="editor.max"
+        :step="editor.step || 1"
+        autocomplete="off"
+      />
+
+      <div v-if="editor.value_type === 'integer'" class="text-ink-gray-6 text-sm">
+        <p v-if="Number.isInteger(editor.recommended)">
+          Recommended: {{ formatConstraint(editor.recommended, editor.unit) }}
+        </p>
+        <p v-if="Number.isInteger(editor.min) && Number.isInteger(editor.max)">
+          Allowed: {{ formatConstraint(editor.min, editor.unit) }} to
+          {{ formatConstraint(editor.max, editor.unit) }}
+        </p>
+      </div>
+      <p v-if="restartWarning" class="text-ink-orange-6 text-sm">
+        {{ restartWarning }}
+      </p>
+      <ErrorMessage v-if="validationError" :message="validationError" />
+      <ErrorMessage v-if="saveError" :message="saveError" />
+
+      <div class="flex justify-end gap-2">
+        <Button variant="ghost" :disabled="saving" @click="editorOpen = false"> Cancel </Button>
+        <Button
+          variant="solid"
+          :loading="saving"
+          :disabled="Boolean(validationError) || unchanged"
+          @click="save"
+        >
+          {{ restartWarning ? 'Update and restart' : 'Update' }}
+        </Button>
+      </div>
+    </div>
   </Dialog>
 </template>
 
@@ -175,26 +182,40 @@ const editorOpen = computed({
     if (!value && !saving.value) editing.value = null
   },
 })
-const editorOptions = computed(() => ({
-  title: editing.value ? `Update ${editing.value.name}` : 'Update database configuration',
-  size: 'sm',
-}))
+const editor = computed(() => editing.value?.edit || null)
 const inputLabel = computed(() => {
-  if (!editing.value) return 'Value'
-  return editing.value.unit ? `Value (${editing.value.unit})` : 'Value'
+  if (!editor.value) return 'Value'
+  return editor.value.unit ? `Value (${editor.value.unit})` : 'Value'
 })
 const validationError = computed(() => {
-  if (!editing.value) return ''
-  if (editing.value.value_type === 'boolean') {
+  if (!editor.value) return ''
+  if (editor.value.value_type === 'boolean') {
     return typeof draftValue.value === 'boolean' ? '' : 'Choose enabled or disabled.'
   }
   if (!Number.isInteger(draftValue.value)) return 'Enter a whole number.'
-  if (draftValue.value < editing.value.min || draftValue.value > editing.value.max) {
-    return `Enter a value between ${editing.value.min} and ${editing.value.max}.`
+  if (Number.isInteger(editor.value.min) && draftValue.value < editor.value.min) {
+    return `Enter a value between ${editor.value.min} and ${editor.value.max}.`
+  }
+  if (Number.isInteger(editor.value.max) && draftValue.value > editor.value.max) {
+    return `Enter a value between ${editor.value.min} and ${editor.value.max}.`
   }
   return ''
 })
-const unchanged = computed(() => editing.value !== null && draftValue.value === editing.value.value)
+const unchanged = computed(() => editor.value !== null && draftValue.value === editor.value.value)
+const restartWarning = computed(() => {
+  if (!editor.value) return ''
+  if (editor.value.action === 'performance_schema') {
+    return 'MariaDB will restart to apply this change.'
+  }
+  if (
+    editor.value.action === 'innodb_buffer_pool_size' &&
+    Number.isInteger(editor.value.dynamic_max) &&
+    draftValue.value > editor.value.dynamic_max
+  ) {
+    return `MariaDB will restart because this value is above its current live Buffer Pool ceiling of ${formatConstraint(editor.value.dynamic_max, editor.value.unit)}.`
+  }
+  return editor.value.requires_restart ? 'MariaDB will restart to apply this change.' : ''
+})
 
 function formatValue(variable) {
   if (!variable.supported || variable.value === null) return 'Unavailable'
@@ -224,9 +245,9 @@ function formatConstraint(value, unit) {
 }
 
 function openEditor(variable) {
-  if (!variable.editable) return
+  if (!variable.editable || !variable.edit) return
   saveError.value = ''
-  draftValue.value = variable.value
+  draftValue.value = variable.edit.value
   editing.value = variable
 }
 

--- a/admin/frontend/dashboard/src/components/settings/DatabaseConfigurations.vue
+++ b/admin/frontend/dashboard/src/components/settings/DatabaseConfigurations.vue
@@ -1,0 +1,277 @@
+<template>
+  <Teleport defer to="#settings-header-actions">
+    <Tooltip text="Refresh database configurations">
+      <Button
+        variant="ghost"
+        icon="lucide-refresh-cw"
+        :loading="loading"
+        aria-label="Refresh database configurations"
+        @click="load"
+      />
+    </Tooltip>
+  </Teleport>
+
+  <div v-if="loading && !snapshot" class="flex justify-center items-center h-40">
+    <Spinner size="lg" class="text-ink-gray-4" />
+  </div>
+  <div v-else>
+    <ErrorMessage v-if="error" :message="error" class="mb-4" />
+
+    <div
+      v-if="snapshot && !snapshot.readable"
+      class="border border-outline-gray-2 bg-surface-gray-1 px-3 py-2 text-ink-gray-7 text-sm"
+    >
+      {{ snapshot.reason }}
+    </div>
+
+    <template v-else-if="snapshot">
+      <div
+        v-if="snapshot.edit_reason"
+        class="mb-4 border border-outline-gray-2 bg-surface-gray-1 px-3 py-2 text-ink-gray-7 text-sm"
+      >
+        {{ snapshot.edit_reason }}
+      </div>
+
+      <FormControl
+        v-model="search"
+        type="text"
+        placeholder="Search variables"
+        autocomplete="off"
+        class="mb-5"
+      />
+
+      <div v-if="groups.length" class="space-y-7">
+        <section v-for="group in groups" :key="group.name">
+          <h4 class="mb-1 font-medium text-ink-gray-6 text-sm">
+            {{ group.name }}
+          </h4>
+          <div class="divide-y divide-outline-alpha-gray-1">
+            <div
+              v-for="variable in group.variables"
+              :key="variable.name"
+              class="flex sm:flex-row sm:items-center sm:justify-between flex-col gap-3 py-3"
+            >
+              <div class="min-w-0">
+                <code class="font-medium text-ink-gray-8 text-base break-all">
+                  {{ variable.name }}
+                </code>
+              </div>
+              <div class="flex items-center justify-between sm:justify-end gap-3 sm:ml-6 shrink-0">
+                <span
+                  class="max-w-48 text-right text-ink-gray-8 text-sm font-mono break-all"
+                  :class="{ 'text-ink-gray-5': !variable.supported }"
+                >
+                  {{ formatValue(variable) }}
+                </span>
+                <Button
+                  v-if="variable.editable"
+                  size="sm"
+                  variant="subtle"
+                  :disabled="saving"
+                  @click="openEditor(variable)"
+                >
+                  Edit
+                </Button>
+                <Tooltip v-else :text="variable.reason || 'Read-only in Pilot'">
+                  <span
+                    class="block size-4 text-ink-gray-4 lucide-lock"
+                    role="img"
+                    :aria-label="variable.reason || 'Read-only in Pilot'"
+                  />
+                </Tooltip>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+      <p v-else class="py-10 text-center text-ink-gray-5 text-sm">
+        No database variables match this search.
+      </p>
+    </template>
+  </div>
+
+  <Dialog v-model="editorOpen" :options="editorOptions">
+    <template #body-content>
+      <div v-if="editing" class="space-y-4">
+        <div
+          v-if="editing.value_type === 'boolean'"
+          class="flex items-center justify-between gap-4"
+        >
+          <p class="font-medium text-ink-gray-8 text-base">Enabled</p>
+          <Switch
+            class="[&_[data-slot='label']]:sr-only [&>div]:!gap-x-0 [&>div]:!py-0"
+            :label="editing.name"
+            :model-value="Boolean(draftValue)"
+            @update:model-value="(value) => (draftValue = value)"
+          />
+        </div>
+        <FormControl
+          v-else
+          v-model.number="draftValue"
+          type="number"
+          :label="inputLabel"
+          :min="editing.min"
+          :max="editing.max"
+          :step="editing.step || 1"
+          autocomplete="off"
+        />
+
+        <p v-if="editing.value_type === 'integer'" class="text-ink-gray-6 text-sm">
+          Allowed: {{ formatConstraint(editing.min, editing.unit) }} to
+          {{ formatConstraint(editing.max, editing.unit) }}
+        </p>
+        <ErrorMessage v-if="validationError" :message="validationError" />
+        <ErrorMessage v-if="saveError" :message="saveError" />
+
+        <div class="flex justify-end gap-2">
+          <Button variant="ghost" :disabled="saving" @click="editorOpen = false">
+            Cancel
+          </Button>
+          <Button
+            variant="solid"
+            :loading="saving"
+            :disabled="Boolean(validationError) || unchanged"
+            @click="save"
+          >
+            Update
+          </Button>
+        </div>
+      </div>
+    </template>
+  </Dialog>
+</template>
+
+<script setup>
+import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { Button, Dialog, ErrorMessage, FormControl, Spinner, Switch, Tooltip } from 'frappe-ui'
+import { databaseApi } from '@/api/database'
+import { openTaskDetailPage } from '@/utils/taskRoute'
+
+const router = useRouter()
+
+const loading = ref(false)
+const snapshot = ref(null)
+const error = ref('')
+const search = ref('')
+const editing = ref(null)
+const draftValue = ref(null)
+const saving = ref(false)
+const saveError = ref('')
+
+const groups = computed(() => {
+  const query = search.value.trim().toLowerCase()
+  const grouped = new Map()
+  for (const variable of snapshot.value?.variables || []) {
+    const searchable = `${variable.name} ${variable.section}`.toLowerCase()
+    if (query && !searchable.includes(query)) continue
+    if (!grouped.has(variable.section)) grouped.set(variable.section, [])
+    grouped.get(variable.section).push(variable)
+  }
+  return Array.from(grouped, ([name, variables]) => ({ name, variables }))
+})
+
+const editorOpen = computed({
+  get: () => Boolean(editing.value),
+  set: (value) => {
+    if (!value && !saving.value) editing.value = null
+  },
+})
+const editorOptions = computed(() => ({
+  title: editing.value ? `Update ${editing.value.name}` : 'Update database configuration',
+  size: 'sm',
+}))
+const inputLabel = computed(() => {
+  if (!editing.value) return 'Value'
+  return editing.value.unit ? `Value (${editing.value.unit})` : 'Value'
+})
+const validationError = computed(() => {
+  if (!editing.value) return ''
+  if (editing.value.value_type === 'boolean') {
+    return typeof draftValue.value === 'boolean' ? '' : 'Choose enabled or disabled.'
+  }
+  if (!Number.isInteger(draftValue.value)) return 'Enter a whole number.'
+  if (draftValue.value < editing.value.min || draftValue.value > editing.value.max) {
+    return `Enter a value between ${editing.value.min} and ${editing.value.max}.`
+  }
+  return ''
+})
+const unchanged = computed(
+  () => editing.value !== null && draftValue.value === editing.value.value,
+)
+
+function formatValue(variable) {
+  if (!variable.supported || variable.value === null) return 'Unavailable'
+  if (variable.value_type === 'boolean') return variable.value ? 'Enabled' : 'Disabled'
+  if (variable.unit === 'bytes' && Number.isFinite(variable.value)) {
+    return formatBytes(variable.value)
+  }
+  return formatConstraint(variable.value, variable.unit)
+}
+
+function formatBytes(value) {
+  const units = ['bytes', 'KB', 'MB', 'GB', 'TB']
+  let amount = value
+  let index = 0
+  while (Math.abs(amount) >= 1024 && index < units.length - 1) {
+    amount /= 1024
+    index += 1
+  }
+  const rounded = Number.isInteger(amount) ? amount : amount.toFixed(1)
+  return `${rounded} ${units[index]}`
+}
+
+function formatConstraint(value, unit) {
+  if (!unit) return String(value)
+  if (unit === 'percent') return `${value}%`
+  return `${value} ${unit}`
+}
+
+function openEditor(variable) {
+  if (!variable.editable) return
+  saveError.value = ''
+  draftValue.value = variable.value
+  editing.value = variable
+}
+
+function idempotencyKey(variable) {
+  const random = globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)
+  return `database-config-${variable}-${Date.now()}-${random}`
+}
+
+async function save() {
+  if (!editing.value || validationError.value || unchanged.value || saving.value) return
+  const variable = editing.value.name
+  saving.value = true
+  saveError.value = ''
+  try {
+    const task = await databaseApi.configurations.set(
+      variable,
+      draftValue.value,
+      idempotencyKey(variable),
+    )
+    editing.value = null
+    openTaskDetailPage(router, task.task_id)
+  } catch (e) {
+    saveError.value = e.message || 'Could not update the database configuration.'
+  } finally {
+    saving.value = false
+  }
+}
+
+async function load() {
+  if (loading.value) return
+  loading.value = true
+  error.value = ''
+  try {
+    snapshot.value = await databaseApi.configurations.list()
+  } catch (e) {
+    snapshot.value = null
+    error.value = e.message || 'Could not load database configurations.'
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(load)
+</script>

--- a/admin/frontend/dashboard/src/components/settings/DatabaseConfigurations.vue
+++ b/admin/frontend/dashboard/src/components/settings/DatabaseConfigurations.vue
@@ -66,12 +66,12 @@
                 <Button
                   v-if="variable.editable"
                   size="sm"
-                  variant="subtle"
+                  variant="ghost"
+                  icon="lucide-pencil"
                   :disabled="saving"
+                  aria-label="Edit"
                   @click="openEditor(variable)"
-                >
-                  Edit
-                </Button>
+                />
                 <Tooltip v-else :text="variable.reason || 'Read-only in Pilot'">
                   <span
                     class="block size-4 text-ink-gray-4 lucide-lock"
@@ -124,9 +124,7 @@
         <ErrorMessage v-if="saveError" :message="saveError" />
 
         <div class="flex justify-end gap-2">
-          <Button variant="ghost" :disabled="saving" @click="editorOpen = false">
-            Cancel
-          </Button>
+          <Button variant="ghost" :disabled="saving" @click="editorOpen = false"> Cancel </Button>
           <Button
             variant="solid"
             :loading="saving"
@@ -142,9 +140,9 @@
 </template>
 
 <script setup>
+import { Button, Dialog, ErrorMessage, FormControl, Spinner, Switch, Tooltip } from 'frappe-ui'
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { Button, Dialog, ErrorMessage, FormControl, Spinner, Switch, Tooltip } from 'frappe-ui'
 import { databaseApi } from '@/api/database'
 import { openTaskDetailPage } from '@/utils/taskRoute'
 
@@ -196,9 +194,7 @@ const validationError = computed(() => {
   }
   return ''
 })
-const unchanged = computed(
-  () => editing.value !== null && draftValue.value === editing.value.value,
-)
+const unchanged = computed(() => editing.value !== null && draftValue.value === editing.value.value)
 
 function formatValue(variable) {
   if (!variable.supported || variable.value === null) return 'Unavailable'

--- a/admin/frontend/dashboard/src/components/settings/DatabaseQuickActions.vue
+++ b/admin/frontend/dashboard/src/components/settings/DatabaseQuickActions.vue
@@ -163,7 +163,7 @@
 </template>
 
 <script setup>
-import { Badge, Button, Dialog, ErrorMessage, FormControl, Switch, Tooltip } from 'frappe-ui'
+import { Button, Dialog, ErrorMessage, FormControl, Switch, Tooltip } from 'frappe-ui'
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { databaseApi } from '@/api/database'
@@ -217,10 +217,6 @@ const showManagedMariaDBDisclaimer = computed(
     capabilities.value !== null &&
     (capabilities.value.engine !== 'mariadb' || !capabilities.value.managed),
 )
-const engineLabel = computed(() => {
-  const labels = { mariadb: 'MariaDB', postgres: 'PostgreSQL', sqlite: 'SQLite' }
-  return labels[capabilities.value?.engine] || 'Database'
-})
 const bufferPoolDescription = computed(() => {
   const capability = action('innodb_buffer_pool_size')
   const description = ''

--- a/admin/frontend/dashboard/src/components/settings/DatabaseQuickActions.vue
+++ b/admin/frontend/dashboard/src/components/settings/DatabaseQuickActions.vue
@@ -17,14 +17,14 @@
   <div v-else>
     <ErrorMessage v-if="error" :message="error" class="mb-4" />
 
-    <!-- <div v-if="capabilities" class="pb-4">
-      <Badge :label="engineLabel" theme="gray" size="sm" />
-    </div> -->
-
     <div
       v-if="showManagedMariaDBDisclaimer"
-      class="mb-4 border border-outline-gray-2 bg-surface-gray-1 px-3 py-2 text-ink-gray-7 text-sm"
+      class="my-4 border rounded border-outline-gray-2 bg-surface-gray-1 p-2 text-ink-gray-7 text-sm flex"
     >
+      <span
+        class="size-4 text-ink-gray-5 lucide-circle-alert inline-block mr-2"
+        aria-hidden="true"
+      />
       Database actions are available only for Pilot-managed MariaDB instances.
     </div>
 
@@ -49,12 +49,11 @@
       >
         <Button
           size="sm"
-          variant="subtle"
+          variant="ghost"
+          icon="lucide-pencil"
           :disabled="!action('innodb_buffer_pool_size').available || Boolean(activeAction)"
           @click="openSizingAction('innodb_buffer_pool_size')"
-        >
-          Update
-        </Button>
+        />
       </SettingsRow>
 
       <SettingsRow
@@ -64,12 +63,11 @@
       >
         <Button
           size="sm"
-          variant="subtle"
+          variant="ghost"
+          icon="lucide-pencil"
           :disabled="!action('max_connections').available || Boolean(activeAction)"
           @click="openSizingAction('max_connections')"
-        >
-          Update
-        </Button>
+        />
       </SettingsRow>
 
       <SettingsRow
@@ -165,9 +163,9 @@
 </template>
 
 <script setup>
+import { Badge, Button, Dialog, ErrorMessage, FormControl, Switch, Tooltip } from 'frappe-ui'
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
-import { Badge, Button, Dialog, ErrorMessage, FormControl, Switch, Tooltip } from 'frappe-ui'
 import { databaseApi } from '@/api/database'
 import SettingsRow from '@/components/settings/SettingsRow.vue'
 import { openTaskDetailPage } from '@/utils/taskRoute'
@@ -235,10 +233,12 @@ const maxConnectionsDescription = computed(() => {
 })
 
 function action(name) {
-  return capabilities.value?.actions?.[name] || {
-    available: false,
-    reason: 'Database capabilities are unavailable.',
-  }
+  return (
+    capabilities.value?.actions?.[name] || {
+      available: false,
+      reason: 'Database capabilities are unavailable.',
+    }
+  )
 }
 
 function formatSizingValue(value, unit = '') {

--- a/admin/frontend/dashboard/src/components/settings/DatabaseQuickActions.vue
+++ b/admin/frontend/dashboard/src/components/settings/DatabaseQuickActions.vue
@@ -17,9 +17,9 @@
   <div v-else>
     <ErrorMessage v-if="error" :message="error" class="mb-4" />
 
-    <div v-if="capabilities" class="pb-4">
+    <!-- <div v-if="capabilities" class="pb-4">
       <Badge :label="engineLabel" theme="gray" size="sm" />
-    </div>
+    </div> -->
 
     <div
       v-if="showManagedMariaDBDisclaimer"
@@ -30,6 +30,7 @@
 
     <div v-if="capabilities" class="divide-y divide-outline-alpha-gray-1">
       <SettingsRow
+        class="!ps-0"
         label="Performance Schema"
         description="Collect database instrumentation for deeper performance diagnostics."
       >
@@ -42,6 +43,7 @@
       </SettingsRow>
 
       <SettingsRow
+        class="!ps-0"
         label="Update InnoDB Buffer Pool Size"
         :description="bufferPoolDescription"
       >
@@ -56,6 +58,7 @@
       </SettingsRow>
 
       <SettingsRow
+        class="!ps-0"
         label="Update Max DB Connections"
         :description="maxConnectionsDescription"
       >
@@ -70,6 +73,7 @@
       </SettingsRow>
 
       <SettingsRow
+        class="!ps-0"
         label="Manage Binlogs"
         description="Inspect binary logs and safely purge complete log ranges."
       >
@@ -84,6 +88,7 @@
       </SettingsRow>
 
       <SettingsRow
+        class="!ps-0"
         label="Restart MariaDB"
         description="Restart the database service and verify that it accepts connections."
       >

--- a/admin/frontend/dashboard/src/components/settings/sections.js
+++ b/admin/frontend/dashboard/src/components/settings/sections.js
@@ -1,15 +1,15 @@
+import ChangeAdminPassword from '@/components/settings/ChangeAdminPassword.vue'
+import DatabaseConfigurations from '@/components/settings/DatabaseConfigurations.vue'
+import DatabaseQuickActions from '@/components/settings/DatabaseQuickActions.vue'
+import Firewall from '@/components/settings/Firewall.vue'
 import Git from '@/components/settings/Git.vue'
-import Workers from '@/components/settings/Workers.vue'
-import S3Bucket from '@/components/settings/S3Bucket.vue'
 import LLM from '@/components/settings/LLM.vue'
 import Notifications from '@/components/settings/Notifications.vue'
-import Firewall from '@/components/settings/Firewall.vue'
-import Waf from '@/components/settings/Waf.vue'
+import S3Bucket from '@/components/settings/S3Bucket.vue'
 import SshKeys from '@/components/settings/SshKeys.vue'
-import ChangeAdminPassword from '@/components/settings/ChangeAdminPassword.vue'
 import TwoFactor from '@/components/settings/TwoFactor.vue'
-import DatabaseQuickActions from '@/components/settings/DatabaseQuickActions.vue'
-import DatabaseConfigurations from '@/components/settings/DatabaseConfigurations.vue'
+import Waf from '@/components/settings/Waf.vue'
+import Workers from '@/components/settings/Workers.vue'
 
 // Single source of truth for id/label/component so SettingsDialog can resolve
 // a routed subsection id without each page owning its own private mapping.
@@ -49,7 +49,7 @@ export const GENERAL_SECTIONS = [
 export const DATABASE_SECTIONS = [
   {
     id: 'configurations',
-    label: 'Configurations',
+    label: 'Database configurations',
     description: 'Inspect MariaDB system variables and tune guarded dynamic settings.',
     component: DatabaseConfigurations,
   },

--- a/admin/frontend/dashboard/src/components/settings/sections.js
+++ b/admin/frontend/dashboard/src/components/settings/sections.js
@@ -9,6 +9,7 @@ import SshKeys from '@/components/settings/SshKeys.vue'
 import ChangeAdminPassword from '@/components/settings/ChangeAdminPassword.vue'
 import TwoFactor from '@/components/settings/TwoFactor.vue'
 import DatabaseQuickActions from '@/components/settings/DatabaseQuickActions.vue'
+import DatabaseConfigurations from '@/components/settings/DatabaseConfigurations.vue'
 
 // Single source of truth for id/label/component so SettingsDialog can resolve
 // a routed subsection id without each page owning its own private mapping.
@@ -46,6 +47,12 @@ export const GENERAL_SECTIONS = [
 ]
 
 export const DATABASE_SECTIONS = [
+  {
+    id: 'configurations',
+    label: 'Configurations',
+    description: 'Inspect MariaDB system variables and tune guarded dynamic settings.',
+    component: DatabaseConfigurations,
+  },
   {
     id: 'quick-actions',
     label: 'Quick actions',

--- a/pilot/core/database/configurations.py
+++ b/pilot/core/database/configurations.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pilot.core.database.mariadb_variables import (
+    MARIADB_VARIABLE_SPECS,
+    MariaDBValue,
+    mariadb_variable_spec,
+)
+from pilot.exceptions import DatabaseError
+from pilot.managers.database.mariadb import MariaDBManager
+from pilot.managers.platform import is_linux
+
+if TYPE_CHECKING:
+    from pilot.config import BenchConfig
+
+
+_MARIADB_ONLY = "Database configurations are available only when the bench uses MariaDB."
+_UNREACHABLE = "MariaDB is not reachable with Pilot's admin credentials."
+_EXTERNAL_READ_ONLY = (
+    "External MariaDB configurations are read-only. Pilot changes only the MariaDB instance it "
+    "provisioned on this server."
+)
+
+
+class DatabaseConfigurations:
+    """Read the MariaDB catalog and authorize its small editable subset."""
+
+    def __init__(
+        self,
+        config: BenchConfig,
+        manager: MariaDBManager | None = None,
+    ) -> None:
+        self.config = config
+        self.manager = (
+            manager
+            if manager is not None
+            else (MariaDBManager(config.mariadb) if config.db_type == "mariadb" else None)
+        )
+
+    def snapshot(self) -> dict:
+        read_reason = self._read_reason()
+        managed = self.config.db_type == "mariadb" and not self.config.mariadb.existing
+        if read_reason:
+            return {
+                "engine": self.config.db_type,
+                "managed": managed,
+                "readable": False,
+                "editable": False,
+                "reason": read_reason,
+                "edit_reason": read_reason,
+                "variables": [],
+            }
+
+        manager = self._manager()
+        values = manager.global_variable_values(spec.name for spec in MARIADB_VARIABLE_SPECS)
+        edit_reason = self._edit_reason()
+        variables = []
+        for spec in MARIADB_VARIABLE_SPECS:
+            raw_value = values.get(spec.name)
+            supported = raw_value is not None
+            try:
+                value = spec.parse_server_value(raw_value) if supported else None
+            except ValueError as exc:
+                raise DatabaseError(str(exc)) from exc
+
+            editable = supported and spec.editable and not edit_reason
+            if not supported:
+                variable_reason = "This variable is not exposed by the installed MariaDB version."
+            elif not spec.editable:
+                variable_reason = spec.read_only_reason
+            else:
+                variable_reason = edit_reason
+
+            variables.append(
+                {
+                    "name": spec.name,
+                    "label": spec.label,
+                    "section": spec.section,
+                    "description": spec.description,
+                    "value": value,
+                    "value_type": spec.value_type,
+                    "unit": spec.unit,
+                    "dynamic": spec.dynamic,
+                    "requires_restart": not spec.dynamic,
+                    "supported": supported,
+                    "editable": editable,
+                    "reason": variable_reason,
+                    "min": spec.minimum,
+                    "max": spec.maximum,
+                    "step": spec.step,
+                }
+            )
+        return {
+            "engine": self.config.db_type,
+            "managed": managed,
+            "readable": True,
+            "editable": not edit_reason,
+            "reason": "",
+            "edit_reason": edit_reason,
+            "variables": variables,
+        }
+
+    def prepare_change(self, name: str, value: object) -> dict:
+        spec = mariadb_variable_spec(name)
+        requested = spec.validate_input(value)
+        edit_reason = self._edit_reason(require_reachable=True)
+        if edit_reason:
+            raise DatabaseError(edit_reason)
+
+        raw_value = self._manager().global_variable_values((name,)).get(name)
+        if raw_value is None:
+            raise DatabaseError(f"MariaDB variable '{name}' is not exposed by the installed MariaDB version.")
+        try:
+            current = spec.parse_server_value(raw_value)
+        except ValueError as exc:
+            raise DatabaseError(str(exc)) from exc
+        return {
+            "name": name,
+            "value": requested,
+            "current": current,
+            "changed": current != requested,
+        }
+
+    def set(self, name: str, value: object) -> bool:
+        spec = mariadb_variable_spec(name)
+        requested: MariaDBValue = spec.validate_input(value)
+        edit_reason = self._edit_reason(require_reachable=True)
+        if edit_reason:
+            raise DatabaseError(edit_reason)
+        return self._manager().set_configuration_variable(name, requested)
+
+    def _read_reason(self) -> str:
+        if self.config.db_type != "mariadb":
+            return _MARIADB_ONLY
+        manager = self._manager()
+        if not self.config.mariadb.existing:
+            if not manager.is_installed():
+                return "MariaDB is not installed on this server."
+            if not manager.is_provisioned():
+                return "Pilot's MariaDB server has not been provisioned."
+        if not manager.is_healthy():
+            return _UNREACHABLE
+        return ""
+
+    def _edit_reason(self, *, require_reachable: bool = False) -> str:
+        if self.config.db_type != "mariadb":
+            return _MARIADB_ONLY
+        if self.config.mariadb.existing:
+            return _EXTERNAL_READ_ONLY
+        if not self.config.admin.allow_bench_management:
+            return "Bench management is disabled on this server."
+        if not is_linux():
+            return "MariaDB configuration changes are available only on Linux."
+        if require_reachable:
+            return self._read_reason()
+        return ""
+
+    def _manager(self) -> MariaDBManager:
+        if self.manager is None:
+            raise DatabaseError(_MARIADB_ONLY)
+        return self.manager

--- a/pilot/core/database/configurations.py
+++ b/pilot/core/database/configurations.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, TypedDict
 
 from pilot.core.database.mariadb_variables import (
     MARIADB_VARIABLE_SPECS,
     MariaDBValue,
+    MariaDBVariableSpec,
+    VariableEditAction,
+    VariableType,
     mariadb_variable_spec,
 )
+from pilot.core.database.quick_actions import DatabaseQuickActions
 from pilot.exceptions import DatabaseError
 from pilot.managers.database.mariadb import MariaDBManager
 from pilot.managers.platform import is_linux
@@ -21,6 +26,33 @@ _EXTERNAL_READ_ONLY = (
     "External MariaDB configurations are read-only. Pilot changes only the MariaDB instance it "
     "provisioned on this server."
 )
+_MEBIBYTE = 1024 * 1024
+
+
+class DatabaseConfigurationEditor(TypedDict):
+    action: VariableEditAction
+    value: MariaDBValue | None
+    value_type: VariableType
+    unit: str
+    min: int | None
+    max: int | None
+    step: int | None
+    recommended: int | None
+    dynamic_max: int | None
+    requires_restart: bool
+
+
+class DatabaseConfigurationChange(TypedDict):
+    action: VariableEditAction
+    name: str
+    value: MariaDBValue
+    current: MariaDBValue
+    changed: bool
+
+
+class GuardedEditor(TypedDict):
+    edit: DatabaseConfigurationEditor | None
+    reason: str
 
 
 class DatabaseConfigurations:
@@ -30,6 +62,7 @@ class DatabaseConfigurations:
         self,
         config: BenchConfig,
         manager: MariaDBManager | None = None,
+        quick_actions: DatabaseQuickActions | None = None,
     ) -> None:
         self.config = config
         self.manager = (
@@ -37,6 +70,7 @@ class DatabaseConfigurations:
             if manager is not None
             else (MariaDBManager(config.mariadb) if config.db_type == "mariadb" else None)
         )
+        self.quick_actions = quick_actions
 
     def snapshot(self) -> dict:
         read_reason = self._read_reason()
@@ -53,24 +87,34 @@ class DatabaseConfigurations:
             }
 
         manager = self._manager()
-        values = manager.global_variable_values(spec.name for spec in MARIADB_VARIABLE_SPECS)
+        raw_values = manager.global_variable_values(spec.name for spec in MARIADB_VARIABLE_SPECS)
         edit_reason = self._edit_reason()
+        values = self._parse_values(raw_values)
+        guarded_editors = self._guarded_editors(values) if not edit_reason else {}
         variables = []
         for spec in MARIADB_VARIABLE_SPECS:
-            raw_value = values.get(spec.name)
-            supported = raw_value is not None
-            try:
-                value = spec.parse_server_value(raw_value) if supported else None
-            except ValueError as exc:
-                raise DatabaseError(str(exc)) from exc
+            supported = spec.name in values
+            value = values.get(spec.name)
 
-            editable = supported and spec.editable and not edit_reason
+            edit = self._editor(spec, value, guarded_editors) if supported and not edit_reason else None
+            editable = edit is not None
             if not supported:
                 variable_reason = "This variable is not exposed by the installed MariaDB version."
             elif not spec.editable:
                 variable_reason = spec.read_only_reason
-            else:
+            elif edit_reason:
                 variable_reason = edit_reason
+            elif not editable:
+                guarded_editor = (
+                    guarded_editors.get(spec.edit_action) if spec.edit_action is not None else None
+                )
+                variable_reason = (
+                    guarded_editor["reason"]
+                    if guarded_editor is not None
+                    else "This variable cannot be changed on the current MariaDB server."
+                )
+            else:
+                variable_reason = ""
 
             variables.append(
                 {
@@ -85,6 +129,7 @@ class DatabaseConfigurations:
                     "requires_restart": not spec.dynamic,
                     "supported": supported,
                     "editable": editable,
+                    "edit": edit,
                     "reason": variable_reason,
                     "min": spec.minimum,
                     "max": spec.maximum,
@@ -95,18 +140,24 @@ class DatabaseConfigurations:
             "engine": self.config.db_type,
             "managed": managed,
             "readable": True,
-            "editable": not edit_reason,
+            "editable": any(variable["editable"] for variable in variables),
             "reason": "",
             "edit_reason": edit_reason,
             "variables": variables,
         }
 
-    def prepare_change(self, name: str, value: object) -> dict:
+    def prepare_change(self, name: str, value: object) -> DatabaseConfigurationChange:
         spec = mariadb_variable_spec(name)
-        requested = spec.validate_input(value)
+        if not spec.editable:
+            spec.validate_input(value)
         edit_reason = self._edit_reason(require_reachable=True)
         if edit_reason:
             raise DatabaseError(edit_reason)
+
+        if spec.edit_action != "configuration":
+            return self._prepare_guarded_change(spec, value)
+
+        requested = spec.validate_input(value)
 
         raw_value = self._manager().global_variable_values((name,)).get(name)
         if raw_value is None:
@@ -116,6 +167,7 @@ class DatabaseConfigurations:
         except ValueError as exc:
             raise DatabaseError(str(exc)) from exc
         return {
+            "action": "configuration",
             "name": name,
             "value": requested,
             "current": current,
@@ -129,6 +181,169 @@ class DatabaseConfigurations:
         if edit_reason:
             raise DatabaseError(edit_reason)
         return self._manager().set_configuration_variable(name, requested)
+
+    def _editor(
+        self,
+        spec: MariaDBVariableSpec,
+        value: MariaDBValue | None,
+        guarded_editors: Mapping[VariableEditAction, GuardedEditor],
+    ) -> DatabaseConfigurationEditor | None:
+        action = spec.edit_action
+        if action is None:
+            return None
+        if action == "configuration":
+            return self._editor_contract(
+                action=action,
+                value=value,
+                value_type=spec.value_type,
+                unit=spec.unit,
+                minimum=spec.minimum,
+                maximum=spec.maximum,
+                step=spec.step,
+                requires_restart=not spec.dynamic,
+            )
+
+        guarded_editor = guarded_editors.get(action)
+        return guarded_editor["edit"] if guarded_editor is not None else None
+
+    def _parse_values(self, raw_values: Mapping[str, object]) -> dict[str, MariaDBValue]:
+        values: dict[str, MariaDBValue] = {}
+        for spec in MARIADB_VARIABLE_SPECS:
+            if spec.name not in raw_values:
+                continue
+            try:
+                values[spec.name] = spec.parse_server_value(raw_values[spec.name])
+            except ValueError as exc:
+                raise DatabaseError(str(exc)) from exc
+        return values
+
+    def _guarded_editors(
+        self,
+        values: Mapping[str, MariaDBValue],
+    ) -> dict[VariableEditAction, GuardedEditor]:
+        editors: dict[VariableEditAction, GuardedEditor] = {}
+        if "performance_schema" in values:
+            editors["performance_schema"] = {
+                "edit": self._editor_contract(
+                    action="performance_schema",
+                    value=values["performance_schema"],
+                    value_type="boolean",
+                    requires_restart=True,
+                ),
+                "reason": "",
+            }
+
+        sizing_actions: tuple[VariableEditAction, ...] = (
+            "innodb_buffer_pool_size",
+            "max_connections",
+        )
+        if not any(action in values for action in sizing_actions):
+            return editors
+        try:
+            limits = self._manager().variable_limits()
+        except DatabaseError as exc:
+            for action in sizing_actions:
+                editors[action] = {"edit": None, "reason": str(exc)}
+            return editors
+
+        if "max_connections" in values:
+            editors["max_connections"] = {
+                "edit": self._editor_contract(
+                    action="max_connections",
+                    value=values["max_connections"],
+                    value_type="integer",
+                    minimum=limits.max_connections_min,
+                    maximum=limits.max_connections_max,
+                    step=1,
+                    recommended=limits.max_connections_recommended,
+                    requires_restart=False,
+                ),
+                "reason": "",
+            }
+
+        if "innodb_buffer_pool_size" in values:
+            buffer_pool_size = values["innodb_buffer_pool_size"]
+            dynamic_max = values.get("innodb_buffer_pool_size_max")
+            if type(buffer_pool_size) is not int or type(dynamic_max) is not int:
+                editors["innodb_buffer_pool_size"] = {
+                    "edit": None,
+                    "reason": "The installed MariaDB version does not expose the live Buffer Pool ceiling.",
+                }
+            else:
+                editors["innodb_buffer_pool_size"] = {
+                    "edit": self._editor_contract(
+                        action="innodb_buffer_pool_size",
+                        value=buffer_pool_size // _MEBIBYTE,
+                        value_type="integer",
+                        unit="MB",
+                        minimum=limits.innodb_buffer_pool_min_mb,
+                        maximum=limits.innodb_buffer_pool_max_mb,
+                        step=1,
+                        recommended=limits.innodb_buffer_pool_recommended_mb,
+                        dynamic_max=dynamic_max // _MEBIBYTE,
+                        requires_restart=False,
+                    ),
+                    "reason": "",
+                }
+        return editors
+
+    @staticmethod
+    def _editor_contract(
+        *,
+        action: VariableEditAction,
+        value: MariaDBValue | None,
+        value_type: VariableType,
+        unit: str = "",
+        minimum: int | None = None,
+        maximum: int | None = None,
+        step: int | None = None,
+        recommended: int | None = None,
+        dynamic_max: int | None = None,
+        requires_restart: bool,
+    ) -> DatabaseConfigurationEditor:
+        return {
+            "action": action,
+            "value": value,
+            "value_type": value_type,
+            "unit": unit,
+            "min": minimum,
+            "max": maximum,
+            "step": step,
+            "recommended": recommended,
+            "dynamic_max": dynamic_max,
+            "requires_restart": requires_restart,
+        }
+
+    def _prepare_guarded_change(
+        self,
+        spec: MariaDBVariableSpec,
+        value: object,
+    ) -> DatabaseConfigurationChange:
+        actions = self._quick_actions()
+        if spec.edit_action == "performance_schema":
+            if type(value) is not bool:
+                raise ValueError("Performance Schema must be either enabled or disabled.")
+            capability = actions.require_performance_schema()
+            current = capability["enabled"]
+        elif spec.edit_action == "innodb_buffer_pool_size":
+            if type(value) is not int:
+                raise ValueError("InnoDB Buffer Pool size must be a whole number.")
+            capability = actions.require_innodb_buffer_pool_size(value)
+            current = capability["current_mb"]
+        elif spec.edit_action == "max_connections":
+            if type(value) is not int:
+                raise ValueError("Maximum connections must be a whole number.")
+            capability = actions.require_max_connections(value)
+            current = capability["current"]
+        else:
+            raise ValueError(f"MariaDB variable '{spec.name}' is read-only in Pilot.")
+        return {
+            "action": spec.edit_action,
+            "name": spec.name,
+            "value": value,
+            "current": current,
+            "changed": current != value,
+        }
 
     def _read_reason(self) -> str:
         if self.config.db_type != "mariadb":
@@ -160,3 +375,8 @@ class DatabaseConfigurations:
         if self.manager is None:
             raise DatabaseError(_MARIADB_ONLY)
         return self.manager
+
+    def _quick_actions(self) -> DatabaseQuickActions:
+        if self.quick_actions is None:
+            self.quick_actions = DatabaseQuickActions(self.config, self._manager())
+        return self.quick_actions

--- a/pilot/core/database/mariadb_variables.py
+++ b/pilot/core/database/mariadb_variables.py
@@ -5,8 +5,16 @@ from typing import Literal
 
 MariaDBValue = bool | int | str
 VariableType = Literal["boolean", "integer", "string"]
+VariableEditAction = Literal[
+    "configuration",
+    "innodb_buffer_pool_size",
+    "max_connections",
+    "performance_schema",
+]
 
-_QUICK_ACTION = "Use Database Quick actions to change this setting with Pilot's host-aware safeguards."
+_BUFFER_POOL_COMPANION = (
+    "Managed automatically with InnoDB Buffer Pool size so Pilot can enforce the host memory budget."
+)
 _MEMORY_SENSITIVE = "Read-only because an unsafe value can exhaust memory shared by MariaDB and the bench."
 _STARTUP_SENSITIVE = "Read-only because Pilot owns this server-level startup setting."
 _WORKLOAD_SENSITIVE = (
@@ -34,7 +42,7 @@ class MariaDBVariableSpec:
     description: str
     value_type: VariableType = "string"
     dynamic: bool = False
-    editable: bool = False
+    edit_action: VariableEditAction | None = None
     minimum: int | None = None
     maximum: int | None = None
     step: int | None = None
@@ -44,6 +52,10 @@ class MariaDBVariableSpec:
     @property
     def option_name(self) -> str:
         return self.name.replace("_", "-")
+
+    @property
+    def editable(self) -> bool:
+        return self.edit_action is not None
 
     def parse_server_value(self, raw_value: object) -> MariaDBValue:
         if self.value_type == "integer":
@@ -61,8 +73,7 @@ class MariaDBVariableSpec:
         return str(raw_value)
 
     def validate_input(self, value: object) -> MariaDBValue:
-        if not self.editable:
-            raise ValueError(f"MariaDB variable '{self.name}' is read-only in Pilot.")
+        self._require_generic_edit_action()
         if self.value_type == "integer":
             if type(value) is not int:
                 raise ValueError(f"{self.label} must be a whole number.")
@@ -76,6 +87,14 @@ class MariaDBVariableSpec:
                 raise ValueError(f"{self.label} must be either enabled or disabled.")
             return value
         raise ValueError(f"MariaDB variable '{self.name}' is not editable in Pilot.")
+
+    def _require_generic_edit_action(self) -> None:
+        if self.edit_action is None:
+            raise ValueError(f"MariaDB variable '{self.name}' is read-only in Pilot.")
+        if self.edit_action != "configuration":
+            raise ValueError(
+                f"MariaDB variable '{self.name}' must be changed through its guarded database action."
+            )
 
     def option_value(self, value: object) -> str:
         validated = self.validate_input(value)
@@ -104,7 +123,7 @@ def _editable_integer(
         description=description,
         value_type="integer",
         dynamic=True,
-        editable=True,
+        edit_action="configuration",
         minimum=minimum,
         maximum=maximum,
         step=1,
@@ -173,14 +192,15 @@ MARIADB_VARIABLE_SPECS = (
         600,
         unit="seconds",
     ),
-    _read_only(
-        "max_connections",
-        "Maximum connections",
-        "Connections",
-        "Maximum number of simultaneous client connections.",
-        _QUICK_ACTION,
+    MariaDBVariableSpec(
+        name="max_connections",
+        label="Maximum connections",
+        section="Connections",
+        description="Maximum number of simultaneous client connections.",
         value_type="integer",
         dynamic=True,
+        edit_action="max_connections",
+        read_only_reason="",
     ),
     _read_only(
         "extra_max_connections",
@@ -271,7 +291,7 @@ MARIADB_VARIABLE_SPECS = (
         description="Write every InnoDB deadlock report to the MariaDB error log.",
         value_type="boolean",
         dynamic=True,
-        editable=True,
+        edit_action="configuration",
         read_only_reason="",
     ),
     _read_only(
@@ -292,22 +312,23 @@ MARIADB_VARIABLE_SPECS = (
         value_type="boolean",
         dynamic=True,
     ),
-    _read_only(
-        "innodb_buffer_pool_size",
-        "InnoDB Buffer Pool size",
-        "InnoDB",
-        "Memory reserved for caching InnoDB data and indexes.",
-        _QUICK_ACTION,
+    MariaDBVariableSpec(
+        name="innodb_buffer_pool_size",
+        label="InnoDB Buffer Pool size",
+        section="InnoDB",
+        description="Memory reserved for caching InnoDB data and indexes.",
         value_type="integer",
         dynamic=True,
+        edit_action="innodb_buffer_pool_size",
         unit="bytes",
+        read_only_reason="",
     ),
     _read_only(
         "innodb_buffer_pool_size_max",
         "InnoDB Buffer Pool live ceiling",
         "InnoDB",
         "MariaDB 11.8 ceiling for increasing the Buffer Pool without a restart.",
-        _QUICK_ACTION,
+        _BUFFER_POOL_COMPANION,
         value_type="integer",
         unit="bytes",
     ),
@@ -316,7 +337,7 @@ MARIADB_VARIABLE_SPECS = (
         "InnoDB Buffer Pool automatic minimum",
         "InnoDB",
         "MariaDB 11.8 lower boundary for automatic Buffer Pool resizing.",
-        _QUICK_ACTION,
+        _BUFFER_POOL_COMPANION,
         value_type="integer",
         unit="bytes",
     ),
@@ -492,13 +513,14 @@ MARIADB_VARIABLE_SPECS = (
         "Recovery behavior used when MariaDB opens a damaged MyISAM table.",
         _RECOVERY_SENSITIVE,
     ),
-    _read_only(
-        "performance_schema",
-        "Performance Schema",
-        "Performance Schema",
-        "Collects instrumentation used by database performance diagnostics.",
-        _PERFORMANCE_SCHEMA,
+    MariaDBVariableSpec(
+        name="performance_schema",
+        label="Performance Schema",
+        section="Performance Schema",
+        description="Collects instrumentation used by database performance diagnostics.",
         value_type="boolean",
+        edit_action="performance_schema",
+        read_only_reason="",
     ),
     _read_only(
         "performance_schema_instrument",
@@ -584,6 +606,9 @@ MARIADB_VARIABLE_SPECS = (
 MARIADB_VARIABLES_BY_NAME = {spec.name: spec for spec in MARIADB_VARIABLE_SPECS}
 MARIADB_VARIABLE_NAMES = frozenset(MARIADB_VARIABLES_BY_NAME)
 EDITABLE_MARIADB_VARIABLE_NAMES = frozenset(spec.name for spec in MARIADB_VARIABLE_SPECS if spec.editable)
+GENERIC_EDITABLE_MARIADB_VARIABLE_NAMES = frozenset(
+    spec.name for spec in MARIADB_VARIABLE_SPECS if spec.edit_action == "configuration"
+)
 
 
 def mariadb_variable_spec(name: str) -> MariaDBVariableSpec:

--- a/pilot/core/database/mariadb_variables.py
+++ b/pilot/core/database/mariadb_variables.py
@@ -1,0 +1,593 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+MariaDBValue = bool | int | str
+VariableType = Literal["boolean", "integer", "string"]
+
+_QUICK_ACTION = "Use Database Quick actions to change this setting with Pilot's host-aware safeguards."
+_MEMORY_SENSITIVE = "Read-only because an unsafe value can exhaust memory shared by MariaDB and the bench."
+_STARTUP_SENSITIVE = "Read-only because Pilot owns this server-level startup setting."
+_WORKLOAD_SENSITIVE = (
+    "Read-only because an unsafe global value can interrupt Frappe requests, jobs, or migrations."
+)
+_REPLICATION_SENSITIVE = (
+    "Read-only because changing binary logging or replication settings can affect recovery data."
+)
+_RECOVERY_SENSITIVE = (
+    "Read-only because this is a recovery control that should only be used during incident response."
+)
+_SECURITY_SENSITIVE = (
+    "Read-only because Pilot keeps this security-sensitive setting at a safe server default."
+)
+_PERFORMANCE_SCHEMA = (
+    "Use the Performance Schema Quick action so Pilot can restart and verify MariaDB safely."
+)
+
+
+@dataclass(frozen=True)
+class MariaDBVariableSpec:
+    name: str
+    label: str
+    section: str
+    description: str
+    value_type: VariableType = "string"
+    dynamic: bool = False
+    editable: bool = False
+    minimum: int | None = None
+    maximum: int | None = None
+    step: int | None = None
+    unit: str = ""
+    read_only_reason: str = _STARTUP_SENSITIVE
+
+    @property
+    def option_name(self) -> str:
+        return self.name.replace("_", "-")
+
+    def parse_server_value(self, raw_value: object) -> MariaDBValue:
+        if self.value_type == "integer":
+            try:
+                return int(str(raw_value))
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"MariaDB returned an invalid value for '{self.name}'.") from exc
+        if self.value_type == "boolean":
+            normalized = str(raw_value).strip().upper()
+            if normalized in {"1", "ON", "TRUE"}:
+                return True
+            if normalized in {"0", "OFF", "FALSE"}:
+                return False
+            raise ValueError(f"MariaDB returned an invalid value for '{self.name}'.")
+        return str(raw_value)
+
+    def validate_input(self, value: object) -> MariaDBValue:
+        if not self.editable:
+            raise ValueError(f"MariaDB variable '{self.name}' is read-only in Pilot.")
+        if self.value_type == "integer":
+            if type(value) is not int:
+                raise ValueError(f"{self.label} must be a whole number.")
+            if self.minimum is not None and value < self.minimum:
+                raise ValueError(f"{self.label} must be at least {self.minimum}{self._unit_suffix()}.")
+            if self.maximum is not None and value > self.maximum:
+                raise ValueError(f"{self.label} cannot be greater than {self.maximum}{self._unit_suffix()}.")
+            return value
+        if self.value_type == "boolean":
+            if type(value) is not bool:
+                raise ValueError(f"{self.label} must be either enabled or disabled.")
+            return value
+        raise ValueError(f"MariaDB variable '{self.name}' is not editable in Pilot.")
+
+    def option_value(self, value: object) -> str:
+        validated = self.validate_input(value)
+        if type(validated) is bool:
+            return "ON" if validated else "OFF"
+        return str(validated)
+
+    def _unit_suffix(self) -> str:
+        return f" {self.unit}" if self.unit else ""
+
+
+def _editable_integer(
+    name: str,
+    label: str,
+    section: str,
+    description: str,
+    minimum: int,
+    maximum: int,
+    *,
+    unit: str = "",
+) -> MariaDBVariableSpec:
+    return MariaDBVariableSpec(
+        name=name,
+        label=label,
+        section=section,
+        description=description,
+        value_type="integer",
+        dynamic=True,
+        editable=True,
+        minimum=minimum,
+        maximum=maximum,
+        step=1,
+        unit=unit,
+        read_only_reason="",
+    )
+
+
+def _read_only(
+    name: str,
+    label: str,
+    section: str,
+    description: str,
+    reason: str,
+    *,
+    value_type: VariableType = "string",
+    dynamic: bool = False,
+    unit: str = "",
+) -> MariaDBVariableSpec:
+    return MariaDBVariableSpec(
+        name=name,
+        label=label,
+        section=section,
+        description=description,
+        value_type=value_type,
+        dynamic=dynamic,
+        unit=unit,
+        read_only_reason=reason,
+    )
+
+
+MARIADB_VARIABLE_SPECS = (
+    _editable_integer(
+        "connect_timeout",
+        "Connection handshake timeout",
+        "Connections",
+        "Seconds MariaDB waits for a client to finish its initial handshake.",
+        2,
+        60,
+        unit="seconds",
+    ),
+    _editable_integer(
+        "wait_timeout",
+        "Idle connection timeout",
+        "Connections",
+        "Seconds an inactive non-interactive connection may remain open.",
+        60,
+        86400,
+        unit="seconds",
+    ),
+    _editable_integer(
+        "net_read_timeout",
+        "Network read timeout",
+        "Connections",
+        "Seconds MariaDB waits for more data from a connected client.",
+        5,
+        600,
+        unit="seconds",
+    ),
+    _editable_integer(
+        "net_write_timeout",
+        "Network write timeout",
+        "Connections",
+        "Seconds MariaDB waits while sending a block to a connected client.",
+        5,
+        600,
+        unit="seconds",
+    ),
+    _read_only(
+        "max_connections",
+        "Maximum connections",
+        "Connections",
+        "Maximum number of simultaneous client connections.",
+        _QUICK_ACTION,
+        value_type="integer",
+        dynamic=True,
+    ),
+    _read_only(
+        "extra_max_connections",
+        "Emergency connections",
+        "Connections",
+        "Connections reserved for administrative access when the main limit is full.",
+        _MEMORY_SENSITIVE,
+        value_type="integer",
+        dynamic=True,
+    ),
+    _read_only(
+        "max_user_connections",
+        "Connections per user",
+        "Connections",
+        "Global default ceiling for simultaneous connections from one database user.",
+        _WORKLOAD_SENSITIVE,
+        value_type="integer",
+        dynamic=True,
+    ),
+    _read_only(
+        "net_buffer_length",
+        "Initial network buffer",
+        "Connections",
+        "Starting per-connection network buffer size.",
+        _MEMORY_SENSITIVE,
+        value_type="integer",
+        dynamic=True,
+        unit="bytes",
+    ),
+    _read_only(
+        "max_allowed_packet",
+        "Maximum packet size",
+        "Connections",
+        "Largest packet accepted by MariaDB clients and the server.",
+        _WORKLOAD_SENSITIVE,
+        value_type="integer",
+        dynamic=True,
+        unit="bytes",
+    ),
+    _read_only(
+        "extra_port",
+        "Emergency connection port",
+        "Connections",
+        "Separate port used for administrative connections.",
+        _STARTUP_SENSITIVE,
+        value_type="integer",
+    ),
+    _editable_integer(
+        "innodb_lock_wait_timeout",
+        "InnoDB lock wait timeout",
+        "InnoDB",
+        "Seconds a statement waits for an InnoDB row lock before failing.",
+        1,
+        300,
+        unit="seconds",
+    ),
+    _editable_integer(
+        "innodb_old_blocks_pct",
+        "InnoDB old buffer percentage",
+        "InnoDB",
+        "Percentage of the Buffer Pool LRU reserved for older pages.",
+        5,
+        95,
+        unit="percent",
+    ),
+    _editable_integer(
+        "innodb_old_blocks_time",
+        "InnoDB old block delay",
+        "InnoDB",
+        "Delay before an old Buffer Pool page can move to the new sublist.",
+        0,
+        60000,
+        unit="milliseconds",
+    ),
+    _editable_integer(
+        "innodb_stats_persistent_sample_pages",
+        "Persistent statistics sample pages",
+        "InnoDB",
+        "Index pages sampled when MariaDB calculates persistent optimizer statistics.",
+        1,
+        1024,
+        unit="pages",
+    ),
+    MariaDBVariableSpec(
+        name="innodb_print_all_deadlocks",
+        label="Log all InnoDB deadlocks",
+        section="InnoDB",
+        description="Write every InnoDB deadlock report to the MariaDB error log.",
+        value_type="boolean",
+        dynamic=True,
+        editable=True,
+        read_only_reason="",
+    ),
+    _read_only(
+        "innodb_status_output_locks",
+        "InnoDB lock status output",
+        "InnoDB",
+        "Include extended lock details in periodic InnoDB status output.",
+        "Read-only because enabling verbose lock output can produce substantial diagnostic logs.",
+        value_type="boolean",
+        dynamic=True,
+    ),
+    _read_only(
+        "innodb_strict_mode",
+        "InnoDB strict mode",
+        "InnoDB",
+        "Reject invalid or incompatible InnoDB table options instead of warning.",
+        _SECURITY_SENSITIVE,
+        value_type="boolean",
+        dynamic=True,
+    ),
+    _read_only(
+        "innodb_buffer_pool_size",
+        "InnoDB Buffer Pool size",
+        "InnoDB",
+        "Memory reserved for caching InnoDB data and indexes.",
+        _QUICK_ACTION,
+        value_type="integer",
+        dynamic=True,
+        unit="bytes",
+    ),
+    _read_only(
+        "innodb_buffer_pool_size_max",
+        "InnoDB Buffer Pool live ceiling",
+        "InnoDB",
+        "MariaDB 11.8 ceiling for increasing the Buffer Pool without a restart.",
+        _QUICK_ACTION,
+        value_type="integer",
+        unit="bytes",
+    ),
+    _read_only(
+        "innodb_buffer_pool_size_auto_min",
+        "InnoDB Buffer Pool automatic minimum",
+        "InnoDB",
+        "MariaDB 11.8 lower boundary for automatic Buffer Pool resizing.",
+        _QUICK_ACTION,
+        value_type="integer",
+        unit="bytes",
+    ),
+    _read_only(
+        "innodb_log_file_size",
+        "InnoDB redo log size",
+        "InnoDB",
+        "Size of the InnoDB redo log used for crash recovery.",
+        _MEMORY_SENSITIVE,
+        value_type="integer",
+        dynamic=True,
+        unit="bytes",
+    ),
+    _read_only(
+        "innodb_force_recovery",
+        "InnoDB force recovery mode",
+        "InnoDB",
+        "Emergency recovery level used when normal InnoDB startup cannot complete.",
+        _RECOVERY_SENSITIVE,
+        value_type="integer",
+    ),
+    _read_only(
+        "innodb_snapshot_isolation",
+        "InnoDB snapshot isolation",
+        "InnoDB",
+        "Controls write conflict detection for repeatable-read transactions.",
+        _WORKLOAD_SENSITIVE,
+        value_type="boolean",
+        dynamic=True,
+    ),
+    _read_only(
+        "innodb_flush_log_at_trx_commit",
+        "Flush log at transaction commit",
+        "InnoDB",
+        "Controls transaction durability when MariaDB or the host crashes.",
+        _SECURITY_SENSITIVE,
+        value_type="integer",
+        dynamic=True,
+    ),
+    _read_only(
+        "tmp_table_size",
+        "In-memory temporary table size",
+        "Memory and temporary tables",
+        "Per-connection ceiling before internal temporary tables move to disk.",
+        _MEMORY_SENSITIVE,
+        value_type="integer",
+        dynamic=True,
+        unit="bytes",
+    ),
+    _read_only(
+        "max_heap_table_size",
+        "MEMORY table size",
+        "Memory and temporary tables",
+        "Maximum size of user-created MEMORY tables and one temporary-table limit.",
+        _MEMORY_SENSITIVE,
+        value_type="integer",
+        dynamic=True,
+        unit="bytes",
+    ),
+    _read_only(
+        "tmp_disk_table_size",
+        "Temporary disk table size",
+        "Memory and temporary tables",
+        "Size limit used for internal temporary tables stored on disk.",
+        _MEMORY_SENSITIVE,
+        value_type="integer",
+        dynamic=True,
+        unit="bytes",
+    ),
+    _read_only(
+        "key_buffer_size",
+        "MyISAM key buffer size",
+        "Memory and temporary tables",
+        "Memory reserved for MyISAM index blocks.",
+        _MEMORY_SENSITIVE,
+        value_type="integer",
+        dynamic=True,
+        unit="bytes",
+    ),
+    _read_only(
+        "tmpdir",
+        "Temporary file directory",
+        "Memory and temporary tables",
+        "Directory MariaDB uses for server-side temporary files.",
+        _STARTUP_SENSITIVE,
+    ),
+    _read_only(
+        "max_statement_time",
+        "Maximum statement time",
+        "Query behavior",
+        "Global time limit after which MariaDB aborts a statement.",
+        _WORKLOAD_SENSITIVE,
+        dynamic=True,
+    ),
+    _read_only(
+        "long_query_time",
+        "Slow query threshold",
+        "Query behavior",
+        "Execution time after which a query is counted as slow.",
+        "Read-only because MariaDB 11.8 uses version-specific slow-query controls.",
+        dynamic=True,
+        unit="seconds",
+    ),
+    _read_only(
+        "binlog_expire_logs_seconds",
+        "Binary log retention",
+        "Binary logging and replication",
+        "Seconds before eligible binary logs expire.",
+        "Use Manage Binlogs so Pilot can inspect and purge complete log ranges safely.",
+        value_type="integer",
+        dynamic=True,
+        unit="seconds",
+    ),
+    _read_only(
+        "expire_logs_days",
+        "Legacy binary log retention",
+        "Binary logging and replication",
+        "Legacy day-based retention period for binary logs.",
+        _REPLICATION_SENSITIVE,
+        dynamic=True,
+        unit="days",
+    ),
+    _read_only(
+        "log_bin",
+        "Binary logging",
+        "Binary logging and replication",
+        "Whether MariaDB writes binary logs for recovery and replication.",
+        _REPLICATION_SENSITIVE,
+    ),
+    _read_only(
+        "binlog_format",
+        "Binary log format",
+        "Binary logging and replication",
+        "How data changes are represented in the binary log.",
+        _REPLICATION_SENSITIVE,
+    ),
+    _read_only(
+        "log_slave_updates",
+        "Log replica updates",
+        "Binary logging and replication",
+        "Whether updates received from a primary are written to this server's binary log.",
+        _REPLICATION_SENSITIVE,
+    ),
+    _read_only(
+        "slave_connections_needed_for_purge",
+        "Replica connections needed for purge",
+        "Binary logging and replication",
+        "MariaDB 11.8 replica-connection threshold used before old row versions are purged.",
+        _REPLICATION_SENSITIVE,
+        value_type="integer",
+    ),
+    _read_only(
+        "read_only",
+        "Read-only mode",
+        "Security and recovery",
+        "Prevents ordinary database users from changing non-temporary tables.",
+        _RECOVERY_SENSITIVE,
+        dynamic=True,
+    ),
+    _read_only(
+        "local_infile",
+        "Local file imports",
+        "Security and recovery",
+        "Allows clients to upload local files through LOAD DATA LOCAL INFILE.",
+        _SECURITY_SENSITIVE,
+        value_type="boolean",
+        dynamic=True,
+    ),
+    _read_only(
+        "myisam_recover_options",
+        "MyISAM recovery options",
+        "Security and recovery",
+        "Recovery behavior used when MariaDB opens a damaged MyISAM table.",
+        _RECOVERY_SENSITIVE,
+    ),
+    _read_only(
+        "performance_schema",
+        "Performance Schema",
+        "Performance Schema",
+        "Collects instrumentation used by database performance diagnostics.",
+        _PERFORMANCE_SCHEMA,
+        value_type="boolean",
+    ),
+    _read_only(
+        "performance_schema_instrument",
+        "Performance Schema instruments",
+        "Performance Schema",
+        "Startup rules controlling which operations Performance Schema instruments.",
+        _PERFORMANCE_SCHEMA,
+    ),
+    _read_only(
+        "performance_schema_consumer_events_statements_current",
+        "Current statement events",
+        "Performance Schema",
+        "Collect current statement instrumentation events.",
+        _PERFORMANCE_SCHEMA,
+        value_type="boolean",
+    ),
+    _read_only(
+        "performance_schema_consumer_events_statements_history",
+        "Statement event history",
+        "Performance Schema",
+        "Collect short statement instrumentation history.",
+        _PERFORMANCE_SCHEMA,
+        value_type="boolean",
+    ),
+    _read_only(
+        "performance_schema_consumer_events_statements_history_long",
+        "Long statement event history",
+        "Performance Schema",
+        "Collect long statement instrumentation history.",
+        _PERFORMANCE_SCHEMA,
+        value_type="boolean",
+    ),
+    _read_only(
+        "performance_schema_consumer_events_stages_current",
+        "Current stage events",
+        "Performance Schema",
+        "Collect current execution-stage instrumentation events.",
+        _PERFORMANCE_SCHEMA,
+        value_type="boolean",
+    ),
+    _read_only(
+        "performance_schema_consumer_events_stages_history",
+        "Stage event history",
+        "Performance Schema",
+        "Collect short execution-stage instrumentation history.",
+        _PERFORMANCE_SCHEMA,
+        value_type="boolean",
+    ),
+    _read_only(
+        "performance_schema_consumer_events_stages_history_long",
+        "Long stage event history",
+        "Performance Schema",
+        "Collect long execution-stage instrumentation history.",
+        _PERFORMANCE_SCHEMA,
+        value_type="boolean",
+    ),
+    _read_only(
+        "performance_schema_consumer_events_waits_current",
+        "Current wait events",
+        "Performance Schema",
+        "Collect current wait instrumentation events.",
+        _PERFORMANCE_SCHEMA,
+        value_type="boolean",
+    ),
+    _read_only(
+        "performance_schema_consumer_events_waits_history",
+        "Wait event history",
+        "Performance Schema",
+        "Collect short wait instrumentation history.",
+        _PERFORMANCE_SCHEMA,
+        value_type="boolean",
+    ),
+    _read_only(
+        "performance_schema_consumer_events_waits_history_long",
+        "Long wait event history",
+        "Performance Schema",
+        "Collect long wait instrumentation history.",
+        _PERFORMANCE_SCHEMA,
+        value_type="boolean",
+    ),
+)
+
+MARIADB_VARIABLES_BY_NAME = {spec.name: spec for spec in MARIADB_VARIABLE_SPECS}
+MARIADB_VARIABLE_NAMES = frozenset(MARIADB_VARIABLES_BY_NAME)
+EDITABLE_MARIADB_VARIABLE_NAMES = frozenset(spec.name for spec in MARIADB_VARIABLE_SPECS if spec.editable)
+
+
+def mariadb_variable_spec(name: str) -> MariaDBVariableSpec:
+    try:
+        return MARIADB_VARIABLES_BY_NAME[name]
+    except KeyError as exc:
+        raise ValueError(f"MariaDB variable '{name}' is not supported by Pilot.") from exc

--- a/pilot/managers/database/mariadb.py
+++ b/pilot/managers/database/mariadb.py
@@ -3,12 +3,18 @@ import os
 import re
 import subprocess
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import NoReturn
 
 from pilot.config import MariaDBConfig
+from pilot.core.database.mariadb_variables import (
+    EDITABLE_MARIADB_VARIABLE_NAMES,
+    MARIADB_VARIABLE_NAMES,
+    MariaDBValue,
+    mariadb_variable_spec,
+)
 from pilot.core.mariadb_memory import (
     MariaDBMemorySizing,
     MariaDBVariableLimits,
@@ -428,6 +434,125 @@ class MariaDBManager(UserOwnedDBManager):
                     apply_error,
                 )
             return True
+
+    def global_variable_values(self, variable_names: Iterable[str]) -> dict[str, str]:
+        """Read known variables in one query without interpolating their names."""
+        names = tuple(dict.fromkeys(variable_names))
+        unsupported = set(names) - MARIADB_VARIABLE_NAMES
+        if unsupported:
+            name = sorted(unsupported)[0]
+            raise DatabaseError(f"Pilot cannot read MariaDB variable '{name}'.")
+        if not names:
+            return {}
+
+        placeholders = ", ".join(["%s"] * len(names))
+        connection = None
+        try:
+            connection = self.connect()
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT VARIABLE_NAME, VARIABLE_VALUE "
+                    "FROM information_schema.GLOBAL_VARIABLES "
+                    f"WHERE VARIABLE_NAME IN ({placeholders})",
+                    names,
+                )
+                rows = cursor.fetchall()
+        except Exception as exc:
+            raise DatabaseError("Could not read MariaDB configuration variables.") from exc
+        finally:
+            if connection is not None:
+                connection.close()
+        return {str(name).lower(): str(value) for name, value in rows}
+
+    def set_configuration_variable(self, name: str, value: MariaDBValue) -> bool:
+        """Persist, apply, verify, and roll back one safe dynamic variable."""
+        spec = self._configuration_variable_spec(name)
+        try:
+            requested = spec.validate_input(value)
+        except ValueError as exc:
+            raise DatabaseError(str(exc)) from exc
+        if not spec.dynamic:
+            raise DatabaseError(f"MariaDB variable '{name}' cannot be changed while running.")
+        self._require_linux_managed_server()
+
+        with self.database_action_lock():
+            self._require_healthy_server()
+            previous = self._read_configuration_variable(name)
+            if previous == requested:
+                return False
+
+            self.ensure_managed_config()
+            previous_content = self.managed_cnf_path.read_text(encoding="utf-8")
+            self._write_managed_option(spec.option_name, spec.option_value(requested))
+            try:
+                self._set_configuration_variable(name, requested)
+                self._verify_configuration_variable(name, requested)
+            except Exception as apply_error:
+                self._rollback_configuration_variable(
+                    previous_content,
+                    name,
+                    previous,
+                    apply_error,
+                )
+            return True
+
+    def _read_configuration_variable(self, name: str) -> MariaDBValue:
+        spec = self._configuration_variable_spec(name)
+        raw_value = self.global_variable_values((name,)).get(name)
+        if raw_value is None:
+            raise DatabaseError(f"MariaDB variable '{name}' is not exposed by the installed MariaDB version.")
+        try:
+            return spec.parse_server_value(raw_value)
+        except ValueError as exc:
+            raise DatabaseError(str(exc)) from exc
+
+    def _set_configuration_variable(self, name: str, value: MariaDBValue) -> None:
+        spec = self._configuration_variable_spec(name)
+        try:
+            validated = spec.validate_input(value)
+        except ValueError as exc:
+            raise DatabaseError(str(exc)) from exc
+        sql_value = int(validated) if type(validated) is bool else validated
+        connection = None
+        try:
+            connection = self.connect()
+            with connection.cursor() as cursor:
+                cursor.execute(f"SET GLOBAL {spec.name} = %s", (sql_value,))
+        except Exception as exc:
+            raise DatabaseError(f"Could not update MariaDB variable '{name}'.") from exc
+        finally:
+            if connection is not None:
+                connection.close()
+
+    def _verify_configuration_variable(self, name: str, expected: MariaDBValue) -> None:
+        if self._read_configuration_variable(name) != expected:
+            raise DatabaseError(f"MariaDB did not apply the requested value for '{name}'.")
+
+    def _rollback_configuration_variable(
+        self,
+        previous_content: str,
+        name: str,
+        previous_value: MariaDBValue,
+        apply_error: Exception,
+    ) -> NoReturn:
+        try:
+            atomic_write_private_text(self.managed_cnf_path, previous_content)
+            self._set_configuration_variable(name, previous_value)
+            self._verify_configuration_variable(name, previous_value)
+        except Exception as rollback_error:
+            raise DatabaseError(
+                f"Could not apply MariaDB variable '{name}', and restoring the previous "
+                f"configuration also failed: {rollback_error}"
+            ) from apply_error
+        raise DatabaseError(
+            f"Could not apply MariaDB variable '{name}'. The previous configuration was restored."
+        ) from apply_error
+
+    @staticmethod
+    def _configuration_variable_spec(name: str):
+        if name not in EDITABLE_MARIADB_VARIABLE_NAMES:
+            raise DatabaseError(f"Pilot cannot change MariaDB variable '{name}'.")
+        return mariadb_variable_spec(name)
 
     def _read_global_integer(self, variable: str) -> int:
         self._require_supported_integer_variable(variable)

--- a/pilot/managers/database/mariadb.py
+++ b/pilot/managers/database/mariadb.py
@@ -10,7 +10,7 @@ from typing import NoReturn
 
 from pilot.config import MariaDBConfig
 from pilot.core.database.mariadb_variables import (
-    EDITABLE_MARIADB_VARIABLE_NAMES,
+    GENERIC_EDITABLE_MARIADB_VARIABLE_NAMES,
     MARIADB_VARIABLE_NAMES,
     MariaDBValue,
     mariadb_variable_spec,
@@ -550,7 +550,7 @@ class MariaDBManager(UserOwnedDBManager):
 
     @staticmethod
     def _configuration_variable_spec(name: str):
-        if name not in EDITABLE_MARIADB_VARIABLE_NAMES:
+        if name not in GENERIC_EDITABLE_MARIADB_VARIABLE_NAMES:
             raise DatabaseError(f"Pilot cannot change MariaDB variable '{name}'.")
         return mariadb_variable_spec(name)
 

--- a/pilot/tasks/set_mariadb_configuration.py
+++ b/pilot/tasks/set_mariadb_configuration.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import ClassVar
+
+from pilot.core.database.configurations import DatabaseConfigurations
+from pilot.exceptions import DatabaseError
+from pilot.tasks import Task, step
+
+
+@dataclass(kw_only=True)
+class SetMariaDBConfigurationTask(Task):
+    command: ClassVar[str] = "set-mariadb-configuration"
+    is_cancellable_while_running: ClassVar[bool] = False
+    _AUDIT_ARG_KEYS: ClassVar[tuple[str, ...]] = ("variable", "value_json")
+
+    variable: str
+    value_json: str
+
+    @step("configure", lambda self: f"Updating MariaDB variable {self.variable}")
+    def run(self) -> None:
+        try:
+            value = json.loads(self.value_json)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise DatabaseError("The MariaDB configuration value is invalid.") from exc
+        DatabaseConfigurations(self.bench.config).set(self.variable, value)
+
+
+if __name__ == "__main__":
+    SetMariaDBConfigurationTask.main()

--- a/tests/admin/backend/api/test_databases_view.py
+++ b/tests/admin/backend/api/test_databases_view.py
@@ -136,6 +136,7 @@ def test_database_configuration_queues_typed_guarded_task(tmp_path: Path) -> Non
     client = _client(tmp_path / "benches" / "current")
     configurations = Mock()
     configurations.prepare_change.return_value = {
+        "action": "configuration",
         "name": "connect_timeout",
         "value": 20,
         "current": 10,
@@ -167,6 +168,82 @@ def test_database_configuration_queues_typed_guarded_task(tmp_path: Path) -> Non
         "variable": "connect_timeout",
         "value_json": "20",
         "idempotency_key": "connect-timeout-20",
+        "resource_key": "database-server",
+    }
+
+
+@pytest.mark.parametrize(
+    ("variable", "value", "current", "action", "task", "task_argument"),
+    [
+        (
+            "max_connections",
+            40,
+            50,
+            "max_connections",
+            "SetMaxDatabaseConnectionsTask",
+            {"max_connections": 40},
+        ),
+        (
+            "innodb_buffer_pool_size",
+            256,
+            128,
+            "innodb_buffer_pool_size",
+            "SetInnoDBBufferPoolSizeTask",
+            {"size_mb": 256},
+        ),
+        (
+            "performance_schema",
+            True,
+            False,
+            "performance_schema",
+            "SetPerformanceSchemaTask",
+            {"state": "enabled"},
+        ),
+    ],
+)
+def test_database_configuration_routes_guarded_variables_to_specialized_tasks(
+    tmp_path: Path,
+    variable: str,
+    value,
+    current,
+    action: str,
+    task: str,
+    task_argument: dict,
+) -> None:
+    client = _client(tmp_path / "benches" / "current")
+    configurations = Mock()
+    configurations.prepare_change.return_value = {
+        "action": action,
+        "name": variable,
+        "value": value,
+        "current": current,
+        "changed": True,
+    }
+    with (
+        patch(
+            "admin.backend.api.v1.databases._configurations",
+            return_value=configurations,
+        ),
+        patch(
+            f"admin.backend.api.v1.databases.{task}.queue",
+            return_value="task-database-configuration",
+        ) as queue,
+        patch(
+            "admin.backend.api.v1.databases.accepted_task_response",
+            return_value=({"task_id": "task-database-configuration"}, 202),
+        ),
+    ):
+        response = client.post(
+            f"/api/v1/database/configurations/{variable}",
+            json={"value": value},
+            headers={"Idempotency-Key": "config-guarded-variable"},
+        )
+
+    assert response.status_code == 202
+    configurations.prepare_change.assert_called_once_with(variable, value)
+    assert queue.call_args.kwargs == {
+        **task_argument,
+        "idempotency_key": "config-guarded-variable",
         "resource_key": "database-server",
     }
 

--- a/tests/admin/backend/api/test_databases_view.py
+++ b/tests/admin/backend/api/test_databases_view.py
@@ -103,6 +103,158 @@ def test_database_quick_actions_returns_capability_payload(tmp_path: Path) -> No
     assert response.get_json() == payload
 
 
+def test_database_configurations_returns_catalog_payload(tmp_path: Path) -> None:
+    client = _client(tmp_path / "benches" / "current")
+    payload = {
+        "engine": "mariadb",
+        "managed": True,
+        "readable": True,
+        "editable": True,
+        "reason": "",
+        "edit_reason": "",
+        "variables": [
+            {
+                "name": "connect_timeout",
+                "value": 10,
+                "editable": True,
+            }
+        ],
+    }
+    configurations = Mock()
+    configurations.snapshot.return_value = payload
+    with patch(
+        "admin.backend.api.v1.databases._configurations",
+        return_value=configurations,
+    ):
+        response = client.get("/api/v1/database/configurations")
+
+    assert response.status_code == 200
+    assert response.get_json() == payload
+
+
+def test_database_configuration_queues_typed_guarded_task(tmp_path: Path) -> None:
+    client = _client(tmp_path / "benches" / "current")
+    configurations = Mock()
+    configurations.prepare_change.return_value = {
+        "name": "connect_timeout",
+        "value": 20,
+        "current": 10,
+        "changed": True,
+    }
+    with (
+        patch(
+            "admin.backend.api.v1.databases._configurations",
+            return_value=configurations,
+        ),
+        patch(
+            "admin.backend.api.v1.databases.SetMariaDBConfigurationTask.queue",
+            return_value="task-config",
+        ) as queue,
+        patch(
+            "admin.backend.api.v1.databases.accepted_task_response",
+            return_value=({"task_id": "task-config"}, 202),
+        ),
+    ):
+        response = client.post(
+            "/api/v1/database/configurations/connect_timeout",
+            json={"value": 20},
+            headers={"Idempotency-Key": "connect-timeout-20"},
+        )
+
+    assert response.status_code == 202
+    configurations.prepare_change.assert_called_once_with("connect_timeout", 20)
+    assert queue.call_args.kwargs == {
+        "variable": "connect_timeout",
+        "value_json": "20",
+        "idempotency_key": "connect-timeout-20",
+        "resource_key": "database-server",
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [None, [], {}, {"other": 20}, {"value": 20, "other": True}],
+)
+def test_database_configuration_requires_exact_value_payload(
+    tmp_path: Path,
+    payload,
+) -> None:
+    client = _client(tmp_path / "benches" / "current")
+    response = client.post(
+        "/api/v1/database/configurations/connect_timeout",
+        json=payload,
+    )
+
+    assert response.status_code == 422
+    assert response.get_json()["error"]["code"] == "invalid_database_configuration"
+
+
+def test_unchanged_database_configuration_does_not_queue_task(tmp_path: Path) -> None:
+    client = _client(tmp_path / "benches" / "current")
+    configurations = Mock()
+    configurations.prepare_change.return_value = {
+        "name": "connect_timeout",
+        "value": 10,
+        "current": 10,
+        "changed": False,
+    }
+    with (
+        patch(
+            "admin.backend.api.v1.databases._configurations",
+            return_value=configurations,
+        ),
+        patch("admin.backend.api.v1.databases.SetMariaDBConfigurationTask.queue") as queue,
+    ):
+        response = client.post(
+            "/api/v1/database/configurations/connect_timeout",
+            json={"value": 10},
+        )
+
+    assert response.status_code == 409
+    assert response.get_json()["error"]["code"] == "database_configuration_unchanged"
+    queue.assert_not_called()
+
+
+def test_database_configuration_validation_error_is_unprocessable(tmp_path: Path) -> None:
+    client = _client(tmp_path / "benches" / "current")
+    configurations = Mock()
+    configurations.prepare_change.side_effect = ValueError(
+        "Connection handshake timeout must be at least 2 seconds."
+    )
+    with patch(
+        "admin.backend.api.v1.databases._configurations",
+        return_value=configurations,
+    ):
+        response = client.post(
+            "/api/v1/database/configurations/connect_timeout",
+            json={"value": 1},
+        )
+
+    assert response.status_code == 422
+    assert response.get_json()["error"]["message"] == (
+        "Connection handshake timeout must be at least 2 seconds."
+    )
+
+
+def test_database_configuration_policy_error_is_conflict(tmp_path: Path) -> None:
+    client = _client(tmp_path / "benches" / "current")
+    configurations = Mock()
+    configurations.prepare_change.side_effect = DatabaseError(
+        "External MariaDB configurations are read-only."
+    )
+    with patch(
+        "admin.backend.api.v1.databases._configurations",
+        return_value=configurations,
+    ):
+        response = client.post(
+            "/api/v1/database/configurations/connect_timeout",
+            json={"value": 20},
+        )
+
+    assert response.status_code == 409
+    assert response.get_json()["error"]["message"] == ("External MariaDB configurations are read-only.")
+
+
 def test_restart_database_queues_guarded_non_cancellable_task(tmp_path: Path) -> None:
     client = _client(tmp_path / "benches" / "current")
     actions = Mock()
@@ -378,6 +530,7 @@ def test_sizing_actions_return_range_errors_as_unprocessable(
 @pytest.mark.parametrize(
     "path",
     [
+        "/api/v1/database/configurations/connect_timeout",
         "/api/v1/database/quick-actions/restart",
         "/api/v1/database/quick-actions/performance-schema",
         "/api/v1/database/quick-actions/innodb-buffer-pool-size",

--- a/tests/pilot/core/test_database_configurations.py
+++ b/tests/pilot/core/test_database_configurations.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from pilot.config import BenchConfig
+from pilot.core.database.configurations import DatabaseConfigurations
+from pilot.core.database.mariadb_variables import (
+    EDITABLE_MARIADB_VARIABLE_NAMES,
+    MARIADB_VARIABLE_NAMES,
+    MARIADB_VARIABLE_SPECS,
+    mariadb_variable_spec,
+)
+from pilot.exceptions import DatabaseError
+from pilot.managers.database.mariadb import MariaDBManager
+
+MODULE = "pilot.core.database.configurations"
+
+PRESS_VARIABLE_NAMES = frozenset(
+    {
+        "binlog_expire_logs_seconds",
+        "binlog_format",
+        "connect_timeout",
+        "expire_logs_days",
+        "extra_max_connections",
+        "extra_port",
+        "innodb_buffer_pool_size",
+        "innodb_force_recovery",
+        "innodb_lock_wait_timeout",
+        "innodb_log_file_size",
+        "innodb_old_blocks_pct",
+        "innodb_old_blocks_time",
+        "innodb_print_all_deadlocks",
+        "innodb_stats_persistent_sample_pages",
+        "innodb_status_output_locks",
+        "innodb_strict_mode",
+        "key_buffer_size",
+        "local_infile",
+        "log_bin",
+        "log_slave_updates",
+        "long_query_time",
+        "max_allowed_packet",
+        "max_connections",
+        "max_heap_table_size",
+        "max_statement_time",
+        "max_user_connections",
+        "myisam_recover_options",
+        "net_buffer_length",
+        "net_read_timeout",
+        "net_write_timeout",
+        "performance_schema",
+        "performance_schema_consumer_events_stages_current",
+        "performance_schema_consumer_events_stages_history",
+        "performance_schema_consumer_events_stages_history_long",
+        "performance_schema_consumer_events_statements_current",
+        "performance_schema_consumer_events_statements_history",
+        "performance_schema_consumer_events_statements_history_long",
+        "performance_schema_consumer_events_waits_current",
+        "performance_schema_consumer_events_waits_history",
+        "performance_schema_consumer_events_waits_history_long",
+        "performance_schema_instrument",
+        "read_only",
+        "tmp_disk_table_size",
+        "tmp_table_size",
+        "tmpdir",
+        "wait_timeout",
+    }
+)
+
+
+def _config(
+    *,
+    db_type: str = "mariadb",
+    existing: bool = False,
+    allow_management: bool = True,
+) -> BenchConfig:
+    config = BenchConfig.default("test")
+    config.db_type = db_type
+    config.mariadb.existing = existing
+    config.admin.allow_bench_management = allow_management
+    return config
+
+
+def _manager(values: dict[str, str] | None = None) -> Mock:
+    manager = Mock(spec=MariaDBManager)
+    manager.is_installed.return_value = True
+    manager.is_provisioned.return_value = True
+    manager.is_healthy.return_value = True
+    manager.global_variable_values.return_value = values or {}
+    return manager
+
+
+def test_catalog_covers_press_variables_and_pilot_mariadb_118_controls() -> None:
+    assert len(MARIADB_VARIABLE_NAMES) == 51
+    assert len(MARIADB_VARIABLE_NAMES) == len(MARIADB_VARIABLE_SPECS)
+    assert PRESS_VARIABLE_NAMES <= MARIADB_VARIABLE_NAMES
+    assert {
+        "connect_timeout",
+        "innodb_buffer_pool_size",
+        "performance_schema",
+        "local_infile",
+        "innodb_buffer_pool_size_max",
+        "innodb_buffer_pool_size_auto_min",
+        "innodb_snapshot_isolation",
+        "slave_connections_needed_for_purge",
+    } <= MARIADB_VARIABLE_NAMES
+    assert {
+        "connect_timeout",
+        "innodb_lock_wait_timeout",
+        "innodb_old_blocks_pct",
+        "innodb_old_blocks_time",
+        "innodb_print_all_deadlocks",
+        "innodb_stats_persistent_sample_pages",
+        "net_read_timeout",
+        "net_write_timeout",
+        "wait_timeout",
+    } == EDITABLE_MARIADB_VARIABLE_NAMES
+
+
+def test_snapshot_reads_catalog_once_and_marks_only_safe_variables_editable() -> None:
+    manager = _manager(
+        {
+            "connect_timeout": "10",
+            "innodb_print_all_deadlocks": "ON",
+            "max_connections": "50",
+        }
+    )
+    with patch(f"{MODULE}.is_linux", return_value=True):
+        result = DatabaseConfigurations(_config(), manager).snapshot()
+
+    rows = {row["name"]: row for row in result["variables"]}
+    assert result["readable"] is True
+    assert result["editable"] is True
+    assert rows["connect_timeout"]["value"] == 10
+    assert rows["connect_timeout"]["editable"] is True
+    assert rows["connect_timeout"]["min"] == 2
+    assert rows["innodb_print_all_deadlocks"]["value"] is True
+    assert rows["max_connections"]["value"] == 50
+    assert rows["max_connections"]["editable"] is False
+    assert "Quick actions" in rows["max_connections"]["reason"]
+    assert rows["local_infile"]["supported"] is False
+    manager.global_variable_values.assert_called_once()
+    requested = set(manager.global_variable_values.call_args.args[0])
+    assert requested == MARIADB_VARIABLE_NAMES
+
+
+def test_external_mariadb_values_are_readable_but_all_edits_are_disabled() -> None:
+    manager = _manager({"connect_timeout": "10"})
+    result = DatabaseConfigurations(_config(existing=True), manager).snapshot()
+
+    assert result["managed"] is False
+    assert result["readable"] is True
+    assert result["editable"] is False
+    assert "External MariaDB configurations are read-only" in result["edit_reason"]
+    assert all(row["editable"] is False for row in result["variables"])
+    manager.is_installed.assert_not_called()
+    manager.is_provisioned.assert_not_called()
+
+
+def test_non_mariadb_snapshot_returns_capability_response_without_manager() -> None:
+    result = DatabaseConfigurations(_config(db_type="sqlite")).snapshot()
+
+    assert result == {
+        "engine": "sqlite",
+        "managed": False,
+        "readable": False,
+        "editable": False,
+        "reason": "Database configurations are available only when the bench uses MariaDB.",
+        "edit_reason": "Database configurations are available only when the bench uses MariaDB.",
+        "variables": [],
+    }
+
+
+def test_unprovisioned_server_is_not_probed() -> None:
+    manager = _manager()
+    manager.is_provisioned.return_value = False
+
+    result = DatabaseConfigurations(_config(), manager).snapshot()
+
+    assert result["readable"] is False
+    assert "has not been provisioned" in result["reason"]
+    manager.is_healthy.assert_not_called()
+    manager.global_variable_values.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "message"),
+    [
+        ("connect_timeout", True, "whole number"),
+        ("connect_timeout", "10", "whole number"),
+        ("connect_timeout", 1, "at least 2"),
+        ("connect_timeout", 61, "greater than 60"),
+        ("innodb_print_all_deadlocks", 1, "enabled or disabled"),
+        ("innodb_print_all_deadlocks", "ON", "enabled or disabled"),
+        ("max_connections", 50, "read-only"),
+        ("unknown_variable", 1, "not supported"),
+    ],
+)
+def test_catalog_rejects_wrong_types_ranges_and_read_only_variables(
+    name: str,
+    value,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        mariadb_variable_spec(name).validate_input(value)
+
+
+def test_prepare_change_normalizes_live_value_and_detects_noop() -> None:
+    manager = _manager({"connect_timeout": "10"})
+    configurations = DatabaseConfigurations(_config(), manager)
+
+    with patch(f"{MODULE}.is_linux", return_value=True):
+        change = configurations.prepare_change("connect_timeout", 10)
+
+    assert change == {
+        "name": "connect_timeout",
+        "value": 10,
+        "current": 10,
+        "changed": False,
+    }
+
+
+def test_prepare_change_rejects_external_server_before_queueing() -> None:
+    manager = _manager({"connect_timeout": "10"})
+
+    with pytest.raises(DatabaseError, match="External MariaDB configurations are read-only"):
+        DatabaseConfigurations(_config(existing=True), manager).prepare_change(
+            "connect_timeout",
+            20,
+        )
+
+
+def test_set_revalidates_policy_and_forwards_normalized_value() -> None:
+    manager = _manager()
+    manager.set_configuration_variable.return_value = True
+    configurations = DatabaseConfigurations(_config(), manager)
+
+    with patch(f"{MODULE}.is_linux", return_value=True):
+        assert configurations.set("innodb_print_all_deadlocks", False) is True
+
+    manager.set_configuration_variable.assert_called_once_with(
+        "innodb_print_all_deadlocks",
+        False,
+    )

--- a/tests/pilot/core/test_database_configurations.py
+++ b/tests/pilot/core/test_database_configurations.py
@@ -12,6 +12,7 @@ from pilot.core.database.mariadb_variables import (
     MARIADB_VARIABLE_SPECS,
     mariadb_variable_spec,
 )
+from pilot.core.mariadb_memory import calculate_mariadb_variable_limits
 from pilot.exceptions import DatabaseError
 from pilot.managers.database.mariadb import MariaDBManager
 
@@ -88,6 +89,11 @@ def _manager(values: dict[str, str] | None = None) -> Mock:
     manager.is_provisioned.return_value = True
     manager.is_healthy.return_value = True
     manager.global_variable_values.return_value = values or {}
+    manager.performance_schema_enabled.return_value = False
+    manager.variable_limits.return_value = calculate_mariadb_variable_limits(2048)
+    manager.innodb_buffer_pool_size_mb.return_value = 128
+    manager.innodb_buffer_pool_size_max_mb.return_value = 352
+    manager.max_connections.return_value = 50
     return manager
 
 
@@ -107,23 +113,29 @@ def test_catalog_covers_press_variables_and_pilot_mariadb_118_controls() -> None
     } <= MARIADB_VARIABLE_NAMES
     assert {
         "connect_timeout",
+        "innodb_buffer_pool_size",
         "innodb_lock_wait_timeout",
         "innodb_old_blocks_pct",
         "innodb_old_blocks_time",
         "innodb_print_all_deadlocks",
         "innodb_stats_persistent_sample_pages",
+        "max_connections",
         "net_read_timeout",
         "net_write_timeout",
+        "performance_schema",
         "wait_timeout",
     } == EDITABLE_MARIADB_VARIABLE_NAMES
 
 
-def test_snapshot_reads_catalog_once_and_marks_only_safe_variables_editable() -> None:
+def test_snapshot_exposes_generic_and_guarded_action_variables_as_editable() -> None:
     manager = _manager(
         {
             "connect_timeout": "10",
+            "innodb_buffer_pool_size": str(128 * 1024 * 1024),
+            "innodb_buffer_pool_size_max": str(352 * 1024 * 1024),
             "innodb_print_all_deadlocks": "ON",
             "max_connections": "50",
+            "performance_schema": "OFF",
         }
     )
     with patch(f"{MODULE}.is_linux", return_value=True):
@@ -134,15 +146,70 @@ def test_snapshot_reads_catalog_once_and_marks_only_safe_variables_editable() ->
     assert result["editable"] is True
     assert rows["connect_timeout"]["value"] == 10
     assert rows["connect_timeout"]["editable"] is True
-    assert rows["connect_timeout"]["min"] == 2
+    assert rows["connect_timeout"]["edit"] == {
+        "action": "configuration",
+        "value": 10,
+        "value_type": "integer",
+        "unit": "seconds",
+        "min": 2,
+        "max": 60,
+        "step": 1,
+        "recommended": None,
+        "dynamic_max": None,
+        "requires_restart": False,
+    }
     assert rows["innodb_print_all_deadlocks"]["value"] is True
     assert rows["max_connections"]["value"] == 50
-    assert rows["max_connections"]["editable"] is False
-    assert "Quick actions" in rows["max_connections"]["reason"]
+    assert rows["max_connections"]["editable"] is True
+    assert rows["max_connections"]["edit"] == {
+        "action": "max_connections",
+        "value": 50,
+        "value_type": "integer",
+        "unit": "",
+        "min": 10,
+        "max": 50,
+        "step": 1,
+        "recommended": 50,
+        "dynamic_max": None,
+        "requires_restart": False,
+    }
+    assert rows["innodb_buffer_pool_size"]["editable"] is True
+    assert rows["innodb_buffer_pool_size"]["edit"] == {
+        "action": "innodb_buffer_pool_size",
+        "value": 128,
+        "value_type": "integer",
+        "unit": "MB",
+        "min": 128,
+        "max": 352,
+        "step": 1,
+        "recommended": 128,
+        "dynamic_max": 352,
+        "requires_restart": False,
+    }
+    assert rows["performance_schema"]["editable"] is True
+    assert rows["performance_schema"]["edit"]["action"] == "performance_schema"
+    assert rows["performance_schema"]["edit"]["value"] is False
+    assert rows["innodb_buffer_pool_size_max"]["editable"] is False
     assert rows["local_infile"]["supported"] is False
     manager.global_variable_values.assert_called_once()
+    manager.performance_schema_enabled.assert_not_called()
+    manager.innodb_buffer_pool_size_mb.assert_not_called()
+    manager.innodb_buffer_pool_size_max_mb.assert_not_called()
+    manager.max_connections.assert_not_called()
     requested = set(manager.global_variable_values.call_args.args[0])
     assert requested == MARIADB_VARIABLE_NAMES
+
+
+def test_buffer_pool_editor_requires_the_mariadb_118_live_ceiling() -> None:
+    manager = _manager({"innodb_buffer_pool_size": str(128 * 1024 * 1024)})
+
+    with patch(f"{MODULE}.is_linux", return_value=True):
+        result = DatabaseConfigurations(_config(), manager).snapshot()
+
+    row = next(variable for variable in result["variables"] if variable["name"] == "innodb_buffer_pool_size")
+    assert row["editable"] is False
+    assert row["edit"] is None
+    assert "does not expose the live Buffer Pool ceiling" in row["reason"]
 
 
 def test_external_mariadb_values_are_readable_but_all_edits_are_disabled() -> None:
@@ -193,7 +260,7 @@ def test_unprovisioned_server_is_not_probed() -> None:
         ("connect_timeout", 61, "greater than 60"),
         ("innodb_print_all_deadlocks", 1, "enabled or disabled"),
         ("innodb_print_all_deadlocks", "ON", "enabled or disabled"),
-        ("max_connections", 50, "read-only"),
+        ("innodb_buffer_pool_size_max", 256, "read-only"),
         ("unknown_variable", 1, "not supported"),
     ],
 )
@@ -206,6 +273,11 @@ def test_catalog_rejects_wrong_types_ranges_and_read_only_variables(
         mariadb_variable_spec(name).validate_input(value)
 
 
+def test_guarded_action_variables_cannot_reach_the_generic_manager_path() -> None:
+    with pytest.raises(ValueError, match="guarded database action"):
+        mariadb_variable_spec("max_connections").validate_input(40)
+
+
 def test_prepare_change_normalizes_live_value_and_detects_noop() -> None:
     manager = _manager({"connect_timeout": "10"})
     configurations = DatabaseConfigurations(_config(), manager)
@@ -214,10 +286,43 @@ def test_prepare_change_normalizes_live_value_and_detects_noop() -> None:
         change = configurations.prepare_change("connect_timeout", 10)
 
     assert change == {
+        "action": "configuration",
         "name": "connect_timeout",
         "value": 10,
         "current": 10,
         "changed": False,
+    }
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "current", "action"),
+    [
+        ("max_connections", 40, 50, "max_connections"),
+        ("innodb_buffer_pool_size", 256, 128, "innodb_buffer_pool_size"),
+        ("performance_schema", True, False, "performance_schema"),
+    ],
+)
+def test_prepare_change_routes_guarded_variables_through_quick_action_policy(
+    name: str,
+    value,
+    current,
+    action: str,
+) -> None:
+    manager = _manager()
+    configurations = DatabaseConfigurations(_config(), manager)
+
+    with (
+        patch(f"{MODULE}.is_linux", return_value=True),
+        patch("pilot.core.database.quick_actions.is_linux", return_value=True),
+    ):
+        change = configurations.prepare_change(name, value)
+
+    assert change == {
+        "action": action,
+        "name": name,
+        "value": value,
+        "current": current,
+        "changed": True,
     }
 
 

--- a/tests/pilot/managers/test_mariadb_manager.py
+++ b/tests/pilot/managers/test_mariadb_manager.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import stat
 import subprocess
-from unittest.mock import Mock, PropertyMock, patch
+from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
 
 import pytest
 
@@ -552,6 +552,158 @@ def test_global_integer_helpers_allow_only_known_variables() -> None:
     ):
         manager._set_global_integer("max_connections; DROP DATABASE mysql", 10)
     connect.assert_not_called()
+
+
+def test_global_variable_catalog_read_uses_parameterized_names() -> None:
+    manager = _manager()
+    connection = MagicMock()
+    cursor = connection.cursor.return_value.__enter__.return_value
+    cursor.fetchall.return_value = [
+        ("CONNECT_TIMEOUT", "10"),
+        ("INNODB_PRINT_ALL_DEADLOCKS", "ON"),
+    ]
+    with patch.object(manager, "connect", return_value=connection):
+        result = manager.global_variable_values(("connect_timeout", "innodb_print_all_deadlocks"))
+
+    assert result == {
+        "connect_timeout": "10",
+        "innodb_print_all_deadlocks": "ON",
+    }
+    sql, parameters = cursor.execute.call_args.args
+    assert "IN (%s, %s)" in sql
+    assert parameters == ("connect_timeout", "innodb_print_all_deadlocks")
+    assert "connect_timeout" not in sql
+    connection.close.assert_called_once()
+
+
+def test_global_variable_catalog_rejects_unknown_name_before_connecting() -> None:
+    manager = _manager()
+    with (
+        patch.object(manager, "connect") as connect,
+        pytest.raises(DatabaseError, match="cannot read"),
+    ):
+        manager.global_variable_values(("connect_timeout; DROP DATABASE mysql",))
+    connect.assert_not_called()
+
+
+def test_safe_configuration_change_applies_live_and_persists(tmp_path) -> None:
+    manager = _manager()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "my.cnf").write_text("# Managed by Pilot.\n[mysqld]\n")
+    managed_file = config_dir / "managed.cnf"
+    managed_file.write_text(
+        "# Managed by Pilot's database variable editor.\n" "[mysqld]\n" "performance-schema = OFF\n"
+    )
+    state = {"connect_timeout": 10}
+
+    def set_value(name, value) -> None:
+        state[name] = value
+
+    with (
+        patch.object(type(manager), "state_dir", new_callable=PropertyMock, return_value=tmp_path),
+        patch(f"{MODULE}.is_macos", return_value=False),
+        patch.object(manager, "is_installed", return_value=True),
+        patch.object(manager, "is_provisioned", return_value=True),
+        patch.object(manager, "is_healthy", return_value=True),
+        patch.object(
+            manager,
+            "_read_configuration_variable",
+            side_effect=lambda name: state[name],
+        ),
+        patch.object(manager, "_set_configuration_variable", side_effect=set_value) as update,
+    ):
+        assert manager.set_configuration_variable("connect_timeout", 20) is True
+
+    update.assert_called_once_with("connect_timeout", 20)
+    assert "connect-timeout = 20" in managed_file.read_text()
+    assert "performance-schema = OFF" in managed_file.read_text()
+
+
+def test_safe_boolean_configuration_is_written_as_on_or_off(tmp_path) -> None:
+    manager = _manager()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "my.cnf").write_text("# Managed by Pilot.\n[mysqld]\n")
+    managed_file = config_dir / "managed.cnf"
+    managed_file.write_text("# Managed by Pilot's database variable editor.\n[mysqld]\n")
+    state = {"innodb_print_all_deadlocks": True}
+
+    def set_value(name, value) -> None:
+        state[name] = value
+
+    with (
+        patch.object(type(manager), "state_dir", new_callable=PropertyMock, return_value=tmp_path),
+        patch(f"{MODULE}.is_macos", return_value=False),
+        patch.object(manager, "is_installed", return_value=True),
+        patch.object(manager, "is_provisioned", return_value=True),
+        patch.object(manager, "is_healthy", return_value=True),
+        patch.object(
+            manager,
+            "_read_configuration_variable",
+            side_effect=lambda name: state[name],
+        ),
+        patch.object(manager, "_set_configuration_variable", side_effect=set_value),
+    ):
+        assert manager.set_configuration_variable("innodb_print_all_deadlocks", False) is True
+
+    assert "innodb-print-all-deadlocks = OFF" in managed_file.read_text()
+
+
+def test_failed_catalog_change_restores_exact_config_and_runtime(tmp_path) -> None:
+    manager = _manager()
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "my.cnf").write_text("# Managed by Pilot.\n[mysqld]\n")
+    managed_file = config_dir / "managed.cnf"
+    previous = "# Managed by Pilot's database variable editor.\n" "[mysqld]\n" "performance-schema = OFF\n"
+    managed_file.write_text(previous)
+
+    with (
+        patch.object(type(manager), "state_dir", new_callable=PropertyMock, return_value=tmp_path),
+        patch(f"{MODULE}.is_macos", return_value=False),
+        patch.object(manager, "is_installed", return_value=True),
+        patch.object(manager, "is_provisioned", return_value=True),
+        patch.object(manager, "is_healthy", return_value=True),
+        patch.object(manager, "_read_configuration_variable", return_value=10),
+        patch.object(manager, "_set_configuration_variable") as update,
+        patch.object(
+            manager,
+            "_verify_configuration_variable",
+            side_effect=[DatabaseError("verification failed"), None],
+        ),
+        pytest.raises(DatabaseError, match="previous configuration was restored"),
+    ):
+        manager.set_configuration_variable("connect_timeout", 20)
+
+    assert managed_file.read_text() == previous
+    assert update.call_args_list == [
+        call("connect_timeout", 20),
+        call("connect_timeout", 10),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "message"),
+    [
+        ("connect_timeout", True, "whole number"),
+        ("connect_timeout", 1, "at least 2"),
+        ("max_connections", 50, "cannot change"),
+        ("connect_timeout; DROP DATABASE mysql", 10, "cannot change"),
+    ],
+)
+def test_catalog_change_rejects_invalid_input_before_touching_server(
+    name: str,
+    value,
+    message: str,
+) -> None:
+    manager = _manager()
+    with (
+        patch.object(manager, "is_installed") as installed,
+        pytest.raises(DatabaseError, match=message),
+    ):
+        manager.set_configuration_variable(name, value)
+    installed.assert_not_called()
 
 
 def test_database_action_lock_is_released_after_action_failure(tmp_path) -> None:

--- a/tests/pilot/tasks/test_mariadb_configuration_task.py
+++ b/tests/pilot/tasks/test_mariadb_configuration_task.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from pilot.exceptions import DatabaseError
+from pilot.internal.tasks.authoring import task_argv_suffix
+from pilot.tasks.set_mariadb_configuration import SetMariaDBConfigurationTask
+
+
+def test_configuration_task_is_not_cancellable_while_mutating_database() -> None:
+    assert SetMariaDBConfigurationTask.is_cancellable_while_running is False
+
+
+def test_configuration_task_preserves_false_as_json_across_cli_boundary() -> None:
+    assert task_argv_suffix(
+        SetMariaDBConfigurationTask,
+        {"variable": "innodb_print_all_deadlocks", "value_json": "false"},
+    ) == ["innodb_print_all_deadlocks", "false"]
+
+
+@pytest.mark.parametrize(
+    ("value_json", "expected"),
+    [("20", 20), ("false", False)],
+)
+def test_configuration_task_decodes_typed_json_and_revalidates(
+    tmp_path: Path,
+    value_json: str,
+    expected,
+) -> None:
+    bench = Mock()
+    configurations = Mock()
+    task = SetMariaDBConfigurationTask(
+        bench=bench,
+        bench_root=tmp_path,
+        variable="connect_timeout",
+        value_json=value_json,
+    )
+
+    with patch(
+        "pilot.tasks.set_mariadb_configuration.DatabaseConfigurations",
+        return_value=configurations,
+    ):
+        task.run()
+
+    configurations.set.assert_called_once_with("connect_timeout", expected)
+
+
+def test_configuration_task_rejects_invalid_json_before_database_call(tmp_path: Path) -> None:
+    bench = Mock()
+    configurations = Mock()
+    task = SetMariaDBConfigurationTask(
+        bench=bench,
+        bench_root=tmp_path,
+        variable="connect_timeout",
+        value_json="not-json",
+    )
+
+    with (
+        patch(
+            "pilot.tasks.set_mariadb_configuration.DatabaseConfigurations",
+            return_value=configurations,
+        ),
+        pytest.raises(DatabaseError, match="value is invalid"),
+    ):
+        task.run()
+
+    configurations.set.assert_not_called()


### PR DESCRIPTION
Add guarded MariaDB configuration editing
- Adds a 51-variable catalog adapted from Press's fixture, with a 9-variable editable allowlist (the rest stay visible but read-only or Quick-Actions-only).
- Validates type/range at the API, task, and manager layers
- Applies changes through the existing database action lock with managed.cnf persistence and rollback on failure.
- Adds a searchable, grouped MariaDB variable browser
- A typed edit dialog under Settings > Database, backed by the new configurations API.

Other UI change:
- /settings/database now displays all Quick Actions under Database actions
- Database configurations appears afterward as a navigable list item

Screenshots
<img width="1069" height="695" alt="Screenshot 2026-08-12 at 1 50 01 PM" src="https://github.com/user-attachments/assets/c00e5b3f-9644-4ce2-b2a1-fd1719712926" />
<img width="1084" height="716" alt="Screenshot 2026-08-12 at 1 50 09 PM" src="https://github.com/user-attachments/assets/20827255-f086-49d8-9d52-700a8a57d2fa" />
<img width="1123" height="694" alt="Screenshot 2026-08-12 at 1 50 21 PM" src="https://github.com/user-attachments/assets/bf2c2697-db17-45c1-9942-e23219ff5595" />



