### PR TITLE
feat: start development benches in the background

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,7 +22,7 @@ Bench commands with `--bench NAME` can run from outside the bench directory. `Be
 - `pilot build`: build assets or download prebuilt assets when available.
 - `pilot frappe -- ...`: pass through to Frappe's bench helper.
 
-In development, `pilot stop` waits until the foreground runner exits and its processes release their configured ports. Unrelated processes on those ports are never signaled or waited for.
+In development, `pilot stop` waits until the foreground runner exits and its processes release their configured ports. Unrelated processes on those ports are never signaled or waited for. `pilot start --detach` runs the development bench in the background with logs in the bench's `logs/bench.log`, and `pilot -b all start` starts development benches this way.
 
 Some runtime commands support all benches when invoked with the CLI option for all-bench execution.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,7 +22,7 @@ Bench commands with `--bench NAME` can run from outside the bench directory. `Be
 - `pilot build`: build assets or download prebuilt assets when available.
 - `pilot frappe -- ...`: pass through to Frappe's bench helper.
 
-In development, `pilot stop` waits until the foreground runner exits and its processes release their configured ports. Unrelated processes on those ports are never signaled or waited for. `pilot start --detach` runs the development bench in the background with logs in the bench's `logs/bench.log`, and `pilot -b all start` starts development benches this way.
+In development, `pilot stop` waits until the foreground runner exits and its processes release their configured ports. Unrelated processes on those ports are never signaled or waited for. `pilot start --detach` runs the development bench in the background with logs in the bench's `logs/bench.log`. `pilot -b all start` skips development benches unless `--detach` is passed.
 
 Some runtime commands support all benches when invoked with the CLI option for all-bench execution.
 

--- a/pilot/commands/base.py
+++ b/pilot/commands/base.py
@@ -46,8 +46,10 @@ class Command:
 
     bench: Bench | None = None
 
-    def prepare_all_sweep(self) -> None:
-        """Adjust the command for a `-b all` sweep; a no-op for most commands."""
+    def prepare_all_sweep(self) -> str | None:
+        """Adjust the command for a `-b all` sweep. Return a reason to skip this
+        bench, or None to run; most commands run unchanged."""
+        return None
 
     def run(self) -> None:
         raise NotImplementedError

--- a/pilot/commands/base.py
+++ b/pilot/commands/base.py
@@ -46,6 +46,9 @@ class Command:
 
     bench: Bench | None = None
 
+    def prepare_all_sweep(self) -> None:
+        """Adjust the command for a `-b all` sweep; a no-op for most commands."""
+
     def run(self) -> None:
         raise NotImplementedError
 

--- a/pilot/commands/runtime/start.py
+++ b/pilot/commands/runtime/start.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
-from pilot.commands import Command
+from pilot.commands import Arg, Command
 
 
 @dataclass(kw_only=True)
@@ -11,6 +11,16 @@ class RunCommand(Command):
     name: ClassVar[str] = "start"
     help: ClassVar[str] = "Start all bench processes."
     supports_all_benches: ClassVar[bool] = True
+    supports_dev_benches: ClassVar[bool] = True
+
+    detach: Annotated[bool, Arg(help="Run the development bench in the background.")] = False
+
+    def prepare_all_sweep(self) -> None:
+        if not self.bench.config.production.enabled:
+            self.detach = True
 
     def run(self) -> None:
+        if self.detach:
+            self.bench.start_detached(on_progress=self.report)
+            return
         self.bench.start(on_progress=self.report)

--- a/pilot/commands/runtime/start.py
+++ b/pilot/commands/runtime/start.py
@@ -15,9 +15,13 @@ class RunCommand(Command):
 
     detach: Annotated[bool, Arg(help="Run the development bench in the background.")] = False
 
-    def prepare_all_sweep(self) -> None:
-        if not self.bench.config.production.enabled:
-            self.detach = True
+    def prepare_all_sweep(self) -> str | None:
+        if self.bench.config.production.enabled:
+            self.detach = False
+            return None
+        if self.detach:
+            return None
+        return "development bench; start it in its own terminal, or pass --detach"
 
     def run(self) -> None:
         if self.detach:

