### PR TITLE
feat: default a new bench to lite mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,6 +88,10 @@ together - instead of separate web, socketio and worker processes. Every key bel
 becomes a flag on `python -m frappe.runner`, which is what the `web` process runs.
 The process manager still supervises it; only the process set changes.
 
+A new bench is created with `enabled = true`. A bench.toml written before this was
+the default carries no `[lite_mode]` table, and keeps the separate process set until
+you turn lite mode on in Settings. Turning it off writes `enabled = false`.
+
 ```toml
 [lite_mode]
 enabled = true

--- a/docs/production.md
+++ b/docs/production.md
@@ -33,9 +33,9 @@ pilot setup letsencrypt
 
 Supported managers are `systemd` and `supervisor`.
 
-The deployed process set is web, socketio, admin, workers, and the two redis
-servers. With `[lite_mode] enabled` it collapses to one bench process plus admin and
-redis - see [Lite Mode](configuration.md#lite-mode).
+A new bench deploys one bench process plus admin and the two redis servers, because
+`[lite_mode] enabled` is the default. Turn lite mode off and the set becomes web,
+socketio, admin, workers, and redis - see [Lite Mode](configuration.md#lite-mode).
 
 Runtime commands:
 

--- a/pilot/config/bench.py
+++ b/pilot/config/bench.py
@@ -747,7 +747,6 @@ _SECTIONS: tuple[_Section, ...] = (
     _Section(
         "lite_mode",
         lambda data: LiteModeConfig.from_dict(data.get("lite_mode", {})),
-        # A bench that opted out never carries the section.
         lambda config: config._lite_mode_section() if config.lite_mode.enabled else None,
     ),
     _Section(

--- a/pilot/config/bench.py
+++ b/pilot/config/bench.py
@@ -72,6 +72,7 @@ FLAT_KEYS = {
     "admin_allow_bench_management": "admin.allow_bench_management",
     "letsencrypt_email": "letsencrypt.email",
     "production_process_manager": "production.process_manager",
+    "lite_mode_enabled": "lite_mode.enabled",
 }
 
 # Framework branches the setup wizard offers, newest/recommended first.
@@ -746,7 +747,7 @@ _SECTIONS: tuple[_Section, ...] = (
     _Section(
         "lite_mode",
         lambda data: LiteModeConfig.from_dict(data.get("lite_mode", {})),
-        # Off by default, so an ordinary bench.toml never carries the section.
+        # A bench that opted out never carries the section.
         lambda config: config._lite_mode_section() if config.lite_mode.enabled else None,
     ),
     _Section(

--- a/pilot/core/bench/creator.py
+++ b/pilot/core/bench/creator.py
@@ -73,13 +73,12 @@ class BenchCreator:
 
         settings = {
             "admin_enabled": True,
-            # The Admin needs a password from the start: the setup wizard authenticates
-            # like every other page, so there is no unprotected window to set one in.
             "admin_password": self.admin_password or secrets.token_urlsafe(12),
             "admin_domain": self.admin_domain,
             # admin.tls is a per-bench choice, not inherited from siblings.
             "admin_tls": bool(self.admin_tls),
             "db_type": self.db_type,
+            "lite_mode_enabled": True,
         }
         if self.process_manager:
             settings["production_process_manager"] = self.process_manager

--- a/tests/pilot/managers/test_lite_mode.py
+++ b/tests/pilot/managers/test_lite_mode.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import tomllib
 from pathlib import Path
+
+import pytest
 
 from pilot.config import (
     AppConfig,
@@ -189,3 +192,32 @@ def test_lite_off_keeps_the_ordinary_process_set(tmp_path: Path) -> None:
     assert "socketio" in names
     assert "worker_default_short_1" in names
     assert "frappe.runner" not in _web(bench).argv
+
+
+def test_a_new_bench_is_created_in_lite_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from pilot.core.bench.creator import BenchCreator
+
+    monkeypatch.setattr(BenchCreator, "_port_is_live", staticmethod(lambda port: False))
+    target = tmp_path / "benches" / "fresh"
+    BenchCreator(target, "fresh").run()
+
+    with open(target / "bench.toml", "rb") as f:
+        data = tomllib.load(f)
+    assert data["lite_mode"]["enabled"] is True
+
+
+def test_an_existing_bench_without_the_section_stays_off(tmp_path: Path) -> None:
+    """Lite is the default for a new bench only. A bench.toml written before
+    the default changed carries no [lite_mode], and must keep the ordinary set."""
+    bench_toml = tmp_path / "bench.toml"
+    bench_toml.write_text(
+        '[bench]\nname = "old"\npython = "3.14"\n\n[[apps]]\n'
+        'name = "frappe"\nrepo = "https://github.com/frappe/frappe"\nbranch = "version-16"\n',
+        encoding="utf-8",
+    )
+
+    assert BenchConfig.read(tmp_path).lite_mode.enabled is False
+
+    BenchConfig.write_flat(tmp_path, "old", {"admin_domain": "old.example.com"})
+
+    assert "lite_mode" not in tomllib.loads(bench_toml.read_text(encoding="utf-8"))


### PR DESCRIPTION
`BenchCreator` writes `[lite_mode] enabled = true`, so a fresh bench runs one process for web, realtime and jobs instead of the web + socketio + worker set. `lite_mode_enabled` joins `FLAT_KEYS` so creation sets it through the same flat-settings path as `admin_tls` and `db_type`.

`LiteModeConfig.enabled` still defaults to `False` in the dataclass, so a `bench.toml` written before this change carries no `[lite_mode]` table and keeps its current process set — no running bench changes topology on upgrade. Opting out stays the Settings toggle.

A new bench on a frappe without `frappe/runner.py` still falls back to the ordinary set through `Bench.is_lite_mode`.