### PR TITLE
fix(dashboard): upgrade frappe-ui to 1.0.0-beta.50

### DIFF
--- a/admin/frontend/dashboard/package-lock.json
+++ b/admin/frontend/dashboard/package-lock.json
@@ -13,7 +13,7 @@
         "@codemirror/lang-sql": "^6.10.0",
         "@codemirror/state": "^6.7.0",
         "@codemirror/view": "^6.43.4",
-        "frappe-ui": "1.0.0-beta.34",
+        "frappe-ui": "1.0.0-beta.50",
         "ky": "^2.0.2",
         "qrcode.vue": "^3.10.0",
         "vue": "^3.5.0",
@@ -325,6 +325,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -336,6 +337,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -343,6 +345,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -353,6 +356,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -360,6 +364,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -370,6 +375,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -387,6 +393,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
       "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.8.0",
         "@floating-ui/utils": "^0.2.12"
@@ -467,12 +474,6 @@
         "import-meta-resolve": "^4.2.0"
       }
     },
-    "node_modules/@interactjs/types": {
-      "version": "1.10.27",
-      "resolved": "https://registry.npmjs.org/@interactjs/types/-/types-1.10.27.tgz",
-      "integrity": "sha512-BUdv0cvs4H5ODuwft2Xp4eL8Vmi3LcihK42z0Ft/FbVJZoRioBsxH+LlsBdK4tAie7PqlKGy+1oyOncu1nQ6eA==",
-      "license": "MIT"
-    },
     "node_modules/@internationalized/date": {
       "version": "3.12.2",
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
@@ -535,12 +536,6 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@juggle/resize-observer": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
-      "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
-      "license": "Apache-2.0"
     },
     "node_modules/@lezer/common": {
       "version": "1.5.2",
@@ -674,6 +669,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -750,6 +746,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -766,6 +763,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -782,6 +780,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -798,6 +797,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -814,6 +814,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -830,9 +831,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -849,9 +848,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -868,9 +865,7 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -887,9 +882,7 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -906,9 +899,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -925,9 +916,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -944,6 +933,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -960,6 +950,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -978,6 +969,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -994,6 +986,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1095,6 +1088,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.28.0.tgz",
       "integrity": "sha512-gUuD5WAYfbDxNSSJya/emh2KSzXZXLUYKW4fEnc1AQ5FE2twzh4LJ9UlKFIawigrUCAksWI5Fy1hRbv+5m4ZdQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1178,6 +1172,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.28.0.tgz",
       "integrity": "sha512-bHITDzT0umTLh+SiEVQzIXkCMt/TzbPM1+HQy9ZxgQDHAJj/vdmfNAnP3RCOrz4lETXyhNQ2b6kxeu3lWckxyA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1373,6 +1368,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.28.0.tgz",
       "integrity": "sha512-zQ66i5DuhVOndmZ0d7H475Y5Yb+BMx+zfCjFkCzEc6WVef5MumtxBVTkGLQ0ibxUaD71s4QQZbjHWagpaTg0eQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1560,6 +1556,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-3.28.0.tgz",
       "integrity": "sha512-UreMyqZSv770+CXJK/l1qeHUdaNMQAVkxSOPWpiY9FiT8B4OQyjA7WBOlWrzbvVTzfJvXWk2Y3SWgVRx+/Cd9A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1599,6 +1596,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.28.0.tgz",
       "integrity": "sha512-DJT1khCK+O/pT1gQlAnoKAx6zwDkgv7GtnhSfkqm1/4KHC3x+SSJnBIgBl9oGHymA+DxWbW1EULU4V3d/kT2uQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1642,6 +1640,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.28.0.tgz",
       "integrity": "sha512-ALcpwZMUdat9gjJKlpscpoqXStoLhU246LPEVBDvJdIsoUKvUu3MrzfXik2Y8mtSGfhjtm9O2TRkWxQiFVMwsQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.4.1",
         "prosemirror-commands": "^1.7.1",
@@ -1703,6 +1702,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.28.0.tgz",
       "integrity": "sha512-24k0CvvazBeHAK2+WrV1n0uDBZBHNbDAq1K8b5KkWSxcAU7zSCytmApS1u7clRW5wg2xKNBdDhNhvk7KSm1kIA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -1737,6 +1737,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1747,6 +1748,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -1782,26 +1784,6 @@
       "version": "0.0.20",
       "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
       "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
-      "license": "MIT"
-    },
-    "node_modules/@vexip-ui/hooks": {
-      "version": "2.9.4",
-      "resolved": "https://registry.npmjs.org/@vexip-ui/hooks/-/hooks-2.9.4.tgz",
-      "integrity": "sha512-dGUiBAeHIsnSVigGSPHcuHBVqrSGW8LV+zGohvOpBfXs8Ynn5ZcSmybIWJ3G826NsicPu9rqwcJG8uvSgG4k4Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.7.0",
-        "@juggle/resize-observer": "^3.4.0",
-        "@vexip-ui/utils": "2.16.4"
-      },
-      "peerDependencies": {
-        "vue": "^3.2.25"
-      }
-    },
-    "node_modules/@vexip-ui/utils": {
-      "version": "2.16.4",
-      "resolved": "https://registry.npmjs.org/@vexip-ui/utils/-/utils-2.16.4.tgz",
-      "integrity": "sha512-KX+Q4EsuwDp6ZlRJ7OAkiYxu52D5CVM8zpqQz/FXYV+JUtzl9T3dvxgtA8gQ0wm5Sh/xT6jp8Wo4X7tLAzRh/A==",
       "license": "MIT"
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -1884,6 +1866,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.40.tgz",
       "integrity": "sha512-gIf497P4kpuALcvs5n3AEg1Vdn0pSY4XbjASIfHNYF1/MP3T2Mf2STERTubysBxCRxzJGJYtF/O7vwJrxFB3Vw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.29.7",
         "@vue/compiler-core": "3.5.40",
@@ -2288,6 +2271,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.44",
         "caniuse-lite": "^1.0.30001806",
@@ -2408,12 +2392,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/classnames": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT"
-    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -2452,6 +2430,7 @@
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
       "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -2494,17 +2473,6 @@
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
       "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "license": "MIT"
-    },
-    "node_modules/core-js": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
-      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
     },
     "node_modules/crelt": {
       "version": "1.0.7",
@@ -2625,13 +2593,13 @@
       }
     },
     "node_modules/echarts": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
-      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.1.0.tgz",
+      "integrity": "sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.6.1"
+        "zrender": "6.1.0"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2764,16 +2732,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/feather-icons": {
-      "version": "4.29.2",
-      "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-4.29.2.tgz",
-      "integrity": "sha512-0TaCFTnBTVCz6U+baY2UJNKne5ifGh7sMG4ZC2LoBWCZdIyPa+y6UiR4lEYGws1JOFWdee8KAsAIvu0VcXqiqA==",
-      "license": "MIT",
-      "dependencies": {
-        "classnames": "^2.2.5",
-        "core-js": "^3.1.3"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2801,9 +2759,9 @@
       }
     },
     "node_modules/frappe-ui": {
-      "version": "1.0.0-beta.34",
-      "resolved": "https://registry.npmjs.org/frappe-ui/-/frappe-ui-1.0.0-beta.34.tgz",
-      "integrity": "sha512-38E9L2mjz2ayFKuRA692Ao7YSFbotCwTi4gstxskVvb1OgqX/0aCY+NJSrIlCYLLeCtw8+m54D63DKn94KUivA==",
+      "version": "1.0.0-beta.50",
+      "resolved": "https://registry.npmjs.org/frappe-ui/-/frappe-ui-1.0.0-beta.50.tgz",
+      "integrity": "sha512-SXJtgSvbpMYkXFhx1lDkuT1oBRi4pvdI3id3FDQFiHflnr8Ct3T40WZ2YA4xaK/5/JKMOd9NYa5mKcnR2OrdBA==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/lang-css": "^6.3.0",
@@ -2818,7 +2776,6 @@
         "@codemirror/lang-yaml": "^6.1.3",
         "@floating-ui/dom": "^1.7.4",
         "@headlessui/vue": "^1.7.14",
-        "@popperjs/core": "^2.11.2",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/line-clamp": "^0.4.4",
         "@tailwindcss/typography": "^0.5.16",
@@ -2862,11 +2819,9 @@
         "codemirror": "^6.0.1",
         "dayjs": "^1.11.13",
         "dompurify": "^3.4.0",
-        "echarts": "^5.6.0",
+        "echarts": "^6.1.0",
         "es-module-lexer": "^1.7.0",
-        "feather-icons": "^4.28.0",
         "fuzzysort": "^3.1.0",
-        "grid-layout-plus": "^1.1.0",
         "highlight.js": "^11.11.1",
         "idb-keyval": "^6.2.0",
         "lowlight": "^3.3.0",
@@ -2951,20 +2906,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/grid-layout-plus": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/grid-layout-plus/-/grid-layout-plus-1.1.1.tgz",
-      "integrity": "sha512-7CWehJubrVC8Ps5QFUlnDsp0kiREvKfi3Pdjp21EyY8BNzSusqI3Utcxvu1Y9UUKe3YExvbhJzIxHK6rorbRaQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@vexip-ui/hooks": "^2.8.0",
-        "@vexip-ui/utils": "^2.16.1",
-        "interactjs": "^1.10.27"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2991,6 +2932,7 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -3036,15 +2978,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/interactjs": {
-      "version": "1.10.27",
-      "resolved": "https://registry.npmjs.org/interactjs/-/interactjs-1.10.27.tgz",
-      "integrity": "sha512-y/8RcCftGAF24gSp76X2JS3XpHiUvDQyhF8i7ujemBz77hwiHDuJzftHx7thY8cxGogwGiPJ+o97kWB6eAXnsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@interactjs/types": "1.10.27"
-      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -3129,6 +3062,7 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3188,6 +3122,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3208,6 +3143,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3228,6 +3164,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3248,6 +3185,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3268,6 +3206,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3288,9 +3227,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3311,9 +3248,7 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3334,9 +3269,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3357,9 +3290,7 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3380,6 +3311,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3400,6 +3332,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3475,6 +3408,7 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -3814,6 +3748,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -4317,6 +4252,7 @@
       "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.139.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -4542,6 +4478,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -4655,6 +4592,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4701,6 +4639,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5080,6 +5019,7 @@
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -5177,6 +5117,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
       "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.40",
         "@vue/compiler-sfc": "3.5.40",
@@ -5214,6 +5155,7 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },
@@ -5314,9 +5256,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
-      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.1.0.tgz",
+      "integrity": "sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "tslib": "2.3.0"

--- a/admin/frontend/dashboard/package.json
+++ b/admin/frontend/dashboard/package.json
@@ -15,7 +15,7 @@
     "@codemirror/lang-sql": "^6.10.0",
     "@codemirror/state": "^6.7.0",
     "@codemirror/view": "^6.43.4",
-    "frappe-ui": "1.0.0-beta.34",
+    "frappe-ui": "1.0.0-beta.50",
     "ky": "^2.0.2",
     "qrcode.vue": "^3.10.0",
     "vue": "^3.5.0",

