### PR TITLE
Fix/create sites before dns config

### DIFF
--- a/pilot/core/bench/setup.py
+++ b/pilot/core/bench/setup.py
@@ -217,6 +217,7 @@ class ProductionSetup:
             data.get("production", {}).pop("nginx", None)
 
     def _write_dns_multitenancy(self) -> None:
+        self.bench.sites_path.mkdir(parents=True, exist_ok=True)
         common_config_path = self.bench.sites_path / "common_site_config.json"
         existing_data: dict = {}
         if common_config_path.exists():

--- a/tests/pilot/commands/test_setup_production.py
+++ b/tests/pilot/commands/test_setup_production.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 import tomllib
 from pathlib import Path
@@ -60,6 +61,20 @@ def test_persist_preserves_other_fields(tmp_path: Path) -> None:
     assert data["apps"][0]["name"] == "frappe"
     # mariadb lives in common_config.toml now, untouched by this rewrite too.
     assert bench.config.mariadb.root_password == "root"
+
+
+def test_write_dns_multitenancy_creates_missing_sites_directory(tmp_path: Path) -> None:
+    bench = _make_bench(tmp_path)
+    bench.sites_path.rmdir()
+
+    assert not bench.sites_path.exists()
+
+    ProductionSetup(bench)._write_dns_multitenancy()
+
+    common_config = bench.sites_path / "common_site_config.json"
+    assert bench.sites_path.is_dir()
+    assert common_config.is_file()
+    assert json.loads(common_config.read_text())["dns_multitenant"] == 1
 
 
 def test_check_admin_domain_uses_toml_value(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fix `pilot setup production` failing when the bench `sites` directory does not yet exist.

During production setup, Pilot writes `dns_multitenant` to:

```text
<bench>/sites/common_site_config.json
```

However, `_write_dns_multitenancy()` previously assumed that the `sites` directory was already present. If it was missing, production setup failed with:

```text
FileNotFoundError: [Errno 2] No such file or directory:
'<bench>/sites/common_site_config.json'
```

## Root Cause

`ProductionSetup._write_dns_multitenancy()` constructed the path to `common_site_config.json` and immediately called `write_private_text()`.

The parent directory was never created or validated first.

This meant a bench could reach the production setup flow successfully, but fail before process manager, nginx, TLS, or admin setup began if `sites/` had not yet been created.

## Changes

* Ensure `self.bench.sites_path` exists before writing `common_site_config.json`.
* Use `mkdir(parents=True, exist_ok=True)` so the operation is safe and idempotent.
* Add a regression test covering production DNS configuration when the `sites` directory is initially absent.
* Verify that:

  * the missing `sites` directory is created;
  * `common_site_config.json` is created successfully;
  * `dns_multitenant` is written as expected.

## Expected Behavior

Running:

```bash
pilot -b <bench> setup production --admin-domain <domain>
```

should not require the `sites` directory to have been created beforehand.

Production setup now creates the directory when necessary and continues normally.

Existing benches where `sites/` and `common_site_config.json` already exist are unaffected.

## Reproduction

Before this fix, a bench without a `sites` directory would fail during production setup with a traceback similar to:

```text
FileNotFoundError: [Errno 2] No such file or directory:
'/home/av/pilot/benches/v15/sites/common_site_config.json'
```

The failure originated from:

```text
ProductionSetup._write_dns_multitenancy()
```

while attempting to persist the DNS multitenancy configuration.

## Testing

Added regression coverage that removes the bench `sites` directory before calling `_write_dns_multitenancy()` and confirms that the method recreates the directory and writes the expected configuration successfully.
