### PR TITLE
fix: Ensure state sanity when reverting multiple sites

### DIFF
--- a/pilot/core/bench/migration/operation.py
+++ b/pilot/core/bench/migration/operation.py
@@ -311,7 +311,7 @@ class MigrationOperation:
         if not self.can_revert:
             raise BenchError("Restore is unavailable: safeguards were not created for this update.")
         self.diagnosis = None
-        self._transition(self._next_revert_phase())
+        self._advance_revert()
 
     def next_revert_site(self) -> str | None:
         return next(
@@ -335,10 +335,11 @@ class MigrationOperation:
                 self.bench._reinstall_apps(filter_set, on_progress)
                 self.bench._rebuild_assets(filter_set, on_progress)
             self.revert_checkpoints["apps"] = True
+            self._save()
         except Exception as error:
             self._fail_revert(error)
             raise
-        self._transition(self._next_revert_phase())
+        self._advance_revert()
 
     def revert_site(
         self, name: str, on_step: OnStep = _NO_STEP, on_progress: OnProgress = _NO_PROGRESS
@@ -355,10 +356,11 @@ class MigrationOperation:
             self.bench.site(name).clear_cache()
             site.migration_status = "recovered"
             self.revert_checkpoints[f"site:{name}"] = True
+            self._save()
         except Exception as error:
             self._fail_revert(error)
             raise
-        self._transition(self._next_revert_phase())
+        self._advance_revert()
 
     def restart(self, on_step: OnStep = _NO_STEP) -> None:
         on_step("restart", "Restarting services")
@@ -373,6 +375,12 @@ class MigrationOperation:
             self._fail_revert(error)
             raise
         self._transition("reverted")
+
+    def _advance_revert(self) -> None:
+        """Enter the next revert phase, staying put while the current one has more units to do."""
+        phase = self._next_revert_phase()
+        if phase != self.state:
+            self._transition(phase)
 
     def _next_revert_phase(self) -> str:
         if self.apps and not self.revert_checkpoints.get("apps"):

--- a/tests/pilot/core/test_migration_operation.py
+++ b/tests/pilot/core/test_migration_operation.py
@@ -9,7 +9,7 @@ import pytest
 
 from pilot.core.app import RevisionPin
 from pilot.core.bench.migration.diagnosis import diagnose
-from pilot.core.bench.migration.operation import AppRevision
+from pilot.core.bench.migration.operation import AppRevision, SiteProgress
 from pilot.core.bench.migration.state import MigrationStateError, get_state, validate_transition
 from pilot.exceptions import BenchError, MigrateError
 from pilot.integrations.marketplace import Marketplace
@@ -664,6 +664,32 @@ def test_revert_skips_reverting_apps_phase_when_no_apps(tmp_path: Path) -> None:
     operation.revert()
 
     assert operation.state == "reverting_sites"
+
+
+def test_revert_site_stays_in_reverting_sites_until_every_site_is_done(tmp_path: Path) -> None:
+    """Recovering the first of several sites must not re-enter its own phase."""
+    mock_bench = MagicMock()
+    mock_bench.path = tmp_path
+
+    from pilot.core.bench.migration.store import MigrationStore
+
+    operation = MigrationStore(mock_bench).create_site_migrate("site1.localhost")
+    operation.sites.append(SiteProgress(name="site2.localhost"))
+    for site in operation.sites:
+        site.backup_status = "backed_up"
+        site.migration_status = "failed"
+    operation.state = get_state("needs_attention")
+
+    operation.revert()
+    operation.revert_site("site1.localhost")
+
+    assert operation.state == "reverting_sites"
+    assert operation.revert_checkpoints["site:site1.localhost"] is True
+    assert operation.next_revert_site() == "site2.localhost"
+
+    operation.revert_site("site2.localhost")
+
+    assert operation.state == "restarting"
 
 
 def test_next_revert_site_skips_pending_and_recovered_sites(tmp_path: Path) -> None:


### PR DESCRIPTION
Reverting multiple sites to original state causes error since moving from reverting -> reverting status which is not allowed, therefore let the reverting status stay till all the sites are reverted.