### PR TITLE
fix: open sites on their served origin and hint when the host cannot resolve

### DIFF
--- a/admin/backend/api/v1/sites/core.py
+++ b/admin/backend/api/v1/sites/core.py
@@ -13,6 +13,7 @@ from admin.backend.api.responses import (
 )
 from admin.backend.api.v1.sites import sites_bp
 from admin.backend.api.v1.sites.login import no_store as _no_store
+from admin.backend.api.v1.sites.login import unreachable_host_hint
 from admin.backend.api.v1.sites.shared import (
     internal_error,
     invalid_fields,
@@ -28,6 +29,7 @@ from admin.backend.middleware import rate_limit, require_scope
 from admin.backend.providers.apps import AppProvider
 from admin.backend.providers.sites import SiteInfo, SiteProvider
 from pilot.core.bench import Bench
+from pilot.core.site.login import site_url
 from pilot.internal.site_paths import site_config_path, site_exists
 from pilot.internal.validators import validate_site_name
 from pilot.tasks.clear_cache import ClearCacheTask
@@ -73,10 +75,12 @@ def detail(name: str):
         http_port = bench_config.http_port
         nginx_enabled = bench_config.production.enabled
         admin_tls = bench_config.admin.tls
+        url = site_url(name, site.site_config, bench_config)
     except Exception:
         http_port = 8000
         nginx_enabled = False
         admin_tls = False
+        url = f"http://{name}:8000"
 
     return jsonify(
         {
@@ -86,6 +90,7 @@ def detail(name: str):
             "http_port": http_port,
             "nginx_enabled": nginx_enabled,
             "admin_tls": admin_tls,
+            "url": url,
         }
     )
 
@@ -247,7 +252,10 @@ def create_login_link(name: str):
             503,
         )
 
-    return _no_store(created_response({"url": url}, url))
+    payload = {"url": url}
+    if hint := unreachable_host_hint(url):
+        payload["hint"] = hint
+    return _no_store(created_response(payload, url))
 
 
 def _site_resource(site: SiteInfo) -> dict:

--- a/admin/backend/api/v1/sites/login.py
+++ b/admin/backend/api/v1/sites/login.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from urllib.parse import urlsplit
+
 from flask import make_response
 
-from pilot.core.site.login import origin, primary_host
+from pilot.core.site.login import is_host_resolvable, origin, primary_host
 
-__all__ = ["no_store", "origin", "primary_host"]
+__all__ = ["no_store", "origin", "primary_host", "unreachable_host_hint"]
 
 
 def no_store(response):
@@ -13,3 +15,15 @@ def no_store(response):
     response.headers["Pragma"] = "no-cache"
     response.headers["Referrer-Policy"] = "no-referrer"
     return response
+
+
+def unreachable_host_hint(url: str) -> str | None:
+    """A UI hint when the URL's host does not resolve on this machine,
+    so the browser most likely cannot reach it either."""
+    host = urlsplit(url).hostname or ""
+    if not host or is_host_resolvable(host):
+        return None
+    return (
+        f"'{host}' does not resolve on this machine. Add it to /etc/hosts "
+        "or use a *.localhost site name so the browser can reach the site."
+    )

--- a/admin/frontend/dashboard/src/composables/sites/useSite.ts
+++ b/admin/frontend/dashboard/src/composables/sites/useSite.ts
@@ -111,8 +111,8 @@ export const useSite = (name) => {
     await _fetchBackups()
   }
 