--- a/pilot/core/bench/__init__.py
+++ b/pilot/core/bench/__init__.py
@@ -242,6 +242,11 @@ class Bench:
 
         BenchRuntime(self).start(on_progress)
 
+    def start_detached(self, on_progress: Callable[[str], None] = lambda message: None) -> None:
+        from pilot.core.bench.runtime import BenchRuntime
+
+        BenchRuntime(self).start_detached(on_progress)
+
     def stop(self, on_progress: Callable[[str], None] = lambda message: None) -> None:
         from pilot.core.bench.runtime import BenchRuntime
 

--- a/pilot/core/bench/runtime.py
+++ b/pilot/core/bench/runtime.py
@@ -125,7 +125,7 @@ class BenchRuntime:
         """Run `pilot start` for this bench as a background session."""
         from pilot.utils import cli_root
 
-        if self.bench.config.production.process_manager:
+        if self.bench.config.production.enabled:
             raise BenchError("--detach only applies to development benches.")
         if not self._is_initialized():
             raise BenchError("Bench is not initialized. Run 'pilot start' in the foreground to finish setup.")
@@ -152,9 +152,10 @@ class BenchRuntime:
         while time.monotonic() < deadline:
             if process.poll() is not None:
                 raise BenchError(f"Background start exited with code {process.returncode}. See {log_path}.")
-            if manager.is_running():
+            if manager.running_supervisor_pid == process.pid:
                 return
             time.sleep(0.2)
+        process.terminate()
         raise BenchError(f"Timed out waiting for the background supervisor. See {log_path}.")
 
     def _start_development(self, initialized: bool, on_progress: Callable[[str], None]) -> None:

--- a/pilot/core/bench/runtime.py
+++ b/pilot/core/bench/runtime.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+import sys
+import time
 from collections.abc import Callable
+from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from pilot.exceptions import BenchError, BenchNotRunningError
@@ -117,6 +120,42 @@ class BenchRuntime:
     def install_requirements(self, on_progress: Callable[[str], None]) -> None:
         self._install_python_requirements(on_progress)
         self._install_js_requirements(on_progress)