--- a/admin/frontend/dashboard/src/App.vue
+++ b/admin/frontend/dashboard/src/App.vue
@@ -12,16 +12,16 @@
 <script setup>
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-import { useTheme, FrappeUIProvider } from 'frappe-ui'
+import { FrappeUIProvider } from 'frappe-ui'
 import ReconnectOverlay from './components/common/ReconnectOverlay.vue'
 import SignedOutDialog from './components/common/SignedOutDialog.vue'
 import MainLayout from './layouts/MainLayout.vue'
 import { useSetupHandoff } from './composables/setup/useSetupHandoff'
+import { useTheme } from './composables/common/useTheme'
 
 const route = useRoute()
 const isFullScreen = computed(() => route.meta.fullScreen === true)
 const { awaitingTerminal } = useSetupHandoff()
-const { initializeTheme } = useTheme()
-
-initializeTheme()
+// Restores the saved light/dark preference on first call.
+useTheme()
 </script>

--- a/admin/frontend/dashboard/src/components/apps/AddAppFromGithubDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/AddAppFromGithubDialog.vue
@@ -38,13 +38,12 @@
             <p v-if="!gitStatus" class="text-ink-gray-5 text-sm">Loading…</p>
             <Alert
               v-else-if="!gitConnected"
-              theme="yellow"
+              theme="amber"
               title="No GitHub account connected"
-              :dismissible="false"
             />
             <template v-else>
               <div
-                class="flex items-center gap-2 bg-surface-gray-1 px-3 py-2 border rounded-lg border-outline-gray-2"
+                class="flex items-center gap-2 bg-surface-gray-1 px-3 py-2 border rounded-6 border-outline-gray-2"
               >
                 <span class="text-ink-gray-7 text-sm">
                   Connected as

--- a/admin/frontend/dashboard/src/components/apps/UninstallAppDialog.vue
+++ b/admin/frontend/dashboard/src/components/apps/UninstallAppDialog.vue
@@ -15,7 +15,7 @@
         v-for="option in options"
         :key="option.value"
         type="button"
-        class="flex items-start gap-2.5 p-2.5 rounded text-left transition duration-150 ease-[var(--ease-out)] active:scale-[0.98]"
+        class="flex items-start gap-2.5 p-2.5 rounded-4 text-left transition duration-150 ease-[var(--ease-out)] active:scale-[0.98]"
         :class="mode === option.value ? 'bg-surface-gray-3' : 'hover:bg-surface-gray-2'"
         @click="mode = option.value"
       >

--- a/admin/frontend/dashboard/src/components/benches/BenchSwitcherDialog.vue
+++ b/admin/frontend/dashboard/src/components/benches/BenchSwitcherDialog.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, watch } from 'vue'
-import { Badge, Button, Dialog, ErrorMessage, ListView, Spinner } from 'frappe-ui'
+import { Badge, Button, Dialog, ErrorMessage, Spinner } from 'frappe-ui'
+import { ListView } from 'frappe-ui/experimental'
 import { useBenches } from '@/composables/benches/useBenches'
 import ActionMenu from '@/components/common/ActionMenu.vue'
 import LucidePlus from '~icons/lucide/plus'