-  const login = async () => {
-    return openSiteLogin(() => sitesApi.loginLink(name))
+  const login = async (options = {}) => {
+    return openSiteLogin(() => sitesApi.loginLink(name), options)
   }
 
   const backup = async () => {

--- a/admin/frontend/dashboard/src/pages/sites/SiteDetail.vue
+++ b/admin/frontend/dashboard/src/pages/sites/SiteDetail.vue
@@ -96,7 +96,7 @@ watch(
 const isMobile = useIsMobile()
 
 const openSite = () => {
-  window.open(`https://${site.value.name}/desk`, '_blank')
+  window.open(`${site.value.url}/desk`, '_blank')
 }
 
 const settingUpSite = ref(false)
@@ -120,10 +120,10 @@ const goToAnalytics = () => {
 }
 
 const loginAsAdmin = () => {
-  toast.promise(login(), {
+  toast.promise(login({ onHint: (hint) => toast.info(hint) }), {
     loading: 'Logging in as admin',
     success: 'Logged in as admin',
-    error: 'Could not log in as admin',
+    error: (caught) => caught?.message || 'Could not log in as admin',
   })
 }
 

--- a/admin/frontend/dashboard/src/pages/sites/Sites.vue
+++ b/admin/frontend/dashboard/src/pages/sites/Sites.vue
@@ -114,14 +114,16 @@ const listRows = computed(() =>
 )
 
 const loginAsAdmin = async (site) => {
-  return openSiteLogin(() => sitesApi.loginLink(site.name))
+  return openSiteLogin(() => sitesApi.loginLink(site.name), {
+    onHint: (hint) => toast.info(hint),
+  })
 }
 
 const openSite = (site) => {
   toast.promise(loginAsAdmin(site), {
     loading: 'Logging in as admin',
     success: 'Logged in as admin',
-    error: 'Could not log in as admin',
+    error: (caught) => caught?.message || 'Could not log in as admin',
   })
 }
 

--- a/admin/frontend/dashboard/src/utils/siteLogin.test.ts
+++ b/admin/frontend/dashboard/src/utils/siteLogin.test.ts
@@ -59,3 +59,25 @@ test('closes the pre-opened window when the link has no url', async () => {
 
   assert.equal(events.length, 0)
 })
+
+test('reports the hint after the popup opens', async () => {
+  installBrowser()
+  const hints = []
+
+  await openSiteLogin(async () => ({ url: 'http://a.test/desk?sid=x', hint: 'add a.test to /etc/hosts' }), {
+    onHint: (hint) => hints.push(hint),
+  })
+
+  assert.deepEqual(hints, ['add a.test to /etc/hosts'])
+})
+
+test('does not report a hint when the link has none', async () => {
+  installBrowser()
+  const hints = []
+
+  await openSiteLogin(async () => ({ url: 'http://site.localhost:7000/desk?sid=x' }), {
+    onHint: (hint) => hints.push(hint),
+  })
+
+  assert.deepEqual(hints, [])
+})

--- a/admin/frontend/dashboard/src/utils/siteLogin.ts
+++ b/admin/frontend/dashboard/src/utils/siteLogin.ts
@@ -1,4 +1,4 @@
-export const openSiteLogin = async (createLink) => {
+export const openSiteLogin = async (createLink, { onHint } = {}) => {
   const link = await createLink()
   if (typeof link?.url !== 'string') {
     throw new Error('The site login link is invalid.')
@@ -12,6 +12,9 @@ export const openSiteLogin = async (createLink) => {
     popup.opener = null
   } catch {
     // cross-origin already - nothing to clear
+  }
+  if (link.hint && onHint) {
+    onHint(link.hint)
   }
   return link
 }

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -66,6 +66,12 @@ Two app operations answer inline instead of returning a task id, because both ar
 - `DELETE /sites/<name>/apps/<app>?mode=disable` returns `{"app": ..., "disabled": true}`. Without the parameter the route queues an uninstall as before.
 - `POST /sites/<name>/apps` for an app the site only has disabled returns `{"app": ..., "enabled": true}`. It falls through to the install queue when a required app has to be installed first.
 
+### Site Detail And Login
+
+`GET /sites/<name>` includes `url`, the origin the site is served on (scheme, primary host, and port derived from the bench config), which the UI uses for "Open site".
+
+`POST /sites/<name>/login` returns `{"url": ...}` plus an optional `hint` when the URL's host does not resolve on the server - the UI surfaces it so the user knows to add a hosts entry or use a `*.localhost` name.
+
 ### Setup
 
 Every `/setup/*` route needs a session, like the rest of the API. The Admin password is set when the bench is created (`pilot new`), so there is no unauthenticated window: a browser reaches the wizard through the `?sid=` link that `pilot start` prints, or by signing in with that password. `POST /benches` returns a `setup_link` token for the same purpose.

--- a/pilot/core/site/login.py
+++ b/pilot/core/site/login.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import re
+import socket
 import subprocess
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
@@ -51,15 +53,19 @@ class SiteLogin:
         return sid if re.fullmatch(r"[A-Za-z0-9._-]+", sid) else None
 
     def redirect_url(self, site_config: dict, proxy_tls: bool = False) -> str:
-        host = primary_host(self.site.config.name, site_config)
-        config = self.site.bench.config
-        if not config.production.enabled:
-            return origin("http", host, config.http_port) + "/desk"
+        return site_url(self.site.config.name, site_config, self.site.bench.config, proxy_tls) + "/desk"
 
-        secure = proxy_tls or (config.admin.tls and bool(site_config.get("ssl")))
-        scheme = "https" if secure else "http"
-        port = 443 if proxy_tls else (config.nginx.https_port if secure else config.nginx.http_port)
-        return origin(scheme, host, port) + "/desk"
+
+def site_url(site_name: str, site_config: dict, bench_config, proxy_tls: bool = False) -> str:
+    """The origin the site is served on, matching how the bench serves it."""
+    host = primary_host(site_name, site_config)
+    if not bench_config.production.enabled:
+        return origin("http", host, bench_config.http_port)
+
+    secure = proxy_tls or (bench_config.admin.tls and bool(site_config.get("ssl")))
+    scheme = "https" if secure else "http"
+    port = 443 if proxy_tls else (bench_config.nginx.https_port if secure else bench_config.nginx.http_port)
+    return origin(scheme, host, port)
 
 
 def primary_host(site: str, site_config: dict) -> str:
@@ -81,3 +87,27 @@ def origin(scheme: str, host: str, port: int) -> str:
     default_port = 443 if scheme == "https" else 80
     suffix = "" if port == default_port else f":{port}"
     return f"{scheme}://{host}{suffix}"
+
+
+# One shared worker: a hung lookup makes later calls queue and time out
+# instead of leaking one resolver thread per request.
+_resolver = ThreadPoolExecutor(max_workers=1, thread_name_prefix="host-resolver")
+
+
+def is_host_resolvable(host: str, timeout: float = 2.0) -> bool:
+    """Whether the host resolves on this machine. Browsers resolve *.localhost
+    names on their own; anything else needs DNS or a hosts-file entry.
+    Resolution runs in a worker thread so a slow DNS server cannot stall the
+    caller; an undecided lookup counts as resolvable."""
+    if host.endswith(".localhost") or host == "localhost":
+        return True
+    future = _resolver.submit(socket.getaddrinfo, host, None)
+    try:
+        future.result(timeout=timeout)
+    except TimeoutError:
+        # Discard the pending lookup so a hung resolver cannot pile up work.
+        future.cancel()
+        return True
+    except OSError:
+        return False
+    return True

--- a/tests/admin/backend/api/test_site_login_view.py
+++ b/tests/admin/backend/api/test_site_login_view.py
@@ -32,6 +32,51 @@ def test_create_login_link_returns_url_with_sid(tmp_path: Path) -> None:
     create_session.assert_called_once_with()
 
 
+def test_create_login_link_hints_when_the_host_does_not_resolve(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    client = _client(bench_root)
+    _write_site(bench_root, "erp.example.test")
+
+    with (
+        patch(
+            "pilot.core.site.login.SiteLogin.create_session",
+            return_value="frappe-session-id",
+        ),
+        patch("pilot.core.site.login.socket.getaddrinfo", side_effect=OSError),
+    ):
+        response = client.post("/api/v1/sites/erp.example.test/login")
+
+    assert response.status_code == 201
+    hint = response.get_json()["hint"]
+    assert "erp.example.test" in hint
+    assert "/etc/hosts" in hint
+
+
+def test_create_login_link_omits_the_hint_for_localhost_names(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    client = _client(bench_root)
+    _write_site(bench_root)
+
+    with patch(
+        "pilot.core.site.login.SiteLogin.create_session",
+        return_value="frappe-session-id",
+    ):
+        response = client.post("/api/v1/sites/s.localhost/login")
+
+    assert response.status_code == 201
+    assert "hint" not in response.get_json()
+
+
+def test_site_detail_exposes_the_served_url(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    client = _client(bench_root)
+    _write_site(bench_root)
+
+    detail = client.get("/api/v1/sites/s.localhost").get_json()
+
+    assert detail["url"] == "http://s.localhost:8000"
+
+
 def test_create_login_link_fails_when_session_creation_fails(tmp_path: Path) -> None:
     bench_root = tmp_path / "benches" / "current"
     client = _client(bench_root)

--- a/tests/pilot/core/test_site_login.py
+++ b/tests/pilot/core/test_site_login.py
@@ -1,0 +1,56 @@
+import threading
+import time
+from unittest.mock import patch
+
+from pilot.core.site.login import _resolver, is_host_resolvable
+
+
+def test_localhost_names_resolve_without_a_lookup() -> None:
+    with patch("pilot.core.site.login.socket.getaddrinfo") as getaddrinfo:
+        assert is_host_resolvable("site.localhost") is True
+        assert is_host_resolvable("localhost") is True
+
+    getaddrinfo.assert_not_called()
+
+
+def test_unresolvable_host_is_reported() -> None:
+    with patch("pilot.core.site.login.socket.getaddrinfo", side_effect=OSError):
+        assert is_host_resolvable("nowhere.example.test") is False
+
+
+def test_slow_lookup_counts_as_resolvable() -> None:
+    def slow_lookup(*args):
+        time.sleep(0.3)
+
+    with patch("pilot.core.site.login.socket.getaddrinfo", side_effect=slow_lookup):
+        assert is_host_resolvable("slow.example.test", timeout=0.05) is True
+
+
+def test_timed_out_lookups_are_cancelled_and_do_not_queue_up() -> None:
+    _resolver.submit(lambda: None).result(timeout=2)  # wait out earlier tests' lookups
+    release = threading.Event()
+    executed_hosts = []
+
+    def blocked_lookup(host, port):
+        executed_hosts.append(host)
+        release.wait(2)
+
+    with patch("pilot.core.site.login.socket.getaddrinfo", side_effect=blocked_lookup):
+        for index in range(5):
+            assert is_host_resolvable(f"host-{index}.example.test", timeout=0.01) is True
+        release.set()
+        time.sleep(0.2)
+
+    assert executed_hosts == ["host-0.example.test"]
+
+
+def test_timed_out_lookups_do_not_accumulate_resolver_threads() -> None:
+    def slow_lookup(*args):
+        time.sleep(0.2)
+
+    with patch("pilot.core.site.login.socket.getaddrinfo", side_effect=slow_lookup):
+        for _ in range(5):
+            assert is_host_resolvable("slow.example.test", timeout=0.01) is True
+
+    resolver_threads = [t for t in threading.enumerate() if t.name.startswith("host-resolver")]
+    assert len(resolver_threads) <= 1


### PR DESCRIPTION
Fixes the two symptoms in #375:

- **Open site**: the button hardcoded `https://<site>/desk`, which breaks whenever the site is not on https at the default port (e.g. dev benches, plain http on `http_port`). The site detail resource now carries a `url` built by the same logic the login redirect already used (extracted as `site_url()` in `pilot/core/site/login.py`), and the button opens that.
- **Login as admin**: the toasts discarded the thrown error (Safari's blocked-popup case showed the generic message instead of "Allow pop-ups to open the site."); they now surface the actual message. And when the site's host does not resolve on the server (custom domain, no DNS/hosts entry), the login response includes a `hint` that the UI shows as a toast — the "hint in UI" suggested in the issue. `*.localhost` names never hint, and the lookup runs in a worker thread with a 2s cap so slow DNS cannot stall request threads.

UI change — logging in to a site whose domain doesn't resolve:

![login hint toast](https://raw.githubusercontent.com/badal8381/pilot/pr-assets/pr-418-login-hint-toast.jpg)

Fixes #375
