### PR TITLE
fix(ui): Raise z-index of dialog so toasts dont dim 

### DIFF
--- a/admin/frontend/dashboard/src/components/common/StatusListView.vue
+++ b/admin/frontend/dashboard/src/components/common/StatusListView.vue
@@ -18,7 +18,7 @@ defineProps({
   <!-- ListRow's own hover paints surface-sidebar, transparent in the dark
        theme. Rows are links, hence the descendant selector. -->
   <ListView
-    class="[&_a:hover]:bg-surface-gray-1"
+    class="max-w-full [&_a:hover]:bg-surface-gray-1"
     :columns="columns"
     :rows="rows"
     row-key="id"

--- a/admin/frontend/dashboard/src/index.css
+++ b/admin/frontend/dashboard/src/index.css
@@ -114,8 +114,9 @@ body {
   animation: fade-in 0.35s var(--ease-out);
 }
 
-#app {
-  isolation: isolate;
+.dialog-overlay,
+.dialog-scroll-container {
+  z-index: 50;
 }
 
 /* Dropdown/Menu content teleports to <body> without a z-index; lift it above both


### PR DESCRIPTION

https://github.com/user-attachments/assets/1c3dcf41-17f7-492c-ac86-098692d578e7


Another solution was to not use FrappeUiProvider in App.vue and use toastprovider wrapped in Teleport to='body' 

but for now we'll just raise the z index of dialog instead of making entire #app have isolate property