--- a/admin/frontend/dashboard/src/components/benches/NewBenchDialog.vue
+++ b/admin/frontend/dashboard/src/components/benches/NewBenchDialog.vue
@@ -271,7 +271,7 @@ async function createBench() {
             command line :
           </p>
           <pre
-            class="bg-surface-gray-2 px-3 py-2.5 rounded-lg text-ink-gray-8 text-sm select-all"
+            class="bg-surface-gray-2 px-3 py-2.5 rounded-6 text-ink-gray-8 text-sm select-all"
           >pilot new my-bench</pre>
         </div>
 
@@ -293,7 +293,7 @@ async function createBench() {
                 v-for="opt in processManagerOptions"
                 :key="opt.value"
                 type="button"
-                class="px-3 py-2 border rounded-lg text-left transition-colors"
+                class="px-3 py-2 border rounded-6 text-left transition-colors"
                 :class="processManager === opt.value
                   ? 'border-outline-gray-3 bg-surface-gray-2'
                   : 'border-outline-gray-2 hover:bg-surface-alpha-gray-1'"
@@ -314,7 +314,7 @@ async function createBench() {
                 @input="error = ''"
                 @keyup.enter="createBench"
               />
-              <p class="bg-surface-gray-2 mt-1.5 px-2.5 py-2 rounded text-ink-gray-6 text-xs">
+              <p class="bg-surface-gray-2 mt-1.5 px-2.5 py-2 rounded-4 text-ink-gray-6 text-xs">
                 Point this domain's DNS A record to this server <b>before</b> creating the bench. It
                 isn't provisioned automatically, so setup can't be reached until it resolves here.
               </p>

--- a/admin/frontend/dashboard/src/components/common/ActionDialog.vue
+++ b/admin/frontend/dashboard/src/components/common/ActionDialog.vue
@@ -32,7 +32,7 @@
 
         <div
           v-if="warning"
-          class="flex items-start gap-3 bg-surface-red-1 p-3 border border-outline-red-2 rounded-lg"
+          class="flex items-start gap-3 bg-surface-red-1 p-3 border border-outline-red-2 rounded-6"
         >
           <span class="mt-0.5 size-4 text-ink-red-6 lucide-alert-triangle shrink-0" />
           <div class="min-w-0 text-p-sm text-ink-red-8">

--- a/admin/frontend/dashboard/src/components/common/ActionMenu.vue
+++ b/admin/frontend/dashboard/src/components/common/ActionMenu.vue
@@ -10,7 +10,7 @@
         v-if="open"
         ref="panel"
         data-dismissable-layer
-        class="z-[60] fixed bg-surface-elevation-1 shadow-2xl p-1 border rounded-lg border-outline-gray-2 w-40 pointer-events-auto"
+        class="z-[60] fixed bg-surface-elevation-1 shadow-2xl p-1 border rounded-6 border-outline-gray-2 w-40 pointer-events-auto"
         :style="panelStyle"
       >
         <Button

--- a/admin/frontend/dashboard/src/components/common/ChartCard.vue
+++ b/admin/frontend/dashboard/src/components/common/ChartCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex flex-col bg-surface-base pt-3 pb-1 border rounded-lg border-outline-gray-2 overflow-hidden"
+    class="flex flex-col bg-surface-base pt-3 pb-1 border rounded-6 border-outline-gray-2 overflow-hidden"
   >
     <div class="flex justify-between items-baseline gap-2 px-4">
       <h3 class="font-medium text-ink-gray-8 text-base">{{ title }}</h3>

--- a/admin/frontend/dashboard/src/components/common/EmptyState.vue
+++ b/admin/frontend/dashboard/src/components/common/EmptyState.vue
@@ -2,14 +2,14 @@
   <div
     class="flex flex-col items-center px-6 text-center"
     :class="[
-      bordered ? 'border border-outline-gray-2 border-dashed rounded-xl' : '',
+      bordered ? 'border border-outline-gray-2 border-dashed rounded-7' : '',
       compact ? 'gap-3 py-6' : 'gap-4 py-12',
     ]"
   >
     <span
       v-if="icon"
       class="place-items-center grid bg-surface-gray-2 text-ink-gray-5 shrink-0"
-      :class="compact ? 'rounded-md size-8' : 'rounded-lg size-10'"
+      :class="compact ? 'rounded-5 size-8' : 'rounded-6 size-10'"
     >
       <span :class="[compact ? 'size-4' : 'size-5', icon]" />
     </span>

--- a/admin/frontend/dashboard/src/components/common/ListRowSkeleton.vue
+++ b/admin/frontend/dashboard/src/components/common/ListRowSkeleton.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="flex items-center gap-3 px-3 py-2.5">
-    <Skeleton class="rounded size-6 shrink-0" />
+    <Skeleton class="rounded-4 size-6 shrink-0" />
 
     <div class="flex-1 min-w-0">
       <!-- Wrappers carry the real row's line-box heights so the swap shifts nothing. -->
       <div class="flex items-center h-4">
-        <Skeleton class="rounded h-3" :class="titleWidth" />
+        <Skeleton class="rounded-4 h-3" :class="titleWidth" />
       </div>
       <div class="flex items-center mt-0.5 h-5">
-        <Skeleton class="rounded h-2.5" :class="subtitleWidth" />
+        <Skeleton class="rounded-4 h-2.5" :class="subtitleWidth" />
       </div>
     </div>
   </div>

--- a/admin/frontend/dashboard/src/components/common/PageHero.vue
+++ b/admin/frontend/dashboard/src/components/common/PageHero.vue
@@ -6,13 +6,13 @@
          re-constrains the card to the body column. -->
     <div class="absolute inset-0 pointer-events-none dot-field" aria-hidden="true" />
     <div
-      class="relative flex justify-between items-center gap-3 mx-auto mt-2 bg-surface-base p-2 sm:p-4 border rounded-xl w-full max-w-3xl border-outline-gray-2"
+      class="relative flex justify-between items-center gap-3 mx-auto mt-2 bg-surface-base p-2 sm:p-4 border rounded-7 w-full max-w-3xl border-outline-gray-2"
     >
       <div class="flex items-center gap-3 min-w-0">
         <slot name="icon">
           <span
             v-if="icon"
-            class="place-items-center grid bg-surface-gray-2 rounded-lg size-9 sm:size-10 text-ink-gray-6 shrink-0"
+            class="place-items-center grid bg-surface-gray-2 rounded-6 size-9 sm:size-10 text-ink-gray-6 shrink-0"
           >
             <span class="size-4 sm:size-5" :class="icon" />
           </span>

--- a/admin/frontend/dashboard/src/components/common/SignedOutDialog.vue
+++ b/admin/frontend/dashboard/src/components/common/SignedOutDialog.vue
@@ -10,7 +10,7 @@
       aria-labelledby="signed-out-title"
     >
       <div
-        class="flex flex-col items-start gap-4 bg-surface-elevation-1 shadow-2xl p-6 border border-outline-gray-1 rounded-xl w-full max-w-sm"
+        class="flex flex-col items-start gap-4 bg-surface-elevation-1 shadow-2xl p-6 border border-outline-gray-1 rounded-7 w-full max-w-sm"
       >
         <div class="flex justify-center items-center bg-surface-gray-2 rounded-full size-9">
           <LucideLock class="size-4 text-ink-gray-6" />

--- a/admin/frontend/dashboard/src/components/common/SimpleTable.vue
+++ b/admin/frontend/dashboard/src/components/common/SimpleTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="bordered ? 'border rounded-lg border-outline-gray-2 overflow-hidden' : ''">
+  <div :class="bordered ? 'border rounded-6 border-outline-gray-2 overflow-hidden' : ''">
     <div class="overflow-x-auto hover-scrollbar" :style="minHeight && !rows.length ? { minHeight } : {}">
       <table class="w-full min-w-max text-sm">
         <thead>

--- a/admin/frontend/dashboard/src/components/common/StatusListView.vue
+++ b/admin/frontend/dashboard/src/components/common/StatusListView.vue
@@ -25,7 +25,8 @@
 </template>
 
 <script setup>
-import { Badge, ListRowItem, ListView } from 'frappe-ui'
+import { Badge } from 'frappe-ui'
+import { ListRowItem, ListView } from 'frappe-ui/experimental'
 
 /**
  * A ListView whose `badge` column renders a Badge and whose other columns

--- a/admin/frontend/dashboard/src/components/common/Table.vue
+++ b/admin/frontend/dashboard/src/components/common/Table.vue
@@ -31,7 +31,7 @@ defineSlots<{
             v-for="(column, i) in columns"
             :key="column.key"
             class="bg-surface-gray-2 px-3 py-2 font-normal text-ink-gray-5 text-sm whitespace-nowrap"
-            :class="[column.class, i === 0 && 'rounded-l', i === columns.length - 1 && 'rounded-r']"
+            :class="[column.class, i === 0 && 'rounded-l-4', i === columns.length - 1 && 'rounded-r-4']"
           >
             {{ column.label }}
           </th>

--- a/admin/frontend/dashboard/src/components/common/WafAnalytics.vue
+++ b/admin/frontend/dashboard/src/components/common/WafAnalytics.vue
@@ -11,11 +11,11 @@
     </div>
 
     <div class="gap-4 grid grid-cols-2 sm:grid-cols-3 mb-4">
-      <div class="bg-surface-white px-4 py-3 border rounded-lg border-outline-gray-2">
+      <div class="bg-surface-white px-4 py-3 border rounded-6 border-outline-gray-2">
         <div class="text-ink-gray-6 text-sm">Flagged requests</div>
         <div class="mt-1 font-semibold text-ink-gray-9 text-xl">{{ totals.flagged }}</div>
       </div>
-      <div class="bg-surface-white px-4 py-3 border rounded-lg border-outline-gray-2">
+      <div class="bg-surface-white px-4 py-3 border rounded-6 border-outline-gray-2">
         <div class="text-ink-gray-6 text-sm">
           {{ data.mode === 'On' ? 'Blocked' : 'Would block' }}
         </div>
@@ -23,7 +23,7 @@
           {{ data.mode === 'On' ? totals.blocked : totals.would_block }}
         </div>
       </div>
-      <div class="bg-surface-white px-4 py-3 border rounded-lg border-outline-gray-2">
+      <div class="bg-surface-white px-4 py-3 border rounded-6 border-outline-gray-2">
         <div class="text-ink-gray-6 text-sm">Detected only</div>
         <div class="mt-1 font-semibold text-ink-gray-9 text-xl">
           {{ totals.flagged - totals.would_block }}
@@ -32,7 +32,7 @@
     </div>
 
     <div class="gap-4 grid grid-cols-1 sm:grid-cols-2">
-      <div class="bg-surface-white p-4 border rounded-lg border-outline-gray-2">
+      <div class="bg-surface-white p-4 border rounded-6 border-outline-gray-2">
         <div class="mb-2 text-ink-gray-6 text-sm">Top rules</div>
         <div v-if="!data.top_rules.length" class="text-ink-gray-5 text-xs">
           No rule matches in this window.
@@ -48,7 +48,7 @@
           <span class="font-medium text-ink-gray-7 text-sm shrink-0">{{ rule.count }}</span>
         </div>
       </div>
-      <div class="bg-surface-white p-4 border rounded-lg border-outline-gray-2">
+      <div class="bg-surface-white p-4 border rounded-6 border-outline-gray-2">
         <div class="mb-2 text-ink-gray-6 text-sm">Top source IPs</div>
         <div v-if="!data.top_ips.length" class="text-ink-gray-5 text-xs">
           No sources in this window.

--- a/admin/frontend/dashboard/src/components/dashboard/DatabaseInsights.vue
+++ b/admin/frontend/dashboard/src/components/dashboard/DatabaseInsights.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div v-if="loading" class="gap-4 grid grid-cols-1 sm:grid-cols-2">
-      <Skeleton v-for="i in 6" :key="i" class="rounded-lg h-[340px]" />
+      <Skeleton v-for="i in 6" :key="i" class="rounded-6 h-[340px]" />
     </div>
     <ErrorMessage v-else-if="error" :message="error" />
     <EmptyState
@@ -30,7 +30,8 @@
 
 <script setup>
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
-import { AxisChart, ErrorMessage, Skeleton } from 'frappe-ui'
+import { ErrorMessage, Skeleton } from 'frappe-ui'
+import { AxisChart } from 'frappe-ui/experimental'
 import ChartCard from '@/components/common/ChartCard.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import SlowQueries from '@/components/dashboard/SlowQueries.vue'

--- a/admin/frontend/dashboard/src/components/dashboard/SiteInsights.vue
+++ b/admin/frontend/dashboard/src/components/dashboard/SiteInsights.vue
@@ -3,7 +3,7 @@
     <SiteUptime :site-name="siteName" :window="window" />
 
     <template v-if="loading">
-      <Skeleton v-for="i in 12" :key="i" class="rounded-lg h-[340px]" />
+      <Skeleton v-for="i in 12" :key="i" class="rounded-6 h-[340px]" />
     </template>
     <ErrorMessage v-else-if="error" :message="error" class="sm:col-span-2" />
 
@@ -29,7 +29,8 @@
 
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
-import { AxisChart, ErrorMessage, Skeleton } from 'frappe-ui'
+import { ErrorMessage, Skeleton } from 'frappe-ui'
+import { AxisChart } from 'frappe-ui/experimental'
 import ChartCard from '@/components/common/ChartCard.vue'
 import SiteUptime from '@/components/dashboard/SiteUptime.vue'
 import { apiErrorMessage } from '@/api/client'

--- a/admin/frontend/dashboard/src/components/dashboard/SiteUptime.vue
+++ b/admin/frontend/dashboard/src/components/dashboard/SiteUptime.vue
@@ -1,6 +1,6 @@
 <template>
-  <Skeleton v-if="loading" class="rounded-lg h-full min-h-[340px]" />
-  <div v-else class="flex flex-col bg-surface-white border rounded-lg border-outline-gray-2 h-full">
+  <Skeleton v-if="loading" class="rounded-6 h-full min-h-[340px]" />
+  <div v-else class="flex flex-col bg-surface-white border rounded-6 border-outline-gray-2 h-full">
     <div class="flex items-center px-4 py-3 border-b border-outline-gray-2">
       <h3 class="font-medium text-ink-gray-8 text-base">Uptime</h3>
     </div>

--- a/admin/frontend/dashboard/src/components/dashboard/SlowQueries.vue
+++ b/admin/frontend/dashboard/src/components/dashboard/SlowQueries.vue
@@ -16,7 +16,7 @@
 
 <script setup>
 import { computed } from 'vue'
-import { AxisChart } from 'frappe-ui'
+import { AxisChart } from 'frappe-ui/experimental'
 import ChartCard from '@/components/common/ChartCard.vue'
 
 const props = defineProps({ overview: { type: Object, default: null } })

--- a/admin/frontend/dashboard/src/components/database/DatabasePanel.vue
+++ b/admin/frontend/dashboard/src/components/database/DatabasePanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-surface-white border rounded-lg border-outline-gray-2">
+  <div class="bg-surface-white border rounded-6 border-outline-gray-2">
     <div class="flex justify-between items-start gap-3 p-4">
       <div class="min-w-0">
         <div class="flex flex-wrap items-center gap-2">

--- a/admin/frontend/dashboard/src/components/database/SQLSchemaDialog.vue
+++ b/admin/frontend/dashboard/src/components/database/SQLSchemaDialog.vue
@@ -15,7 +15,7 @@
           <button
             v-for="table in filteredTables"
             :key="table.name"
-            class="block px-2 py-1.5 rounded-md w-full text-sm text-left truncate transition-colors"
+            class="block px-2 py-1.5 rounded-5 w-full text-sm text-left truncate transition-colors"
             :class="selected?.name === table.name
               ? 'bg-surface-gray-2 text-ink-gray-9 font-medium'
               : 'text-ink-gray-7 hover:bg-surface-alpha-gray-1'"

--- a/admin/frontend/dashboard/src/components/database/TableSizesDialog.vue
+++ b/admin/frontend/dashboard/src/components/database/TableSizesDialog.vue
@@ -26,7 +26,8 @@
 
 <script setup>
 import { computed, ref, watch } from 'vue'
-import { Dialog, ErrorMessage, ListView, LoadingText } from 'frappe-ui'
+import { Dialog, ErrorMessage, LoadingText } from 'frappe-ui'
+import { ListView } from 'frappe-ui/experimental'
 import { apiErrorMessage } from '@/api/client'
 import { databaseApi } from '@/api/database'
 import { formatBytes } from '@/utils/format'

--- a/admin/frontend/dashboard/src/components/logs/LogView.vue
+++ b/admin/frontend/dashboard/src/components/logs/LogView.vue
@@ -5,7 +5,7 @@
     ref="el"
     class="bg-surface-gray-2 overflow-auto font-mono text-ink-gray-8 text-p-sm"
     @scroll="onScroll"
-    :class="[wrap ? 'whitespace-pre-wrap' : 'whitespace-pre', rounded ? 'rounded' : '', fill ? 'flex-1 h-0' : 'max-h-[50vh]', rows ? '' : 'px-4 py-3']"
+    :class="[wrap ? 'whitespace-pre-wrap' : 'whitespace-pre', rounded-4 ? 'rounded-4' : '', fill ? 'flex-1 h-0' : 'max-h-[50vh]', rows ? '' : 'px-4 py-3']"
   >
     <p v-if="!lines.length" class="text-ink-gray-4" :class="rows ? 'px-4 py-3' : ''">
       {{ emptyText }}

--- a/admin/frontend/dashboard/src/components/marketplace/MarketplaceAppCardSkeleton.vue
+++ b/admin/frontend/dashboard/src/components/marketplace/MarketplaceAppCardSkeleton.vue
@@ -5,10 +5,10 @@
     <div class="flex-1 py-2 min-w-0">
       <!-- Wrappers carry the real card's line-box heights so the swap shifts nothing. -->
       <div class="flex items-center h-4">
-        <Skeleton class="rounded h-3" :class="titleWidth" />
+        <Skeleton class="rounded-4 h-3" :class="titleWidth" />
       </div>
       <div class="flex items-center mt-0.5 h-5">
-        <Skeleton class="rounded h-2.5" :class="descriptionWidth" />
+        <Skeleton class="rounded-4 h-2.5" :class="descriptionWidth" />
       </div>
     </div>
   </div>

--- a/admin/frontend/dashboard/src/components/search/SearchDialog.vue
+++ b/admin/frontend/dashboard/src/components/search/SearchDialog.vue
@@ -60,7 +60,7 @@ const navigate = (delta: number) => {
     @click.self="close"
   >
     <div
-      class="search-panel mt-[15vh] w-full max-w-lg overflow-hidden rounded bg-surface-gray-1 shadow-lg"
+      class="search-panel mt-[15vh] w-full max-w-lg overflow-hidden rounded-4 bg-surface-gray-1 shadow-lg"
       @keydown.esc.prevent="close"
       @keydown.enter.prevent="go(activeIndex)"
       @keydown.up.prevent="navigate(-1)"
@@ -90,7 +90,7 @@ const navigate = (delta: number) => {
               v-for="(item, i) in group.items"
               :key="`${name}-${item.name}`"
               role="option"
-              class="flex cursor-pointer items-center gap-2 rounded p-2 hover:bg-surface-gray-2"
+              class="flex cursor-pointer items-center gap-2 rounded-4 p-2 hover:bg-surface-gray-2"
               :class="[
                 flatItems.indexOf(item) === activeIndex ? 'bg-surface-gray-2' : '',
                 i === group.items.length - 1 ? 'mb-3' : 'mb-0.5',
@@ -153,7 +153,7 @@ const navigate = (delta: number) => {
 }
 
 kbd {
-  @apply inline-flex h-5 min-w-5 items-center justify-center rounded-sm;
+  @apply inline-flex h-5 min-w-5 items-center justify-center rounded-1;
   @apply border border-outline-gray-2 bg-surface-gray-2 px-1 font-sans text-ink-gray-6;
   font-size: 0.6875rem;
   line-height: 1;

--- a/admin/frontend/dashboard/src/components/settings/Firewall.vue
+++ b/admin/frontend/dashboard/src/components/settings/Firewall.vue
@@ -3,7 +3,7 @@
     <Spinner size="lg" class="text-ink-gray-4" />
   </div>
   <div v-else class="space-y-6">
-    <Alert v-if="!production" title="Not enforced yet" theme="yellow" :dismissible="false">
+    <Alert v-if="!production" title="Not enforced yet" theme="amber">
       <template #description>
         <span class="text-ink-gray-6 text-p-sm"
           >These rules take effect only in production (they're applied by nginx). This bench isn't
@@ -27,7 +27,7 @@
       @update:model-value="(v) => (defaultPolicy = v ? 'deny' : 'allow')"
     />
 
-    <Alert v-if="lockoutRisk" title="Heads up" theme="yellow" :dismissible="false">
+    <Alert v-if="lockoutRisk" title="Heads up" theme="amber">
       <template #description>
         <span class="text-ink-gray-6 text-p-sm"
           >Everyone is blocked by default. Add an <b>Allow</b> rule for your own IP<template

--- a/admin/frontend/dashboard/src/components/settings/Git.vue
+++ b/admin/frontend/dashboard/src/components/settings/Git.vue
@@ -3,7 +3,7 @@
     <Spinner size="lg" class="text-ink-gray-4" />
   </div>
   <div v-else class="space-y-6">
-    <Alert v-if="!connected" theme="blue" title="Connect GitHub" :dismissible="false">
+    <Alert v-if="!connected" theme="blue" title="Connect GitHub">
       <template #description>
         <p class="text-ink-gray-6 text-p-sm">
           Install private apps and browse your repos. Paste a

--- a/admin/frontend/dashboard/src/components/settings/LLM.vue
+++ b/admin/frontend/dashboard/src/components/settings/LLM.vue
@@ -3,7 +3,7 @@
     <Spinner size="lg" class="text-ink-gray-4" />
   </div>
   <div v-else class="space-y-6">
-    <Alert v-if="!connected" theme="blue" title="Why connect an AI assistant?" :dismissible="false">
+    <Alert v-if="!connected" theme="blue" title="Why connect an AI assistant?">
       <template #description>
         <p class="text-ink-gray-6 text-p-sm">
           Connect any LLM provider supported by litellm to power assistant features, like explaining
@@ -30,10 +30,10 @@
     </div>
 
     <div class="space-y-4">
-      <Autocomplete
+      <Combobox
         label="Provider"
+        v-model="provider"
         :options="providerOptions"
-        :model-value="providerSelection"
         placeholder="Search providers…"
         @update:model-value="onProviderSelect"
       />
@@ -62,13 +62,12 @@
         placeholder="Your served model name"
       />
       <div v-else class="space-y-1.5">
-        <Autocomplete
+        <Combobox
           label="Model"
+          v-model="model"
           :options="modelOptions"
-          :model-value="modelSelection"
           :loading="modelsLoading"
           :placeholder="modelPlaceholder"
-          @update:model-value="(o) => (model = o?.value || '')"
         />
         <p v-if="modelsError" class="text-ink-red-6 text-p-sm">{{ modelsError }}</p>
         <p v-else-if="modelsHint" class="text-ink-gray-5 text-p-sm">{{ modelsHint }}</p>
@@ -114,7 +113,7 @@
 
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
-import { Alert, Autocomplete, Button, ErrorMessage, FormControl, Spinner, toast } from 'frappe-ui'
+import { Alert, Button, Combobox, ErrorMessage, FormControl, Spinner, toast } from 'frappe-ui'
 import { apiErrorMessage } from '@/api/client'
 import { settingsApi } from '@/api/settings'
 
@@ -145,13 +144,7 @@ const hasApiKey = computed(() => Boolean(apiKey.value.trim() || apiKeySet.value)
 const providerOptions = computed(() =>
   providers.value.map((p) => ({ label: p.label, value: p.value })),
 )
-const providerSelection = computed(
-  () => providerOptions.value.find((o) => o.value === provider.value) || null,
-)
 const modelOptions = computed(() => models.value.map((m) => ({ label: m, value: m })))
-const modelSelection = computed(() =>
-  model.value ? { label: model.value, value: model.value } : null,
-)
 const hasApiBase = computed(() => Boolean(apiBase.value.trim()))
 const apiBaseError = computed(() => {
   if (!provider.value || !needsApiBase.value || hasApiBase.value) return ''
@@ -200,8 +193,8 @@ async function fetchModels(providerValue) {
   }
 }
 
-function onProviderSelect(option) {
-  provider.value = option?.value || ''
+function onProviderSelect(value) {
+  provider.value = value || ''
   model.value = ''
   fetchModels(provider.value)
 }

--- a/admin/frontend/dashboard/src/components/settings/S3Bucket.vue
+++ b/admin/frontend/dashboard/src/components/settings/S3Bucket.vue
@@ -3,7 +3,7 @@
     <Spinner size="lg" class="text-ink-gray-4" />
   </div>
   <div v-else class="space-y-6">
-    <Alert v-if="!connected" theme="blue" title="Why connect object storage?" :dismissible="false">
+    <Alert v-if="!connected" theme="blue" title="Why connect object storage?">
       <template #description>
         <p class="text-ink-gray-6 text-p-sm">
           Connect S3-compatible object storage to send offsite backups and snapshots.

--- a/admin/frontend/dashboard/src/components/settings/Sessions.vue
+++ b/admin/frontend/dashboard/src/components/settings/Sessions.vue
@@ -38,7 +38,7 @@
   <div v-else class="space-y-5">
     <div
       v-if="loadError"
-      class="py-12 border border-dashed rounded-xl border-outline-red-2 text-ink-red-3 text-p-sm text-center"
+      class="py-12 border border-dashed rounded-7 border-outline-red-2 text-ink-red-3 text-p-sm text-center"
     >
       {{ loadError }}
     </div>
@@ -109,7 +109,8 @@
 
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
-import { Button, Dialog, Dropdown, ListRowItem, ListView, Spinner, toast } from 'frappe-ui'
+import { Button, Dialog, Dropdown, Spinner, toast } from 'frappe-ui'
+import { ListRowItem, ListView } from 'frappe-ui/experimental'
 import EmptyState from '@/components/common/EmptyState.vue'
 import { sessionApi } from '@/api/session'
 import { auditApi } from '@/api/audit'

--- a/admin/frontend/dashboard/src/components/settings/SettingsRow.vue
+++ b/admin/frontend/dashboard/src/components/settings/SettingsRow.vue
@@ -6,7 +6,7 @@
     :is="as"
     :type="as === 'button' ? 'button' : undefined"
     class="flex justify-between items-center gap-x-2.5 px-2.5 py-3"
-    :class="interactive ? 'w-full rounded transition-colors cursor-pointer text-left hover:bg-surface-alpha-gray-1' : ''"
+    :class="interactive ? 'w-full rounded-4 transition-colors cursor-pointer text-left hover:bg-surface-alpha-gray-1' : ''"
   >
     <div class="flex flex-col gap-1">
       <!-- Matches frappe-ui's InputLabel (text-base) / InputDescription (text-p-sm). -->

--- a/admin/frontend/dashboard/src/components/settings/SshKeys.vue
+++ b/admin/frontend/dashboard/src/components/settings/SshKeys.vue
@@ -8,7 +8,7 @@
     </div>
     <div
       v-if="loadError"
-      class="py-12 border border-dashed rounded-xl border-outline-red-2 text-ink-red-3 text-p-sm text-center"
+      class="py-12 border border-dashed rounded-7 border-outline-red-2 text-ink-red-3 text-p-sm text-center"
     >
       {{ loadError }}
     </div>
@@ -84,7 +84,8 @@
 
 <script setup>
 import { computed, onMounted, ref } from 'vue'
-import { Button, Dialog, ErrorMessage, FormControl, ListRowItem, ListView, Spinner, toast } from 'frappe-ui'
+import { Button, Dialog, ErrorMessage, FormControl, Spinner, toast } from 'frappe-ui'
+import { ListRowItem, ListView } from 'frappe-ui/experimental'
 import EmptyState from '@/components/common/EmptyState.vue'
 import { apiErrorMessage } from '@/api/client'
 import { sshKeysApi } from '@/api/sshKeys'

--- a/admin/frontend/dashboard/src/components/settings/TwoFactor.vue
+++ b/admin/frontend/dashboard/src/components/settings/TwoFactor.vue
@@ -21,7 +21,7 @@
 
     <div
       v-if="atDeviceLimit"
-      class="bg-surface-amber-1 p-3 border border-outline-amber-2 rounded-lg text-ink-amber-8 text-p-sm"
+      class="bg-surface-amber-1 p-3 border border-outline-amber-2 rounded-6 text-ink-amber-8 text-p-sm"
     >
       All {{ status.max_devices }} device slots are in use. Remove one to enrol another, or share
       an existing device's setup key to add another authenticator app.
@@ -101,7 +101,7 @@
           <p class="text-ink-gray-6 text-p-base">
             Scan with Authy, Bitwarden, Microsoft Authenticator or any TOTP app.
           </p>
-          <div class="flex justify-center bg-surface-white p-4 rounded-lg">
+          <div class="flex justify-center bg-surface-white p-4 rounded-6">
             <QrcodeVue :value="enrollment.provisioning_url" :size="176" level="M" render-as="svg" />
           </div>
           <details class="group">
@@ -113,7 +113,7 @@
               ></span>
               Can't scan? Enter the key by hand
             </summary>
-            <div class="bg-surface-gray-2 mt-2 p-3 rounded-lg">
+            <div class="bg-surface-gray-2 mt-2 p-3 rounded-6">
               <p class="font-mono text-ink-gray-8 text-base break-all">{{ enrollment.secret }}</p>
               <button class="mt-1 text-ink-blue-3 text-sm" @click="copy(enrollment.secret)">
                 Copy key
@@ -148,7 +148,7 @@
         These are shown once. Store them somewhere safe — each one signs you in when no device
         is available, and works only once.
       </p>
-      <div class="gap-x-6 gap-y-2 grid grid-cols-2 bg-surface-gray-2 mt-3 px-4 py-3.5 rounded-lg">
+      <div class="gap-x-6 gap-y-2 grid grid-cols-2 bg-surface-gray-2 mt-3 px-4 py-3.5 rounded-6">
         <span
           v-for="code in codes"
           :key="code"
@@ -197,7 +197,8 @@
 
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
-import { Button, Dialog, ErrorMessage, FormControl, ListRowItem, ListView, Spinner, toast } from 'frappe-ui'
+import { Button, Dialog, ErrorMessage, FormControl, Spinner, toast } from 'frappe-ui'
+import { ListRowItem, ListView } from 'frappe-ui/experimental'
 import QrcodeVue from 'qrcode.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import SettingsRow from '@/components/settings/SettingsRow.vue'

--- a/admin/frontend/dashboard/src/components/settings/Version.vue
+++ b/admin/frontend/dashboard/src/components/settings/Version.vue
@@ -9,7 +9,7 @@
       <p class="text-ink-gray-7 text-p-base">
         This is a development install. Update it from a terminal:
       </p>
-      <pre class="p-3 bg-surface-gray-2 rounded overflow-x-auto text-ink-gray-8 text-sm">git pull
+      <pre class="p-3 bg-surface-gray-2 rounded-4 overflow-x-auto text-ink-gray-8 text-sm">git pull
 pilot admin build
 pilot admin upgrade</pre>
       <p class="text-ink-gray-5 text-p-sm">The last step restarts the admin service.</p>
@@ -22,7 +22,7 @@ pilot admin upgrade</pre>
       </div>
       <pre
         v-else
-        class="p-3 bg-surface-gray-2 rounded max-h-64 overflow-auto text-ink-gray-7 text-sm whitespace-pre-wrap"
+        class="p-3 bg-surface-gray-2 rounded-4 max-h-64 overflow-auto text-ink-gray-7 text-sm whitespace-pre-wrap"
       >{{ log }}</pre>
     </div>
 

--- a/admin/frontend/dashboard/src/components/settings/Waf.vue
+++ b/admin/frontend/dashboard/src/components/settings/Waf.vue
@@ -51,7 +51,7 @@
       <!-- Chrome marks a clicked summary :focus-visible; blur keeps the focus
            ring for keyboard only. w-fit so the ring hugs the word. -->
       <summary
-        class="flex items-center gap-1.5 pr-1.5 rounded-sm w-fit text-ink-gray-6 text-base cursor-pointer select-none"
+        class="flex items-center gap-1.5 pr-1.5 rounded-1 w-fit text-ink-gray-6 text-base cursor-pointer select-none"
         @click="(e) => e.currentTarget.blur()"
       >
         <span

--- a/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
+++ b/admin/frontend/dashboard/src/components/settings/WafCustomRules.vue
@@ -22,13 +22,13 @@
 
     <div
       v-if="rules.length"
-      class="bg-surface-elevation-1 p-1 border border-outline-gray-2 rounded-lg"
+      class="bg-surface-elevation-1 p-1 border border-outline-gray-2 rounded-6"
     >
       <div
         v-for="rule in rules"
         :key="keyOf(rule)"
         :data-rule-key="keyOf(rule)"
-        class="rounded ring-1 ring-inset transition-shadow"
+        class="rounded-4 ring-1 ring-inset transition-shadow"
         :class="[
           // Fast in, slow out. transition-shadow: a ring is box-shadow underneath.
           flaggedKey === keyOf(rule) ? 'ring-outline-red-3 duration-75' : 'ring-transparent duration-1000',
@@ -41,7 +41,7 @@
       >
         <!-- The whole row toggles; interactive children stop the click. -->
         <div
-          class="flex items-center gap-3 px-2.5 h-10 rounded transition-colors cursor-pointer select-none hover:bg-surface-alpha-gray-1"
+          class="flex items-center gap-3 px-2.5 h-10 rounded-4 transition-colors cursor-pointer select-none hover:bg-surface-alpha-gray-1"
           @click="toggleOpen(rule)"
         >
           <button
@@ -167,7 +167,7 @@
                extra 0.875rem drops the curve to the middle of this row. -->
           <span
             aria-hidden="true"
-            class="absolute left-1 -top-4 h-[1.875rem] w-2.5 border-l border-b rounded-bl-lg border-outline-gray-3"
+            class="absolute left-1 -top-4 h-[1.875rem] w-2.5 border-l border-b rounded-bl-6 border-outline-gray-3"
           />
           <div class="flex flex-wrap items-center gap-2 text-ink-gray-7 text-base">
             <span>Then</span>

--- a/admin/frontend/dashboard/src/components/sites/Backups.vue
+++ b/admin/frontend/dashboard/src/components/sites/Backups.vue
@@ -20,7 +20,7 @@
 
     <ErrorMessage v-if="error" :message="error" />
 
-    <div :class="backups.length ? '' : 'rounded-xl border border-dashed border-outline-gray-2'">
+    <div :class="backups.length ? '' : 'rounded-7 border border-dashed border-outline-gray-2'">
       <div v-if="backupsLoading" class="flex justify-center py-12">
         <LoadingText />
       </div>
@@ -111,11 +111,9 @@ import {
   Dialog,
   Dropdown,
   ErrorMessage,
-  ListFooter,
-  ListView,
-  ListRowItem,
   LoadingText,
 } from 'frappe-ui'
+import { ListFooter, ListView, ListRowItem } from 'frappe-ui/experimental'
 import EmptyState from '@/components/common/EmptyState.vue'
 import BackupConfigDialog from '@/components/sites/BackupConfigDialog.vue'
 import { apiErrorMessage } from '@/api/client'

--- a/admin/frontend/dashboard/src/components/sites/Config.vue
+++ b/admin/frontend/dashboard/src/components/sites/Config.vue
@@ -24,7 +24,7 @@
     <!-- Config table -->
     <div
       v-if="!rows.length"
-      class="py-12 border border-dashed rounded-xl border-outline-gray-2 text-ink-gray-5 text-sm text-center"
+      class="py-12 border border-dashed rounded-7 border-outline-gray-2 text-ink-gray-5 text-sm text-center"
     >
       No config keys.
     </div>
@@ -111,7 +111,8 @@
 
 <script setup>
 import { computed, ref } from 'vue'
-import { Button, Dialog, Dropdown, ErrorMessage, ListView, ListRowItem, TextInput } from 'frappe-ui'
+import { Button, Dialog, Dropdown, ErrorMessage, TextInput } from 'frappe-ui'
+import { ListView, ListRowItem } from 'frappe-ui/experimental'
 import { sitesApi } from '@/api/sites'
 import { useSite } from '@/composables/sites/useSite'
 

--- a/admin/frontend/dashboard/src/components/sites/NewSiteDialog.vue
+++ b/admin/frontend/dashboard/src/components/sites/NewSiteDialog.vue
@@ -72,7 +72,7 @@
               v-for="app in availableApps"
               :key="app.name"
               type="button"
-              class="flex items-center gap-3 hover:bg-surface-alpha-gray-1 px-2 py-2 rounded min-w-0 text-left transition-colors"
+              class="flex items-center gap-3 hover:bg-surface-alpha-gray-1 px-2 py-2 rounded-4 min-w-0 text-left transition-colors"
               @click="toggleApp(app.name)"
             >
               <AppIcon :name="app.name" size="lg" />

--- a/admin/frontend/dashboard/src/components/sites/SiteRow.vue
+++ b/admin/frontend/dashboard/src/components/sites/SiteRow.vue
@@ -2,7 +2,7 @@
   <component
     :is="interactive ? 'button' : 'div'"
     :type="interactive ? 'button' : null"
-    class="flex items-center gap-2.5 p-2.5 rounded min-w-0 text-left"
+    class="flex items-center gap-2.5 p-2.5 rounded-4 min-w-0 text-left"
     :class="[stateClass, interactive && 'transition duration-150 ease-[var(--ease-out)] active:scale-[0.98]']"
     :disabled="interactive && disabled ? true : null"
   >

--- a/admin/frontend/dashboard/src/components/sites/SiteSkeleton.vue
+++ b/admin/frontend/dashboard/src/components/sites/SiteSkeleton.vue
@@ -1,16 +1,16 @@
 <template>
   <!-- The real card's classes, so nothing reflows when sites land. -->
   <div
-    class="flex items-center gap-3 bg-surface-base p-2 sm:px-3 sm:py-2 border rounded-lg border-outline-gray-2"
+    class="flex items-center gap-3 bg-surface-base p-2 sm:px-3 sm:py-2 border rounded-6 border-outline-gray-2"
   >
-    <Skeleton class="rounded size-8 shrink-0" />
+    <Skeleton class="rounded-4 size-8 shrink-0" />
     <div class="flex-1 min-w-0">
       <!-- 24px and 20px line boxes, matching the real card's two rows. -->
       <div class="flex items-center h-6">
-        <Skeleton class="rounded h-3.5" :class="nameWidth" />
+        <Skeleton class="rounded-4 h-3.5" :class="nameWidth" />
       </div>
       <div class="flex items-center h-5">
-        <Skeleton class="rounded w-12 h-2.5" />
+        <Skeleton class="rounded-4 w-12 h-2.5" />
       </div>
     </div>
   </div>

--- a/admin/frontend/dashboard/src/components/storage/BinlogPurgeAlert.vue
+++ b/admin/frontend/dashboard/src/components/storage/BinlogPurgeAlert.vue
@@ -91,22 +91,15 @@ const purge = async () => {
 <template>
   <Alert
     v-if="show"
+    class="mt-4"
     title="Binary logs are taking up space"
-    :dismissible="false"
-    class="mt-4 !bg-surface-blue-1"
+    theme="blue"
+    :primary-action="{ label: 'Purge binary logs', onClick: openDialog }"
   >
     <template #description>
       <p class="text-ink-gray-6 prose-sm">
         Binary logs are using {{ formatBytes(bytes) }}. Purge older logs to free up space.
       </p>
-    </template>
-
-    <template #footer>
-      <div class="flex col-span-2 items-center gap-3">
-        <Button  theme='blue' class="ml-auto" @click="openDialog"
-          >Purge binary logs</Button
-        >
-      </div>
     </template>
   </Alert>
 

--- a/admin/frontend/dashboard/src/components/storage/DatabaseStorageCard.vue
+++ b/admin/frontend/dashboard/src/components/storage/DatabaseStorageCard.vue
@@ -102,7 +102,7 @@ const isDatabaseListExpandable = computed(
           v-for="row in visibleDatabases"
           :key="row.schema"
           :to="row.site ? { path: '/database/analyzer', query: { site: row.site } } : undefined"
-          class="group block px-2 rounded no-underline transition-colors"
+          class="group block px-2 rounded-4 no-underline transition-colors"
           :class="{ 'hover:bg-surface-gray-1': row.site }"
         >
           <div

--- a/admin/frontend/dashboard/src/components/tasks/TaskDebugDialog.vue
+++ b/admin/frontend/dashboard/src/components/tasks/TaskDebugDialog.vue
@@ -5,12 +5,12 @@
         <div v-if="streaming && !text" class="flex justify-center py-10">
           <LoadingText text="Analyzing the failure…" />
         </div>
-        <Alert v-if="error" theme="red" title="Couldn't debug this task" :dismissible="false">
+        <Alert v-if="error" theme="red" title="Couldn't debug this task" :icon="false">
           <template #description>{{ error }}</template>
         </Alert>
         <div
           v-if="text"
-          class="bg-surface-gray-2 p-4 rounded-lg max-h-[60vh] overflow-y-auto prose prose-sm dark:prose-invert max-w-none"
+          class="bg-surface-gray-2 p-4 rounded-6 max-h-[60vh] overflow-y-auto prose prose-sm dark:prose-invert max-w-none"
         >
           <span v-html="html"></span>
           <span

--- a/admin/frontend/dashboard/src/components/tasks/TaskStep.vue
+++ b/admin/frontend/dashboard/src/components/tasks/TaskStep.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div
-      class="flex items-center gap-3 px-2.5 py-2 rounded transition-colors"
+      class="flex items-center gap-3 px-2.5 py-2 rounded-4 transition-colors"
       :class="hasOutput ? 'cursor-pointer hover:bg-surface-gray-1' : ''"
       @click="toggle"
     >

--- a/admin/frontend/dashboard/src/components/tasks/TaskSteps.vue
+++ b/admin/frontend/dashboard/src/components/tasks/TaskSteps.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     v-if="hasSteps"
-    class="flex flex-col gap-1 p-1 border border-outline-gray-2 rounded-lg min-w-0"
+    class="flex flex-col gap-1 p-1 border border-outline-gray-2 rounded-6 min-w-0"
   >
     <TaskStep
       v-for="section in stepSections"

--- a/admin/frontend/dashboard/src/components/updates/JobRow.vue
+++ b/admin/frontend/dashboard/src/components/updates/JobRow.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     type="button"
-    class="flex items-center gap-1.5 px-2.5 py-2 rounded transition-colors w-full hover:bg-surface-gray-1 text-sm text-left"
+    class="flex items-center gap-1.5 px-2.5 py-2 rounded-4 transition-colors w-full hover:bg-surface-gray-1 text-sm text-left"
     :class="failed ? 'text-ink-red-7' : 'text-ink-gray-7'"
   >
     <span

--- a/admin/frontend/dashboard/src/components/updates/UpdateSection.vue
+++ b/admin/frontend/dashboard/src/components/updates/UpdateSection.vue
@@ -1,11 +1,11 @@
 <template>
   <details
     :open="open"
-    class="group/section rounded-lg border border-outline-gray-2 p-1"
+    class="group/section rounded-6 border border-outline-gray-2 p-1"
     @toggle="$emit('update:open', $event.target.open)"
   >
     <summary
-      class="flex items-center justify-between px-2.5 py-2 rounded transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
+      class="flex items-center justify-between px-2.5 py-2 rounded-4 transition-colors cursor-pointer select-none hover:bg-surface-gray-1"
     >
       <div class="flex items-center gap-2">
         <span class="size-4 text-ink-gray-5 shrink-0" :class="icon" />

--- a/admin/frontend/dashboard/src/composables/common/useTheme.ts
+++ b/admin/frontend/dashboard/src/composables/common/useTheme.ts
@@ -1,19 +1,26 @@
-import { useTheme as useFrappeTheme } from 'frappe-ui'
+import { useColorScheme } from 'frappe-ui'
 
 type Theme = 'light' | 'dark' | 'system'
 
+/**
+ * Thin wrapper around frappe-ui's `useColorScheme` that keeps Pilot's
+ * `setTheme` / `currentTheme` call sites unchanged.
+ *
+ * frappe-ui already mutes transitions during the swap, so the old
+ * `no-transition` dance here is no longer needed.
+ */
 export const useTheme = () => {
-  const { setTheme: setFrappeTheme, ...rest } = useFrappeTheme()
+  const { colorScheme, setColorScheme, toggleColorScheme } = useColorScheme()
 
   const setTheme = (theme: Theme) => {
-    document.documentElement.classList.add('no-transition')
-    setFrappeTheme(theme)
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        document.documentElement.classList.remove('no-transition')
-      })
-    })
+    setColorScheme(theme)
   }
 
