### PR TITLE
fix(setup): keep production setup free of psutil

### DIFF
--- a/admin/frontend/dashboard/src/pages/auth/Login.vue
+++ b/admin/frontend/dashboard/src/pages/auth/Login.vue
@@ -66,13 +66,7 @@ const login = async () => {
         <PilotLogo class="size-8" />
         <div class="flex flex-col gap-1">
           <h1 class="font-semibold text-ink-gray-9 text-lg">Sign In</h1>
-          <p v-if="session.wizard" class="text-ink-gray-5 text-p-base">
-            This bench is not set up yet. Open the setup link printed by
-            <code class="bg-surface-gray-2 px-1 py-0.5 rounded-4 font-mono text-ink-gray-8">pilot start</code>,
-            or sign in with the admin password from when the bench was created.
-          </p>
-
-          <p v-else class="text-ink-gray-5 text-p-base">Welcome! Please sign in to continue.</p>
+          <p class="text-ink-gray-5 text-p-base">Welcome! Please sign in to continue.</p>
         </div>
       </div>
 

--- a/pilot/core/bench/setup.py
+++ b/pilot/core/bench/setup.py
@@ -141,7 +141,7 @@ class ProductionSetup:
             SystemdProcessManager(self.bench).remove_units()
 
     def _setup_monitoring(self):
-        from pilot.core.server.monitoring import MonitorConfigurator
+        from pilot.core.server.monitoring_config import MonitorConfigurator
         from pilot.core.site.uptime_monitoring_config import UptimeMonitorConfigurator
 
         monitor = MonitorConfigurator(self.bench)

--- a/tests/pilot/commands/test_setup_production.py
+++ b/tests/pilot/commands/test_setup_production.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 import tomllib
 from pathlib import Path
 
@@ -196,6 +197,32 @@ def test_setup_monitoring_runs_privileged_setup_at_provision_time(tmp_path: Path
     cmd._setup_monitoring()
 
     assert called == ["monitor", "uptime"]
+
+
+class _BlockPsutil:
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] == "psutil":
+            raise ImportError("psutil is not installed on the system python")
+        return None
+
+
+def test_setup_monitoring_runs_without_psutil(tmp_path: Path, monkeypatch) -> None:
+    """The CLI runs on the system python, which has no third-party packages."""
+    from pilot.core.server.monitoring_config import MonitorConfigurator
+    from pilot.core.site.uptime_monitoring_config import UptimeMonitorConfigurator
+
+    bench = _make_bench(tmp_path, process_manager="systemd")
+    cmd = ProductionSetup(bench)
+
+    for configurator in (MonitorConfigurator, UptimeMonitorConfigurator):
+        monkeypatch.setattr(configurator, "install", lambda self: None)
+        monkeypatch.setattr(configurator, "setup", lambda self: None)
+
+    for module in ("psutil", "pilot.core.server.monitoring", "pilot.core.server.monitoring_proc"):
+        monkeypatch.delitem(sys.modules, module, raising=False)
+    monkeypatch.setattr(sys, "meta_path", [_BlockPsutil(), *sys.meta_path])
+
+    cmd._setup_monitoring()
 
 
 def test_setup_letsencrypt_reraises_by_default(tmp_path: Path, monkeypatch) -> None:

--- a/tests/pilot/commands/test_setup_production.py
+++ b/tests/pilot/commands/test_setup_production.py
@@ -203,7 +203,6 @@ class _BlockPsutil:
     def find_spec(self, name, path=None, target=None):
         if name.split(".")[0] == "psutil":
             raise ImportError("psutil is not installed on the system python")
-        return None
 
 
 def test_setup_monitoring_runs_without_psutil(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
The `pilot setup production` command failed with `No module named 'psutil'`. It imported `MonitorConfigurator` from the monitoring daemon module, and that module imports `psutil` at the top level. The CLI runs on the system Python, so it must not use third-party packages.

This change imports `MonitorConfigurator` from `monitoring_config`. The daemon itself runs under the admin virtual environment, where `psutil` is installed.

The login page now shows one sign-in message. The setup message was not necessary, because the reset dialog tells the user how to set a new admin password.