+
+    def start_detached(self, on_progress: Callable[[str], None]) -> None:
+        """Run `pilot start` for this bench as a background session."""
+        from pilot.utils import cli_root
+
+        if self.bench.config.production.process_manager:
+            raise BenchError("--detach only applies to development benches.")
+        if not self._is_initialized():
+            raise BenchError("Bench is not initialized. Run 'pilot start' in the foreground to finish setup.")
+        log_path = self.bench.logs_path / "bench.log"
+        self.bench.logs_path.mkdir(parents=True, exist_ok=True)
+        with log_path.open("ab") as log_file:
+            process = subprocess.Popen(
+                [sys.executable, str(cli_root() / "bin" / "pilot"), "-b", self.bench.path.name, "start"],
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+        self._wait_for_detached_supervisor(process, log_path)
+        on_progress(f"Started in the background (pid {process.pid}). Logs: {log_path}")
+
+    def _wait_for_detached_supervisor(
+        self, process: subprocess.Popen, log_path: Path, timeout: float = 30.0
+    ) -> None:
+        from pilot.managers.processes.local import ProcessManager
+
+        manager = ProcessManager(self.bench)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                raise BenchError(f"Background start exited with code {process.returncode}. See {log_path}.")
+            if manager.is_running():
+                return
+            time.sleep(0.2)
+        raise BenchError(f"Timed out waiting for the background supervisor. See {log_path}.")
 
     def _start_development(self, initialized: bool, on_progress: Callable[[str], None]) -> None:
         from pilot.managers.processes.local import ProcessManager

--- a/pilot/internal/cli/registry.py
+++ b/pilot/internal/cli/registry.py
@@ -136,8 +136,10 @@ def _run_for_bench(
         print(f"== {name} == (skipped: dev mode)")
         return True
     print(f"== {name} ==")
+    command = command_from_args(cls, args, bench)
+    command.prepare_all_sweep()
     try:
-        command_from_args(cls, args, bench).run()
+        command.run()
     except BenchNotRunningError as e:
         print(str(e))
     except BenchError as e:

--- a/pilot/internal/cli/registry.py
+++ b/pilot/internal/cli/registry.py
@@ -135,9 +135,11 @@ def _run_for_bench(
     if not bench.config.production.enabled and not cls.supports_dev_benches:
         print(f"== {name} == (skipped: dev mode)")
         return True
-    print(f"== {name} ==")
     command = command_from_args(cls, args, bench)
-    command.prepare_all_sweep()
+    if skip_reason := command.prepare_all_sweep():
+        print(f"== {name} == (skipped: {skip_reason})")
+        return True
+    print(f"== {name} ==")
     try:
         command.run()
     except BenchNotRunningError as e:

--- a/tests/pilot/commands/test_commands.py
+++ b/tests/pilot/commands/test_commands.py
@@ -1472,9 +1472,20 @@ def test_start_detached_rejects_production_benches(tmp_path: Path) -> None:
     from pilot.core.bench.runtime import BenchRuntime
 
     bench = make_bench(tmp_path)
+    bench.config.production.enabled = True
     bench.config.production.process_manager = "systemd"
 
     with pytest.raises(BenchError, match="development"):
+        BenchRuntime(bench).start_detached(lambda _message: None)
+
+
+def test_start_detached_allows_a_stale_process_manager_setting(tmp_path: Path) -> None:
+    from pilot.core.bench.runtime import BenchRuntime
+
+    bench = make_bench(tmp_path)
+    bench.config.production.process_manager = "systemd"
+
+    with pytest.raises(BenchError, match="not initialized"):
         BenchRuntime(bench).start_detached(lambda _message: None)
 
 
@@ -1494,7 +1505,10 @@ def test_start_detached_spawns_background_supervisor(tmp_path: Path, monkeypatch
         return SimpleNamespace(poll=lambda: None, pid=4321, returncode=None)
 
     monkeypatch.setattr("pilot.core.bench.runtime.subprocess.Popen", fake_popen)
-    monkeypatch.setattr("pilot.managers.processes.local.ProcessManager.is_running", lambda _self: True)
+    monkeypatch.setattr(
+        "pilot.managers.processes.local.ProcessManager.running_supervisor_pid",
+        property(lambda _self: 4321),
+    )
     messages = []
 
     runtime.start_detached(messages.append)
@@ -1519,3 +1533,35 @@ def test_start_detached_reports_early_exit(tmp_path: Path, monkeypatch) -> None:
 
     with pytest.raises(BenchError, match="exited with code 1"):
         runtime.start_detached(lambda _message: None)
+
+
+def test_detached_start_waits_for_the_new_supervisor(tmp_path: Path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from pilot.core.bench.runtime import BenchRuntime
+
+    runtime = BenchRuntime(make_bench(tmp_path))
+    supervisor_pids = iter((123, 4321))
+    monkeypatch.setattr(
+        "pilot.managers.processes.local.ProcessManager.running_supervisor_pid",
+        property(lambda _self: next(supervisor_pids)),
+    )
+    monkeypatch.setattr("pilot.core.bench.runtime.time.sleep", lambda _seconds: None)
+    process = SimpleNamespace(poll=lambda: None, pid=4321)
+
+    runtime._wait_for_detached_supervisor(process, tmp_path / "bench.log")
+
+
+def test_detached_start_terminates_the_process_on_timeout(tmp_path: Path) -> None:
+    from pilot.core.bench.runtime import BenchRuntime
+
+    process = MagicMock()
+    process.poll.return_value = None
+    process.pid = 4321
+
+    with pytest.raises(BenchError, match="Timed out"):
+        BenchRuntime(make_bench(tmp_path))._wait_for_detached_supervisor(
+            process, tmp_path / "bench.log", timeout=0
+        )
+
+    process.terminate.assert_called_once_with()

--- a/tests/pilot/commands/test_commands.py
+++ b/tests/pilot/commands/test_commands.py
@@ -1456,3 +1456,66 @@ def test_start_rebuilds_admin_in_a_dev_checkout(tmp_path: Path, monkeypatch: pyt
     BenchRuntime(make_bench(tmp_path))._ensure_admin_dist(lambda _message: None)
 
     build.assert_called_once_with(on_progress=ANY)
+
+
+def test_start_detach_uses_background_start(tmp_path: Path) -> None:
+    from pilot.commands.runtime.start import RunCommand
+
+    bench = make_bench(tmp_path)
+    with patch.object(Bench, "start_detached") as detached:
+        RunCommand(bench=bench, detach=True).run()
+
+    detached.assert_called_once()
+
+
+def test_start_detached_rejects_production_benches(tmp_path: Path) -> None:
+    from pilot.core.bench.runtime import BenchRuntime
+
+    bench = make_bench(tmp_path)
+    bench.config.production.process_manager = "systemd"
+
+    with pytest.raises(BenchError, match="development"):
+        BenchRuntime(bench).start_detached(lambda _message: None)
+
+
+def test_start_detached_spawns_background_supervisor(tmp_path: Path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from pilot.core.bench.runtime import BenchRuntime
+
+    bench = make_bench(tmp_path)
+    _mark_initialized(bench)
+    runtime = BenchRuntime(bench)
+    captured = {}
+
+    def fake_popen(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(poll=lambda: None, pid=4321, returncode=None)
+
+    monkeypatch.setattr("pilot.core.bench.runtime.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("pilot.managers.processes.local.ProcessManager.is_running", lambda _self: True)
+    messages = []
+
+    runtime.start_detached(messages.append)
+
+    assert captured["argv"][-3:] == ["-b", bench.path.name, "start"]
+    assert captured["kwargs"]["start_new_session"] is True
+    assert any("background" in message for message in messages)
+
+
+def test_start_detached_reports_early_exit(tmp_path: Path, monkeypatch) -> None:
+    from types import SimpleNamespace
+
+    from pilot.core.bench.runtime import BenchRuntime
+
+    bench = make_bench(tmp_path)
+    _mark_initialized(bench)
+    runtime = BenchRuntime(bench)
+    monkeypatch.setattr(
+        "pilot.core.bench.runtime.subprocess.Popen",
+        lambda *_args, **_kwargs: SimpleNamespace(poll=lambda: 1, pid=4321, returncode=1),
+    )
+
+    with pytest.raises(BenchError, match="exited with code 1"):
+        runtime.start_detached(lambda _message: None)

--- a/tests/pilot/test_cli.py
+++ b/tests/pilot/test_cli.py
@@ -190,7 +190,7 @@ def test_dispatch_all_runs_stop_on_dev_benches(tmp_path, monkeypatch, capsys):
     import argparse
     from types import SimpleNamespace
 
-    from pilot.commands.runtime.start import RunCommand
+    from pilot.commands.runtime.restart import RestartCommand
     from pilot.commands.runtime.stop import StopCommand
     from pilot.internal.cli import registry
     from pilot.internal.cli.dispatch import CliContext
@@ -205,7 +205,7 @@ def test_dispatch_all_runs_stop_on_dev_benches(tmp_path, monkeypatch, capsys):
     monkeypatch.setattr(
         registry,
         "command_from_args",
-        lambda _cls, _args, bench: SimpleNamespace(run=lambda: ran.append(bench)),
+        lambda _cls, _args, bench: SimpleNamespace(run=lambda: ran.append(bench), prepare_all_sweep=lambda: None),
     )
     context = CliContext(installation_root=tmp_path, bench_name="all")
 
@@ -213,7 +213,7 @@ def test_dispatch_all_runs_stop_on_dev_benches(tmp_path, monkeypatch, capsys):
     assert len(ran) == 2
 
     ran.clear()
-    registry.dispatch_all(argparse.Namespace(_command_cls=RunCommand), argparse.ArgumentParser(), context)
+    registry.dispatch_all(argparse.Namespace(_command_cls=RestartCommand), argparse.ArgumentParser(), context)
     assert ran == []
     assert "skipped: dev mode" in capsys.readouterr().out
 
@@ -241,7 +241,7 @@ def test_dispatch_all_stop_tolerates_stopped_benches(tmp_path, monkeypatch):
     monkeypatch.setattr(
         registry,
         "command_from_args",
-        lambda _cls, _args, _bench: SimpleNamespace(run=not_running),
+        lambda _cls, _args, _bench: SimpleNamespace(run=not_running, prepare_all_sweep=lambda: None),
     )
     registry.dispatch_all(args, argparse.ArgumentParser(), context)
 
@@ -251,7 +251,34 @@ def test_dispatch_all_stop_tolerates_stopped_benches(tmp_path, monkeypatch):
     monkeypatch.setattr(
         registry,
         "command_from_args",
-        lambda _cls, _args, _bench: SimpleNamespace(run=broken),
+        lambda _cls, _args, _bench: SimpleNamespace(run=broken, prepare_all_sweep=lambda: None),
     )
     with pytest.raises(BenchError, match="Failed for: alpha"):
         registry.dispatch_all(args, argparse.ArgumentParser(), context)
+
+
+def test_dispatch_all_start_detaches_dev_benches(tmp_path, monkeypatch):
+    import argparse
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from pilot.commands.runtime.start import RunCommand
+    from pilot.internal.cli import registry
+    from pilot.internal.cli.dispatch import CliContext
+
+    bench_dir = tmp_path / "benches" / "alpha"
+    bench_dir.mkdir(parents=True)
+    (bench_dir / "bench.toml").write_text("")
+    dev_bench = SimpleNamespace(
+        config=SimpleNamespace(production=SimpleNamespace(enabled=False)),
+        start=MagicMock(),
+        start_detached=MagicMock(),
+    )
+    monkeypatch.setattr(registry, "load_bench", lambda _context: dev_bench)
+    context = CliContext(installation_root=tmp_path, bench_name="all")
+    args = argparse.Namespace(_command_cls=RunCommand, detach=False)
+
+    registry.dispatch_all(args, argparse.ArgumentParser(), context)
+
+    dev_bench.start_detached.assert_called_once()
+    dev_bench.start.assert_not_called()

--- a/tests/pilot/test_cli.py
+++ b/tests/pilot/test_cli.py
@@ -257,7 +257,7 @@ def test_dispatch_all_stop_tolerates_stopped_benches(tmp_path, monkeypatch):
         registry.dispatch_all(args, argparse.ArgumentParser(), context)
 
 
-def test_dispatch_all_start_detaches_dev_benches(tmp_path, monkeypatch):
+def test_dispatch_all_start_skips_dev_benches_without_detach(tmp_path, monkeypatch, capsys):
     import argparse
     from types import SimpleNamespace
     from unittest.mock import MagicMock
@@ -276,9 +276,18 @@ def test_dispatch_all_start_detaches_dev_benches(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(registry, "load_bench", lambda _context: dev_bench)
     context = CliContext(installation_root=tmp_path, bench_name="all")
-    args = argparse.Namespace(_command_cls=RunCommand, detach=False)
 
-    registry.dispatch_all(args, argparse.ArgumentParser(), context)
+    registry.dispatch_all(
+        argparse.Namespace(_command_cls=RunCommand, detach=False), argparse.ArgumentParser(), context
+    )
+
+    dev_bench.start.assert_not_called()
+    dev_bench.start_detached.assert_not_called()
+    assert "pass --detach" in capsys.readouterr().out
+
+    registry.dispatch_all(
+        argparse.Namespace(_command_cls=RunCommand, detach=True), argparse.ArgumentParser(), context
+    )
 
     dev_bench.start_detached.assert_called_once()
     dev_bench.start.assert_not_called()


### PR DESCRIPTION
## Problem

`pilot -b all start` skipped development benches with only "(skipped: dev mode)", and there was no way to start a development bench without holding a terminal.

## Changes

- `pilot start --detach` runs a development bench in the background: the supervisor is spawned in its own session with output in the bench's `logs/bench.log`, and the command waits for it to record itself before returning. Early exit and uninitialized benches fail loudly; production benches reject the flag.
- `pilot -b all start` keeps development benches foreground by default: it skips them with a message pointing at `--detach`, and detaches them only when the flag is passed. Production benches in the sweep start normally either way.

Stacked on #411, whose synchronous stop and supervisor record make a detached supervisor findable and stoppable.