-  return { ...rest, setTheme }
+  return {
+    currentTheme: colorScheme,
+    setTheme,
+    colorScheme,
+    setColorScheme,
+    toggleColorScheme,
+  }
 }

--- a/admin/frontend/dashboard/src/layouts/MainLayout.vue
+++ b/admin/frontend/dashboard/src/layouts/MainLayout.vue
@@ -79,7 +79,7 @@ function breadcrumbsFromRouteMeta({ title = '' }) {
       <div class="flex items-center justify-between">
         <template v-if="route.name == 'Home'">
           <div class="flex items-center gap-2">
-            <PilotLogo class="size-6 rounded-sm" />
+            <PilotLogo class="size-6 rounded-1" />
             <span class="text-ink-gray-9">Home</span>
           </div>
         </template>

--- a/admin/frontend/dashboard/src/pages/Activities.vue
+++ b/admin/frontend/dashboard/src/pages/Activities.vue
@@ -226,9 +226,9 @@ onMounted(() => {
     <div v-if="loading" class="flex flex-col gap-1 mt-4">
       <div v-for="i in 8" :key="i" class="flex items-center gap-3 px-4 py-3">
         <Skeleton class="rounded-full size-6 shrink-0" />
-        <Skeleton class="h-3 rounded" :class="i % 2 ? 'w-48' : 'w-36'" />
-        <Skeleton class="ml-auto h-3 w-24 rounded shrink-0" />
-        <Skeleton class="h-3 w-16 rounded shrink-0" />
+        <Skeleton class="h-3 rounded-4" :class="i % 2 ? 'w-48' : 'w-36'" />
+        <Skeleton class="ml-auto h-3 w-24 rounded-4 shrink-0" />
+        <Skeleton class="h-3 w-16 rounded-4 shrink-0" />
       </div>
     </div>
 
@@ -265,10 +265,10 @@ onMounted(() => {
     <!-- empty state -->
     <div
       v-else
-      class="flex flex-col justify-center items-center gap-3 mt-4 h-1/2 border border-dashed rounded-xl
+      class="flex flex-col justify-center items-center gap-3 mt-4 h-1/2 border border-dashed rounded-7
       border-outline-gray-2 py-10"
     >
-      <div class="place-items-center grid bg-surface-gray-2 rounded-lg size-10">
+      <div class="place-items-center grid bg-surface-gray-2 rounded-6 size-10">
         <span class="lucide-history size-5 text-ink-gray-5" />
       </div>
 

--- a/admin/frontend/dashboard/src/pages/activities/Activity.vue
+++ b/admin/frontend/dashboard/src/pages/activities/Activity.vue
@@ -31,7 +31,7 @@
 
     <div
       v-if="siteFilter"
-      class="flex items-center gap-2 bg-surface-blue-1 mt-4 px-3 py-2 rounded shrink-0"
+      class="flex items-center gap-2 bg-surface-blue-1 mt-4 px-3 py-2 rounded-4 shrink-0"
     >
       <span class="lucide-filter size-4 text-ink-blue-7 shrink-0" />
       <p class="flex-1 min-w-0 text-p-sm text-ink-blue-8 truncate">
@@ -49,7 +49,7 @@
 
     <div
       v-else-if="activities.length"
-      class="flex flex-col flex-1 border border-outline-gray-2 rounded mt-4 min-h-0 overflow-hidden"
+      class="flex flex-col flex-1 border border-outline-gray-2 rounded-4 mt-4 min-h-0 overflow-hidden"
     >
       <div class="flex-1 overflow-y-auto">
         <table class="w-full text-left">

--- a/admin/frontend/dashboard/src/pages/auth/Login.vue
+++ b/admin/frontend/dashboard/src/pages/auth/Login.vue
@@ -7,7 +7,7 @@
           <h1 class="font-semibold text-ink-gray-9 text-lg">Sign In</h1>
           <p v-if="session.wizard" class="text-ink-gray-5 text-p-base">
             This bench is not set up yet. Open the setup link printed by
-            <code class="bg-surface-gray-2 px-1 py-0.5 rounded font-mono text-ink-gray-8">pilot start</code>,
+            <code class="bg-surface-gray-2 px-1 py-0.5 rounded-4 font-mono text-ink-gray-8">pilot start</code>,
             or sign in with the admin password from when the bench was created.
           </p>
           <p v-else class="text-ink-gray-5 text-p-base">Welcome! Please sign in to continue.</p>
@@ -89,7 +89,7 @@
           <li>SSH into the server.</li>
           <li>
             Run
-            <code class="bg-surface-gray-2 px-1 py-0.5 rounded font-mono text-ink-gray-8"
+            <code class="bg-surface-gray-2 px-1 py-0.5 rounded-4 font-mono text-ink-gray-8"
               >pilot -b {{ session.benchName }} set-admin-password</code
             >
           </li>

--- a/admin/frontend/dashboard/src/pages/dashboard/Analytics.vue
+++ b/admin/frontend/dashboard/src/pages/dashboard/Analytics.vue
@@ -44,9 +44,9 @@
 
     <!-- Loading state -->
     <template v-else-if="pageLoading">
-      <Skeleton v-if="!isHistorical" class="mb-6 rounded-lg h-[88px]" />
+      <Skeleton v-if="!isHistorical" class="mb-6 rounded-6 h-[88px]" />
       <div class="gap-4 grid grid-cols-1 sm:grid-cols-2 mb-6">
-        <Skeleton v-for="i in 6" :key="i" class="rounded-lg h-[340px]" />
+        <Skeleton v-for="i in 6" :key="i" class="rounded-6 h-[340px]" />
       </div>
     </template>
 
@@ -54,7 +54,7 @@
       <!-- Live stats bar: CPU / Memory / Storage -->
       <div
         v-if="liveStats"
-        class="bg-surface-white mb-6 border rounded-lg border-outline-gray-2 overflow-hidden"
+        class="bg-surface-white mb-6 border rounded-6 border-outline-gray-2 overflow-hidden"
       >
         <div class="flex sm:flex-row flex-col divide-outline-gray-2 sm:divide-x">
           <div
@@ -100,7 +100,7 @@
 
       <!-- Live mode collecting its first points, with the stat bar already up -->
       <div v-else-if="!isHistorical" class="gap-4 grid grid-cols-1 sm:grid-cols-2 mb-6">
-        <Skeleton v-for="i in 6" :key="i" class="rounded-lg h-[340px]" />
+        <Skeleton v-for="i in 6" :key="i" class="rounded-6 h-[340px]" />
       </div>
 
       <!-- WAF analytics (only renders when the WAF has logged activity) -->
@@ -112,7 +112,8 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { LoadingText, ErrorMessage, AxisChart, Skeleton } from 'frappe-ui'
+import { LoadingText, ErrorMessage, Skeleton } from 'frappe-ui'
+import { AxisChart } from 'frappe-ui/experimental'
 import ChartCard from '@/components/common/ChartCard.vue'
 import EmptyState from '@/components/common/EmptyState.vue'
 import StickyToolbar from '@/components/common/StickyToolbar.vue'

--- a/admin/frontend/dashboard/src/pages/database/Analyzer.vue
+++ b/admin/frontend/dashboard/src/pages/database/Analyzer.vue
@@ -16,7 +16,7 @@
 
     <div
       v-else-if="diagnostics && !diagnostics.supported"
-      class="flex flex-col items-center gap-1 bg-surface-white py-14 border rounded-lg border-outline-gray-2 text-center"
+      class="flex flex-col items-center gap-1 bg-surface-white py-14 border rounded-6 border-outline-gray-2 text-center"
     >
       <span class="size-6 text-ink-gray-3 lucide-database" />
       <p class="font-medium text-ink-gray-7 text-sm">No database server</p>
@@ -180,7 +180,7 @@
         Any bench sharing this server may own it.
       </p>
 
-      <dl class="space-y-1.5 bg-surface-gray-1 mt-3 p-3 rounded-lg text-xs">
+      <dl class="space-y-1.5 bg-surface-gray-1 mt-3 p-3 rounded-6 text-xs">
         <div
           v-for="item in killDetails"
           :key="item.label"
@@ -216,7 +216,7 @@
         used for point-in-time recovery and replication.
       </p>
 
-      <dl class="space-y-1.5 bg-surface-gray-1 mt-3 p-3 rounded-lg text-xs">
+      <dl class="space-y-1.5 bg-surface-gray-1 mt-3 p-3 rounded-6 text-xs">
         <div
           v-for="item in purgeDetails"
           :key="item.label"
@@ -243,14 +243,11 @@ import {
   Dialog,
   ErrorMessage,
   FormControl,
-  ListHeader,
-  ListRowItem,
-  ListRows,
-  ListView,
   LoadingText,
   Tooltip,
   toast,
 } from 'frappe-ui'
+import { ListHeader, ListRowItem, ListRows, ListView } from 'frappe-ui/experimental'
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { apiErrorMessage } from '@/api/client'

--- a/admin/frontend/dashboard/src/pages/database/SQLPlayground.vue
+++ b/admin/frontend/dashboard/src/pages/database/SQLPlayground.vue
@@ -14,7 +14,7 @@
     style="height: 75vh;"
   >
     <span
-      class="place-items-center grid bg-surface-gray-2 rounded-lg size-10 text-ink-gray-5 shrink-0"
+      class="place-items-center grid bg-surface-gray-2 rounded-6 size-10 text-ink-gray-5 shrink-0"
     >
       <span class="size-5 lucide-database" />
     </span>
@@ -32,7 +32,7 @@
 
   <div v-else class="flex flex-col gap-3">
     <!-- Editor card -->
-    <div class="border rounded-lg border-outline-gray-2 overflow-hidden transition-colors">
+    <div class="border rounded-6 border-outline-gray-2 overflow-hidden transition-colors">
       <div class="h-44 sm:h-[220px]">
         <SQLCodeEditor
           ref="editorRef"
@@ -83,7 +83,7 @@
     </div>
 
     <!-- Error -->
-    <Alert v-if="error" theme="red" title="Query failed" :dismissible="false">
+    <Alert v-if="error" theme="red" title="Query failed">
       <template #description>
         <p class="font-mono text-xs break-words whitespace-pre-wrap">{{ error }}</p>
       </template>
@@ -96,7 +96,7 @@
         <TabButtons v-model="activeTab" type="underline" :options="tabOptions" />
       </div>
 
-      <div v-if="currentResult" class="border rounded-lg border-outline-gray-2 overflow-hidden">
+      <div v-if="currentResult" class="border rounded-6 border-outline-gray-2 overflow-hidden">
         <!-- Write query success (no result set) -->
         <div
           v-if="!currentResult.columns.length"
@@ -182,7 +182,7 @@
         </button>
         <pre
           v-if="showSql"
-          class="bg-surface-gray-1 mt-1.5 px-3 py-2 border rounded-lg border-outline-gray-2 overflow-x-auto text-ink-gray-7 text-xs break-words whitespace-pre-wrap"
+          class="bg-surface-gray-1 mt-1.5 px-3 py-2 border rounded-6 border-outline-gray-2 overflow-x-auto text-ink-gray-7 text-xs break-words whitespace-pre-wrap"
           style="font-family: ui-monospace, SFMono-Regular, monospace;"
         >{{ currentResult.query }}</pre>
       </div>
@@ -200,7 +200,7 @@
         the database. Are you sure you want to continue?
       </p>
       <pre
-        class="bg-surface-gray-1 mt-3 px-3 py-2 border rounded-lg border-outline-gray-2 max-h-40 overflow-y-auto text-ink-gray-7 text-xs break-words whitespace-pre-wrap"
+        class="bg-surface-gray-1 mt-3 px-3 py-2 border rounded-6 border-outline-gray-2 max-h-40 overflow-y-auto text-ink-gray-7 text-xs break-words whitespace-pre-wrap"
         style="font-family: ui-monospace, SFMono-Regular, monospace;"
       >{{ pendingQuery }}</pre>
       <div class="flex justify-end gap-2 mt-4">

--- a/admin/frontend/dashboard/src/pages/editor/Launcher.vue
+++ b/admin/frontend/dashboard/src/pages/editor/Launcher.vue
@@ -31,7 +31,7 @@
           :href="`/editor/${encodeURIComponent(app.name)}`"
           target="_blank"
           rel="noopener"
-          class="group block bg-surface-white hover:bg-surface-gray-1 p-2.5 border border-outline-gray-2 hover:border-outline-gray-3 rounded-lg no-underline transition duration-150 ease-[var(--ease-out)]"
+          class="group block bg-surface-white hover:bg-surface-gray-1 p-2.5 border border-outline-gray-2 hover:border-outline-gray-3 rounded-6 no-underline transition duration-150 ease-[var(--ease-out)]"
         >
           <MarketplaceAppCard :app="app" class="-my-2">
             <template #actions><span /></template>

--- a/admin/frontend/dashboard/src/pages/logs/Logs.vue
+++ b/admin/frontend/dashboard/src/pages/logs/Logs.vue
@@ -27,7 +27,7 @@
             v-else
             v-for="log in filteredLogs"
             :key="log.filename"
-            class="sm:px-3 py-2.5 rounded w-full text-left transition-colors shrink-0"
+            class="sm:px-3 py-2.5 rounded-4 w-full text-left transition-colors shrink-0"
             :class="selectedFile === log.filename ? 'bg-surface-gray-3' : 'hover:bg-surface-gray-1'"
             @click="selectedFile = log.filename"
           >

--- a/admin/frontend/dashboard/src/pages/marketplace/Marketplace.vue
+++ b/admin/frontend/dashboard/src/pages/marketplace/Marketplace.vue
@@ -1,12 +1,12 @@
 <template>
   <PageHero v-if="loading">
-    <template #icon><Skeleton class="rounded-lg size-9 sm:size-10 shrink-0" /></template>
+    <template #icon><Skeleton class="rounded-6 size-9 sm:size-10 shrink-0" /></template>
     <template #title>
-      <Skeleton class="rounded w-40 h-4" />
+      <Skeleton class="rounded-4 w-40 h-4" />
       <Skeleton class="rounded-full w-14 h-5 shrink-0" />
     </template>
-    <template #subtitle><Skeleton class="rounded w-24 h-3.5" /></template>
-    <template #actions><Skeleton class="rounded w-28 h-8 sm:h-7" /></template>
+    <template #subtitle><Skeleton class="rounded-4 w-24 h-3.5" /></template>
+    <template #actions><Skeleton class="rounded-4 w-28 h-8 sm:h-7" /></template>
   </PageHero>
 
   <PageHero v-else icon="lucide-store">
@@ -47,7 +47,7 @@
     <!-- Mirrors one section of the real grid so apps land in place. -->
     <section v-if="loading" class="mt-12">
       <div class="flex items-center h-4">
-        <Skeleton class="rounded w-32 h-3.5" />
+        <Skeleton class="rounded-4 w-32 h-3.5" />
       </div>
       <div class="gap-x-6 gap-y-4 grid grid-cols-1 md:grid-cols-2 mt-3">
         <MarketplaceAppCardSkeleton v-for="i in 8" :key="i" :index="i - 1" />

--- a/admin/frontend/dashboard/src/pages/settings/Settings.vue
+++ b/admin/frontend/dashboard/src/pages/settings/Settings.vue
@@ -23,7 +23,7 @@ const themeOptions = computed(() => [
 <template>
   <div class="mx-auto max-w-3xl">
     <div
-      class="flex flex-col divide-y divide-outline-gray-1 rounded-lg border border-outline-gray-1"
+      class="flex flex-col divide-y divide-outline-gray-1 rounded-6 border border-outline-gray-1"
     >
       <div class="flex items-center gap-3 px-3 py-2.5  text-ink-gray-8">
         <span class="size-4 text-ink-gray-6 lucide-cloud" />

--- a/admin/frontend/dashboard/src/pages/setup/Setup.vue
+++ b/admin/frontend/dashboard/src/pages/setup/Setup.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex justify-center items-center p-4 h-screen">
     <div
-      class="flex flex-col bg-surface-base shadow-sm border rounded-xl border-outline-gray-2 w-full"
+      class="flex flex-col bg-surface-base shadow-sm border rounded-7 border-outline-gray-2 w-full"
       :class="modalWidthClass"
       style="max-height: calc(100vh - 2rem)"
     >
@@ -69,9 +69,10 @@
             class="flex items-center self-start gap-1 text-ink-gray-5 hover:text-ink-gray-7 text-sm"
             @click="toggleStreamDetails"
           >
-            <FeatherIcon
-              :name="showStreamDetails ? 'chevron-down' : 'chevron-right'"
+            <span
+              :class="showStreamDetails ? 'lucide-chevron-down' : 'lucide-chevron-right'"
               class="w-4 h-4"
+              aria-hidden="true"
             />
             {{ showStreamDetails ? 'Hide details' : 'Show details' }}
           </button>
@@ -107,7 +108,7 @@
           <div>
             <p class="font-medium text-ink-gray-6 text-xs">Develop locally</p>
             <code
-              class="block bg-surface-gray-2 mt-1 px-2 py-1.5 rounded font-mono text-ink-gray-8 text-sm select-all"
+              class="block bg-surface-gray-2 mt-1 px-2 py-1.5 rounded-4 font-mono text-ink-gray-8 text-sm select-all"
               >{{ pilotCommand }}
               start</code
             >
@@ -115,7 +116,7 @@
           <div>
             <p class="font-medium text-ink-gray-6 text-xs">Deploy to production</p>
             <code
-              class="block bg-surface-gray-2 mt-1 px-2 py-1.5 rounded font-mono text-ink-gray-8 text-sm select-all"
+              class="block bg-surface-gray-2 mt-1 px-2 py-1.5 rounded-4 font-mono text-ink-gray-8 text-sm select-all"
               >{{ pilotCommand }}
               setup production --admin-domain &lt;your-domain&gt; --tls --letsencrypt-email
               &lt;you@example.com&gt;</code
@@ -193,7 +194,6 @@ import {
   FormLabel,
   Password,
   ErrorMessage,
-  FeatherIcon,
   LoadingText,
 } from 'frappe-ui'
 import TaskStream from '../../components/tasks/TaskStream.vue'

--- a/admin/frontend/dashboard/src/pages/sites/SiteDetail.vue
+++ b/admin/frontend/dashboard/src/pages/sites/SiteDetail.vue
@@ -1,20 +1,20 @@
 <template>
   <template v-if="loading">
     <PageHero>
-      <template #icon><Skeleton class="rounded-lg size-9 sm:size-10 shrink-0" /></template>
+      <template #icon><Skeleton class="rounded-6 size-9 sm:size-10 shrink-0" /></template>
       <template #title>
-        <Skeleton class="rounded w-40 h-4" />
+        <Skeleton class="rounded-4 w-40 h-4" />
         <Skeleton class="rounded-full w-14 h-5 shrink-0" />
       </template>
       <template #actions>
-        <Skeleton class="hidden sm:block rounded w-28 h-7" />
-        <Skeleton class="hidden sm:block rounded w-24 h-7" />
-        <Skeleton class="rounded size-7" />
+        <Skeleton class="hidden sm:block rounded-4 w-28 h-7" />
+        <Skeleton class="hidden sm:block rounded-4 w-24 h-7" />
+        <Skeleton class="rounded-4 size-7" />
       </template>
     </PageHero>
     <div class="mx-auto w-full max-w-3xl">
       <StickyToolbar>
-        <Skeleton class="rounded w-64 h-7 sm:h-8" />
+        <Skeleton class="rounded-4 w-64 h-7 sm:h-8" />
       </StickyToolbar>
     </div>
   </template>

--- a/admin/frontend/dashboard/src/pages/sites/Sites.vue
+++ b/admin/frontend/dashboard/src/pages/sites/Sites.vue
@@ -51,7 +51,7 @@
         <div
           v-for="site in filteredSites"
           :key="site.name"
-          class="flex items-center gap-3 bg-surface-base p-2 sm:px-3 sm:py-2 border rounded-lg border-outline-gray-2 hover:border-outline-gray-3 transition-colors"
+          class="flex items-center gap-3 bg-surface-base p-2 sm:px-3 sm:py-2 border rounded-6 border-outline-gray-2 hover:border-outline-gray-3 transition-colors"
         >
           <RouterLink
             :to="{ name: 'SiteDetail', params: { name: site.name } }"
@@ -59,7 +59,7 @@
           >
             <!-- Icon -->
             <div
-              class="place-items-center grid bg-surface-gray-2 rounded size-8 text-ink-gray-6 shrink-0"
+              class="place-items-center grid bg-surface-gray-2 rounded-4 size-8 text-ink-gray-6 shrink-0"
             >
               <span class="size-4 lucide-globe"></span>
             </div>
@@ -199,10 +199,10 @@ import {
   Dropdown,
   ErrorMessage,
   FormControl,
-  ListView,
   TabButtons,
   toast,
 } from 'frappe-ui'
+import { ListView } from 'frappe-ui/experimental'
 import EmptyState from '@/components/common/EmptyState.vue'
 import NewSiteDialog from '@/components/sites/NewSiteDialog.vue'
 import SiteSkeleton from '@/components/sites/SiteSkeleton.vue'

--- a/admin/frontend/dashboard/src/pages/storage/Storage.vue
+++ b/admin/frontend/dashboard/src/pages/storage/Storage.vue
@@ -62,7 +62,7 @@ onMounted(load)
 
     <div
       v-if="loading && !storageData"
-      class="bg-surface-base border border-outline-gray-2 rounded-xl overflow-hidden"
+      class="bg-surface-base border border-outline-gray-2 rounded-7 overflow-hidden"
     >
       <div
         class="divide-y lg:divide-x lg:divide-y-0 grid grid-cols-1 divide-outline-gray-2 lg:grid-cols-2"
@@ -72,7 +72,7 @@ onMounted(load)
           <Skeleton
             v-for="row in 4"
             :key="row"
-            class="h-3.5 rounded"
+            class="h-3.5 rounded-4"
             :class="row % 2 ? 'w-full' : 'w-2/3'"
           />
         </div>
@@ -83,7 +83,7 @@ onMounted(load)
 
     <div
       v-else-if="storageData"
-      class="bg-surface-base border border-outline-gray-2 rounded-xl fade-in overflow-hidden"
+      class="bg-surface-base border border-outline-gray-2 rounded-7 fade-in overflow-hidden"
     >
       <div
         class="divide-y lg:divide-x lg:divide-y-0 grid grid-cols-1 divide-outline-gray-2 lg:grid-cols-2"

--- a/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
+++ b/admin/frontend/dashboard/src/pages/updates/UpdateDetail.vue
@@ -3,13 +3,13 @@
     <!-- Skeleton mirrors the page: meta row, then a card of rows. -->
     <div v-if="loading && !op" class="px-2">
       <div class="flex justify-between items-center py-2">
-        <Skeleton class="rounded w-44 h-4" />
-        <Skeleton class="rounded w-24 h-4" />
+        <Skeleton class="rounded-4 w-44 h-4" />
+        <Skeleton class="rounded-4 w-24 h-4" />
       </div>
-      <div class="mt-6 p-1 border border-outline-gray-2 rounded-lg">
+      <div class="mt-6 p-1 border border-outline-gray-2 rounded-6">
         <div class="flex justify-between items-center px-2.5 py-2">
-          <Skeleton class="rounded w-24 h-4" />
-          <Skeleton class="rounded w-12 h-3" />
+          <Skeleton class="rounded-4 w-24 h-4" />
+          <Skeleton class="rounded-4 w-12 h-3" />
         </div>
         <div
           v-for="index in 3"
@@ -17,7 +17,7 @@
           class="px-2.5 py-2"
           :style="{ opacity: 1 - index * 0.25 }"
         >
-          <Skeleton class="rounded w-48 h-4" />
+          <Skeleton class="rounded-4 w-48 h-4" />
         </div>
       </div>
     </div>
@@ -46,7 +46,7 @@
       <ErrorMessage v-if="error" class="mt-4" :message="error" />
 
       <!-- Unresolved failure -->
-      <section v-if="isAttention" class="mt-4 overflow-hidden rounded-lg border border-outline-gray-2">
+      <section v-if="isAttention" class="mt-4 overflow-hidden rounded-6 border border-outline-gray-2">
         <div class="p-4">
           <div class="flex items-center gap-2">
             <span class="lucide-alert-triangle size-4 shrink-0 text-ink-red-6" />
@@ -62,7 +62,7 @@
           <p v-if="op.diagnosis?.patch" class="mt-2 text-p-sm text-ink-gray-7">
             Failing patch
             <code
-              class="ml-1 rounded bg-surface-gray-2 px-1.5 py-0.5 font-mono text-xs text-ink-gray-8"
+              class="ml-1 rounded-4 bg-surface-gray-2 px-1.5 py-0.5 font-mono text-xs text-ink-gray-8"
             >
               {{ op.diagnosis.patch }}
             </code>
@@ -88,7 +88,7 @@
           <button
             v-if="pending"
             type="button"
-            class="mt-4 flex items-center gap-2 px-2 py-1 rounded transition-colors text-p-sm text-ink-gray-7 hover:bg-surface-gray-1"
+            class="mt-4 flex items-center gap-2 px-2 py-1 rounded-4 transition-colors text-p-sm text-ink-gray-7 hover:bg-surface-gray-1"
             @click="openTaskLog({ id: pending.task_id })"
           >
             <Spinner size="md" class="text-ink-amber-7" />
@@ -161,7 +161,7 @@
               class="flex items-center justify-between gap-4 px-2.5 py-2"
             >
               <div class="flex items-center gap-2 min-w-0 flex-1">
-                <AppIcon :name="app.name" class="!rounded-sm size-5" initial-class="text-xs" />
+                <AppIcon :name="app.name" class="!rounded-1 size-5" initial-class="text-xs" />
                 <p class="min-w-0 truncate text-ink-gray-9 text-base">
                   {{ app.name }}
                 </p>
@@ -218,7 +218,7 @@
           <div>
             <div v-for="site in op.sites" :key="site.name">
               <div
-                class="flex items-center gap-2 px-2.5 py-2 rounded transition-colors"
+                class="flex items-center gap-2 px-2.5 py-2 rounded-4 transition-colors"
                 :class="siteJobs(site.name).length ? 'cursor-pointer hover:bg-surface-gray-1' : ''"
                 @click="toggleSiteJobs(site.name)"
               >
@@ -271,7 +271,7 @@
           :key="index"
           class="px-2.5 py-2 text-sm text-ink-gray-7"
         >
-          <code class="rounded bg-surface-gray-2 px-1 font-mono text-xs">{{ decision.patch }}</code>
+          <code class="rounded-4 bg-surface-gray-2 px-1 font-mono text-xs">{{ decision.patch }}</code>
           on
           <span class="font-medium text-ink-gray-8">{{ decision.site }}</span>
         </div>
@@ -282,7 +282,7 @@
         <template #body-content>
           <p class="text-p-sm text-ink-gray-6">
             Skipping marks
-            <code class="rounded bg-surface-gray-2 px-1 font-mono">{{ op.diagnosis?.patch }}</code>
+            <code class="rounded-4 bg-surface-gray-2 px-1 font-mono">{{ op.diagnosis?.patch }}</code>
             as completed for
             <b class="text-ink-gray-9">{{ op.failed_site }}</b> without running it. This cannot be
             undone, and the migration carries on from where it stopped.


### PR DESCRIPTION
## Summary
- Bumps dashboard `frappe-ui` from `1.0.0-beta.34` → `1.0.0-beta.50` (latest on the 1.0.0 beta line; no stable `1.0.0` yet).
- Migrates `Alert` call sites for [frappe-ui#1005](https://github.com/frappe/frappe-ui/pull/1005) / [pilot#376](https://github.com/frappe/pilot/issues/376): `yellow` → `amber`, drop redundant `:dismissible="false"`, `#footer` → `primaryAction`.
- Also applies the loud breaks needed for a green build on this pin: numbered radius tokens (`tokens-v2 --radius-only`), `useTheme` → `useColorScheme`, `FeatherIcon` → `lucide-*`, `ListView`/`AxisChart` → `frappe-ui/experimental`, `Autocomplete` → `Combobox`.

## Test plan
- [x] `npm install && npm run build` in `admin/frontend/dashboard`
- [ ] Spot-check Alerts: Firewall (amber), Git/LLM/S3, Binlog purge action, Task debug dialog, SQL Playground, Add App from GitHub
- [ ] Theme switcher (Settings / app menu / search) still toggles light/dark/system
- [ ] Sites / Tasks / Updates list views render
- [ ] Analytics charts render
- [ ] LLM settings provider/model pickers work

Closes #376 (Alert section; remaining migration sections can follow as they land on the issue).

Made with [Cursor](https://cursor.com)