### PR TITLE
fix: quote paths in backup cron command to handle spaces

### DIFF
--- a/pilot/core/site/backups.py
+++ b/pilot/core/site/backups.py
@@ -1,6 +1,7 @@
 """Apply a retention policy to one site's backups, local and offsite."""
 
 import re
+import shlex
 import sys
 from dataclasses import asdict
 from pathlib import Path
@@ -155,10 +156,10 @@ class SiteBackups:
 
     def _cron_command(self) -> str:
         log_file = self.site.bench.logs_path / f"backup-{self.site.config.name}.log"
-        return (
-            f"{sys.executable} -m pilot.tasks.backup_site {self.site.bench.path} "
-            f"{self.site.config.name} --with-files >> {log_file} 2>&1"
+        python, bench, site, log = (
+            shlex.quote(str(p)) for p in (sys.executable, self.site.bench.path, self.site.config.name, log_file)
         )
+        return f"{python} -m pilot.tasks.backup_site {bench} {site} --with-files >> {log} 2>&1"
 
 
 def retention_from_payload(block: dict | None):

--- a/tests/pilot/core/test_backup_pruner.py
+++ b/tests/pilot/core/test_backup_pruner.py
@@ -114,6 +114,24 @@ def test_prunes_local_and_offsite_when_healthy(tmp_path) -> None:
     assert (backups / "20260103_020000-site1-database.sql.gz").exists()
 
 
+def test_cron_command_quotes_paths_with_spaces(tmp_path) -> None:
+    """Scheduled backup command must quote paths so the shell does not split them."""
+    import shlex
+
+    spaced = tmp_path / "bench with spaces"
+    bench = SimpleNamespace(
+        path=spaced,
+        sites_path=spaced / "sites",
+        logs_path=spaced / "logs",
+    )
+    site = Site(SiteConfig(name="site.localhost", apps=[]), bench)
+    command = site.backups._cron_command()
+    argv = shlex.split(command.split(">>")[0])
+    assert argv[-3] == str(spaced)  # bench_root
+    assert argv[-2] == "site.localhost"  # site name
+    assert argv[-1] == "--with-files"
+
+
 def test_backup_file_names_from_a_request_stay_inside_the_site(tmp_path) -> None:
     """A delete or download names the file, so nothing may point outside the directory."""
     import pytest


### PR DESCRIPTION
Fixes https://github.com/frappe/pilot/issues/405

The scheduled backup cron command was not quoting paths for the shell. If the bench path or log file path contained spaces, the shell would split the command and the backup would fail or run against the wrong path.

This fix uses shlex.quote() (the same pattern already used by registry_cache.py) to properly quote sys.executable, bench path, site name, and log file path.

Also adds a regression test to ensure paths with spaces are quoted correctly.