### PR TITLE
fix(backup): run scheduled backups from cron and save schedules in UTC

### DIFF
--- a/admin/frontend/dashboard/src/components/common/CronScheduleControl.vue
+++ b/admin/frontend/dashboard/src/components/common/CronScheduleControl.vue
@@ -2,6 +2,9 @@
 import { computed, onMounted, ref } from 'vue'
 import { Button, Dialog, Dropdown, ErrorMessage, Select } from 'frappe-ui'
 
+import { formatTime } from '@/utils/backup'
+import { cronToPicks, picksToCron } from '@/utils/cron'
+
 const props = defineProps({
   title: { type: String, default: '' },
   // Lowercase plural noun used in button/dialog copy, e.g. "backups", "snapshots".
@@ -35,20 +38,32 @@ const WEEKDAY_OPTIONS = [
 
 const monthDayOptions = Array.from({ length: 31 }, (_, i) => ({ label: `${i + 1}`, value: i + 1 }))
 
-const hourOptions = Array.from({ length: 24 }, (_, h) => {
-  const label =
-    h === 0 ? '12:00 AM' : h < 12 ? `${h}:00 AM` : h === 12 ? '12:00 PM' : `${h - 12}:00 PM`
-  return { label, value: h }
-})
+const hourOptions = Array.from({ length: 24 }, (_, h) => ({ label: formatTime(h), value: h }))
 
 const WEEKDAY_FULL = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
-const PRESET_CRONS = ['0 2 * * *', '0 2 * * 0']
+
+// Local-time presets; the server stores their UTC equivalents.
+const PRESETS = [
+  { label: 'Daily, 2:00 AM', picks: { frequency: 'daily', weekday: 0, monthDay: 1, hour: 2, minute: 0 } },
+  { label: 'Weekly, Sunday 2:00 AM', picks: { frequency: 'weekly', weekday: 0, monthDay: 1, hour: 2, minute: 0 } },
+]
+
+const presetCron = (index) => picksToCron(PRESETS[index].picks)
+
+const matchingPreset = (picks) =>
+  PRESETS.findIndex(
+    (preset) =>
+      preset.picks.frequency === picks.frequency &&
+      preset.picks.hour === picks.hour &&
+      preset.picks.minute === picks.minute &&
+      (picks.frequency !== 'weekly' || preset.picks.weekday === picks.weekday),
+  )
 
 const disabled = ref(true)
 const loading = ref(false)
 const error = ref('')
 
-const schedulePreset = ref(PRESET_CRONS[0])
+const schedulePreset = ref(0)
 const showCustomDialog = ref(false)
 const showDisableConfirm = ref(false)
 const scheduleSaving = ref(false)
@@ -56,28 +71,29 @@ const schedFrequency = ref('daily')
 const schedWeekday = ref(0)
 const schedMonthDay = ref(1)
 const schedHour = ref(2)
+const schedMinute = ref(0)
 
-const formatHour = (h) => {
-  if (h === 0) return '12:00 AM'
-  if (h < 12) return `${h}:00 AM`
-  if (h === 12) return '12:00 PM'
-  return `${h - 12}:00 PM`
-}
+const schedHourPick = computed({
+  get: () => schedHour.value,
+  set: (value) => {
+    schedHour.value = value
+    schedMinute.value = 0
+  },
+})
 
 const customScheduleLabel = computed(() => {
-  const time = formatHour(schedHour.value)
+  const time = formatTime(schedHour.value, schedMinute.value)
   if (schedFrequency.value === 'weekly')
     return `Weekly, ${WEEKDAY_FULL[schedWeekday.value]} ${time}`
   if (schedFrequency.value === 'monthly') return `Monthly, ${schedMonthDay.value} ${time}`
   return `Daily, ${time}`
 })
 
-const currentScheduleLabel = computed(() => {
-  if (schedulePreset.value === 'custom') return customScheduleLabel.value
-  if (schedulePreset.value === '0 2 * * *') return 'Daily, 2:00 AM'
-  if (schedulePreset.value === '0 2 * * 0') return 'Weekly, Sunday 2:00 AM'
-  return 'Custom'
-})
+const currentScheduleLabel = computed(() =>
+  schedulePreset.value === 'custom'
+    ? customScheduleLabel.value
+    : PRESETS[schedulePreset.value]?.label || 'Custom',
+)
 
 const scheduleOptions = computed(() => {
   const customEntry = {
@@ -86,10 +102,10 @@ const scheduleOptions = computed(() => {
       showCustomDialog.value = true
     },
   }
-  const presets = [
-    { label: 'Daily, 2:00 AM', onClick: () => setPreset('0 2 * * *') },
-    { label: 'Weekly, Sunday 2:00 AM', onClick: () => setPreset('0 2 * * 0') },
-  ]
+  const presets = PRESETS.map((preset, index) => ({
+    label: preset.label,
+    onClick: () => setPreset(index),
+  }))
   const disableEntry = {
     label: `Disable ${props.noun}`,
     theme: 'red',
@@ -102,23 +118,25 @@ const scheduleOptions = computed(() => {
     : [...presets, customEntry, disableEntry]
 })
 
-const schedCron = computed(() => {
-  const h = schedHour.value
-  if (schedFrequency.value === 'weekly') return `0 ${h} * * ${schedWeekday.value}`
-  if (schedFrequency.value === 'monthly') return `0 ${h} ${schedMonthDay.value} * *`
-  return `0 ${h} * * *`
-})
+// The pickers hold local time; the server stores the schedule in UTC.
+const schedCron = computed(() =>
+  picksToCron({
+    frequency: schedFrequency.value,
+    weekday: schedWeekday.value,
+    monthDay: schedMonthDay.value,
+    hour: schedHour.value,
+    minute: schedMinute.value,
+  }),
+)
 
 const parseCronToState = (cron) => {
-  const [, h, dom, , dow] = cron.split(' ')
-  schedHour.value = isNaN(parseInt(h)) ? 0 : parseInt(h)
-  if (dom !== '*') {
-    schedFrequency.value = 'monthly'
-    schedMonthDay.value = parseInt(dom) || 1
-  } else if (dow !== '*') {
-    schedFrequency.value = 'weekly'
-    schedWeekday.value = parseInt(dow) || 0
-  } else schedFrequency.value = 'daily'
+  const picks = cronToPicks(cron)
+  schedFrequency.value = picks.frequency
+  schedWeekday.value = picks.weekday
+  schedMonthDay.value = picks.monthDay
+  schedHour.value = picks.hour
+  schedMinute.value = picks.minute
+  return picks
 }
 
 const load = async () => {
@@ -129,18 +147,18 @@ const load = async () => {
       return
     }
     disabled.value = false
-    parseCronToState(data.schedule)
-    schedulePreset.value = PRESET_CRONS.includes(data.schedule) ? data.schedule : 'custom'
+    const matched = matchingPreset(parseCronToState(data.schedule))
+    schedulePreset.value = matched === -1 ? 'custom' : matched
   } catch (e) {
     error.value = e.message || 'Failed to load schedule.'
   }
 }
 
-const setPreset = async (cron) => {
+const setPreset = async (index) => {
   error.value = ''
   try {
-    await props.setSchedule(cron)
-    schedulePreset.value = cron
+    await props.setSchedule(presetCron(index))
+    schedulePreset.value = index
     disabled.value = false
   } catch (e) {
     error.value = e.message || 'Failed to save schedule.'
@@ -180,9 +198,9 @@ const enable = async () => {
   error.value = ''
   loading.value = true
   try {
-    await props.setSchedule(PRESET_CRONS[0])
+    await props.setSchedule(presetCron(0))
     disabled.value = false
-    schedulePreset.value = PRESET_CRONS[0]
+    schedulePreset.value = 0
   } catch (e) {
     error.value = e.message || `Failed to enable ${props.noun}.`
   } finally {
@@ -246,7 +264,7 @@ defineExpose({ disabled, currentScheduleLabel, loading, enable })
 
       <div class="space-y-1.5">
         <p class="font-medium text-ink-gray-7 text-sm">Time</p>
-        <Select v-model="schedHour" :options="hourOptions" class="w-full" />
+        <Select v-model.number="schedHourPick" :options="hourOptions" class="w-full" />
       </div>
 
       <p v-if="retentionHint" class="text-ink-gray-4 text-p-sm">{{ retentionHint }}</p>

--- a/admin/frontend/dashboard/src/components/sites/BackupConfigDialog.vue
+++ b/admin/frontend/dashboard/src/components/sites/BackupConfigDialog.vue
@@ -5,6 +5,7 @@ import { Button, Checkbox, Dialog, ErrorMessage, FormControl, Select } from 'fra
 import { apiErrorMessage } from '@/api/client'
 import { sitesApi } from '@/api/sites'
 import { formatHour } from '@/utils/backup'
+import { cronToPicks, picksToCron } from '@/utils/cron'
 
 const props = defineProps({ siteName: { type: String, required: true } })
 const emit = defineEmits(['saved'])
@@ -40,6 +41,7 @@ const frequency = ref('daily')
 const weekday = ref(0)
 const monthDay = ref(1)
 const hour = ref(2)
+const minute = ref(0)
 const scheme = ref('gfs')
 const keepLast = ref(7)
 const keepDaily = ref(7)
@@ -53,23 +55,33 @@ const schemeHint = computed(() =>
     : 'Keeps recent daily, weekly, monthly and yearly backups; the rest are pruned.',
 )
 
-const cron = computed(() => {
-  if (frequency.value === 'weekly') return `0 ${hour.value} * * ${weekday.value}`
-  if (frequency.value === 'monthly') return `0 ${hour.value} ${monthDay.value} * *`
-  return `0 ${hour.value} * * *`
+// The pickers hold local time; the server stores the schedule in UTC.
+const cron = computed(() =>
+  picksToCron({
+    frequency: frequency.value,
+    weekday: weekday.value,
+    monthDay: monthDay.value,
+    hour: hour.value,
+    minute: minute.value,
+  }),
+)
+
+const hourPick = computed({
+  get: () => hour.value,
+  set: (value) => {
+    hour.value = value
+    minute.value = 0
+  },
 })
 
 const applySchedule = (schedule) => {
   if (!schedule) return
-  const [, h, dom, , dow] = schedule.split(' ')
-  hour.value = parseInt(h) || 0
-  if (dom !== '*') {
-    frequency.value = 'monthly'
-    monthDay.value = parseInt(dom) || 1
-  } else if (dow !== '*') {
-    frequency.value = 'weekly'
-    weekday.value = parseInt(dow) || 0
-  } else frequency.value = 'daily'
+  const picks = cronToPicks(schedule)
+  frequency.value = picks.frequency
+  weekday.value = picks.weekday
+  monthDay.value = picks.monthDay
+  hour.value = picks.hour
+  minute.value = picks.minute
 }
 
 const applyRetention = (retention) => {
@@ -162,7 +174,7 @@ defineExpose({ open })
             v-model.number="monthDay"
             :options="monthDayOptions"
           />
-          <Select label="Time" v-model.number="hour" :options="hourOptions" />
+          <Select label="Time" v-model.number="hourPick" :options="hourOptions" />
         </div>
 
         <div class="space-y-4 pt-5 border-t border-outline-gray-1">

--- a/admin/frontend/dashboard/src/utils/backup.ts
+++ b/admin/frontend/dashboard/src/utils/backup.ts
@@ -1,19 +1,23 @@
 // Shared backup schedule/retention formatting for the site Backups tab.
 
+import { cronToPicks } from './cron.ts'
+
 const WEEKDAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
 
-export const formatHour = (h) => {
-  if (h === 0) return '12:00 AM'
-  if (h < 12) return `${h}:00 AM`
-  if (h === 12) return '12:00 PM'
-  return `${h - 12}:00 PM`
+export const formatTime = (hour, minute = 0) => {
+  const suffix = hour < 12 ? 'AM' : 'PM'
+  const display = hour % 12 === 0 ? 12 : hour % 12
+  return `${display}:${String(minute).padStart(2, '0')} ${suffix}`
 }
 
+export const formatHour = (hour) => formatTime(hour)
+
+/** Label a UTC cron expression in the viewer's local time. */
 export const cronToLabel = (cron) => {
   if (!cron) return ''
-  const [, hour, dom, , dow] = cron.split(' ')
-  const time = formatHour(parseInt(hour) || 0)
-  if (dom !== '*') return `Monthly on day ${dom}, ${time}`
-  if (dow !== '*') return `Weekly on ${WEEKDAYS[parseInt(dow)] || 'Sunday'}, ${time}`
+  const picks = cronToPicks(cron)
+  const time = formatTime(picks.hour, picks.minute)
+  if (picks.frequency === 'monthly') return `Monthly on day ${picks.monthDay}, ${time}`
+  if (picks.frequency === 'weekly') return `Weekly on ${WEEKDAYS[picks.weekday]}, ${time}`
   return `Daily at ${time}`
 }

--- a/admin/frontend/dashboard/src/utils/cron.test.ts
+++ b/admin/frontend/dashboard/src/utils/cron.test.ts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { cronToPicks, picksToCron } from './cron.ts'
+
+const picks = (over = {}) => ({
+  frequency: 'daily',
+  weekday: 0,
+  monthDay: 1,
+  hour: 2,
+  minute: 0,
+  ...over,
+})
+
+// A fixed reference date keeps the UTC offset lookup deterministic.
+const REFERENCE = new Date('2026-08-26T00:00:00Z')
+
+const inZone = (zone, run) => {
+  const actual = process.env.TZ
+  process.env.TZ = zone
+  try {
+    run()
+  } finally {
+    process.env.TZ = actual
+  }
+}
+
+test('a half-hour-ahead zone converts the local hour into a UTC minute', () => {
+  // 8:00 PM in Asia/Kolkata (UTC+5:30) is 14:30 UTC.
+  inZone('Asia/Kolkata', () => {
+    assert.equal(picksToCron(picks({ hour: 20 }), REFERENCE), '30 14 * * *')
+    assert.equal(cronToPicks('30 14 * * *', REFERENCE).hour, 20)
+    assert.equal(cronToPicks('30 14 * * *', REFERENCE).minute, 0)
+  })
+})
+
+test('a UTC browser stores the local hour unchanged', () => {
+  inZone('UTC', () => {
+    assert.equal(picksToCron(picks({ hour: 20 }), REFERENCE), '0 20 * * *')
+    assert.equal(cronToPicks('0 20 * * *', REFERENCE).hour, 20)
+  })
+})
+
+test('a behind-UTC zone rolls the weekday forward when the UTC time crosses midnight', () => {
+  // 8:00 PM Monday in America/New_York (UTC-4 in August) is 00:00 UTC on Tuesday.
+  inZone('America/New_York', () => {
+    assert.equal(picksToCron(picks({ frequency: 'weekly', weekday: 1, hour: 20 }), REFERENCE), '0 0 * * 2')
+    assert.equal(cronToPicks('0 0 * * 2', REFERENCE).weekday, 1)
+  })
+})
+
+test('an ahead-of-UTC zone rolls the weekday back when the UTC time crosses midnight', () => {
+  // 1:00 AM Monday in Asia/Kolkata is 19:30 UTC on Sunday.
+  inZone('Asia/Kolkata', () => {
+    assert.equal(picksToCron(picks({ frequency: 'weekly', weekday: 1, hour: 1 }), REFERENCE), '30 19 * * 0')
+    assert.equal(cronToPicks('30 19 * * 0', REFERENCE).weekday, 1)
+  })
+})
+
+test('the day of month rolls with the same crossing', () => {
+  inZone('America/New_York', () => {
+    assert.equal(picksToCron(picks({ frequency: 'monthly', monthDay: 12, hour: 20 }), REFERENCE), '0 0 13 * *')
+    assert.equal(cronToPicks('0 0 13 * *', REFERENCE).monthDay, 12)
+  })
+})
+
+test('every frequency round-trips in a half-hour zone', () => {
+  inZone('Asia/Kolkata', () => {
+    for (const over of [
+      { hour: 20 },
+      { frequency: 'weekly', weekday: 3, hour: 6 },
+      { frequency: 'monthly', monthDay: 12, hour: 23 },
+    ]) {
+      const wanted = picks(over)
+      const back = cronToPicks(picksToCron(wanted, REFERENCE), REFERENCE)
+      assert.equal(back.frequency, wanted.frequency)
+      assert.equal(back.hour, wanted.hour)
+      assert.equal(back.minute, wanted.minute)
+      if (wanted.frequency === 'weekly') assert.equal(back.weekday, wanted.weekday)
+      if (wanted.frequency === 'monthly') assert.equal(back.monthDay, wanted.monthDay)
+    }
+  })
+})
+
+test('an empty expression falls back to the defaults', () => {
+  const back = cronToPicks('', REFERENCE)
+  assert.equal(back.frequency, 'daily')
+  assert.equal(back.hour, 2)
+})
+
+test('a malformed expression does not produce NaN', () => {
+  const back = cronToPicks('x y * * *', REFERENCE)
+  assert.equal(Number.isNaN(back.hour), false)
+  assert.equal(Number.isNaN(back.minute), false)
+})

--- a/admin/frontend/dashboard/src/utils/cron.test.ts
+++ b/admin/frontend/dashboard/src/utils/cron.test.ts
@@ -64,6 +64,31 @@ test('the day of month rolls with the same crossing', () => {
   })
 })
 
+test('a day-one monthly schedule never rolls back to day 31', () => {
+  // Rolling day 1 back would land on day 31 and skip every month without one.
+  inZone('Asia/Kolkata', () => {
+    const cron = picksToCron(picks({ frequency: 'monthly', monthDay: 1, hour: 1 }), REFERENCE)
+    assert.equal(cron, '30 19 1 * *')
+    // Held at day 1, the run lands a day later in local time, which is what the picker reads back.
+    assert.equal(cronToPicks(cron, REFERENCE).monthDay, 2)
+  })
+})
+
+test('a day-31 monthly schedule never rolls past the end of the month', () => {
+  inZone('America/New_York', () => {
+    const cron = picksToCron(picks({ frequency: 'monthly', monthDay: 31, hour: 20 }), REFERENCE)
+    assert.equal(cron, '0 0 31 * *')
+  })
+})
+
+test('a clamped monthly schedule stays put once it is read back', () => {
+  inZone('Asia/Kolkata', () => {
+    const first = picksToCron(picks({ frequency: 'monthly', monthDay: 1, hour: 1 }), REFERENCE)
+    const reread = picksToCron(cronToPicks(first, REFERENCE), REFERENCE)
+    assert.equal(reread, first)
+  })
+})
+
 test('every frequency round-trips in a half-hour zone', () => {
   inZone('Asia/Kolkata', () => {
     for (const over of [

--- a/admin/frontend/dashboard/src/utils/cron.ts
+++ b/admin/frontend/dashboard/src/utils/cron.ts
@@ -1,0 +1,78 @@
+// Cron entries run in the server's timezone, which Pilot keeps as UTC. The schedule pickers work
+// in the browser's local time, so every expression is converted on the way in and out.
+
+export type Frequency = 'daily' | 'weekly' | 'monthly'
+
+export type SchedulePicks = {
+  frequency: Frequency
+  weekday: number
+  monthDay: number
+  hour: number
+  minute: number
+}
+
+const DAYS_IN_WEEK = 7
+const MAX_MONTH_DAY = 31
+
+export const DEFAULT_PICKS: SchedulePicks = {
+  frequency: 'daily',
+  weekday: 0,
+  monthDay: 1,
+  hour: 2,
+  minute: 0,
+}
+
+const toInt = (value: string | undefined, fallback = 0) => {
+  const parsed = parseInt(value ?? '', 10)
+  return isNaN(parsed) ? fallback : parsed
+}
+
+const wrapWeekday = (day: number) => ((day % DAYS_IN_WEEK) + DAYS_IN_WEEK) % DAYS_IN_WEEK
+
+// Cron cannot say "last day of the month", so a day-1 schedule that lands on the previous UTC
+// day wraps to 31 and skips shorter months.
+const wrapMonthDay = (day: number) => (((day - 1) % MAX_MONTH_DAY) + MAX_MONTH_DAY) % MAX_MONTH_DAY + 1
+
+// Whether the UTC calendar day of `moment` is behind, level with, or ahead of its local day.
+const dayOffset = (moment: Date) => {
+  const difference = moment.getUTCDay() - moment.getDay()
+  if (difference === DAYS_IN_WEEK - 1) return -1
+  if (difference === 1 - DAYS_IN_WEEK) return 1
+  return difference
+}
+
+/** The UTC cron expression that fires at the local time these picks describe. */
+export const picksToCron = (picks: SchedulePicks, reference = new Date()): string => {
+  const moment = new Date(reference.getTime())
+  moment.setHours(picks.hour, picks.minute, 0, 0)
+
+  const time = `${moment.getUTCMinutes()} ${moment.getUTCHours()}`
+  const offset = dayOffset(moment)
+  if (picks.frequency === 'weekly') return `${time} * * ${wrapWeekday(picks.weekday + offset)}`
+  if (picks.frequency === 'monthly') return `${time} ${wrapMonthDay(picks.monthDay + offset)} * *`
+  return `${time} * * *`
+}
+
+/** The local picks a UTC cron expression fires at. */
+export const cronToPicks = (cron: string, reference = new Date()): SchedulePicks => {
+  if (!cron) return { ...DEFAULT_PICKS }
+  const [minuteField, hourField, monthDayField, , weekdayField] = cron.trim().split(/\s+/)
+
+  const moment = new Date(reference.getTime())
+  moment.setUTCHours(toInt(hourField), toInt(minuteField), 0, 0)
+  const offset = -dayOffset(moment)
+
+  const picks: SchedulePicks = {
+    ...DEFAULT_PICKS,
+    hour: moment.getHours(),
+    minute: moment.getMinutes(),
+  }
+  if (monthDayField !== '*') {
+    picks.frequency = 'monthly'
+    picks.monthDay = wrapMonthDay(toInt(monthDayField, 1) + offset)
+  } else if (weekdayField !== '*') {
+    picks.frequency = 'weekly'
+    picks.weekday = wrapWeekday(toInt(weekdayField) + offset)
+  }
+  return picks
+}

--- a/admin/frontend/dashboard/src/utils/cron.ts
+++ b/admin/frontend/dashboard/src/utils/cron.ts
@@ -1,6 +1,3 @@
-// Cron entries run in the server's timezone, which Pilot keeps as UTC. The schedule pickers work
-// in the browser's local time, so every expression is converted on the way in and out.
-
 export type Frequency = 'daily' | 'weekly' | 'monthly'
 
 export type SchedulePicks = {
@@ -29,9 +26,9 @@ const toInt = (value: string | undefined, fallback = 0) => {
 
 const wrapWeekday = (day: number) => ((day % DAYS_IN_WEEK) + DAYS_IN_WEEK) % DAYS_IN_WEEK
 
-// Cron cannot say "last day of the month", so a day-1 schedule that lands on the previous UTC
-// day wraps to 31 and skips shorter months.
-const wrapMonthDay = (day: number) => (((day - 1) % MAX_MONTH_DAY) + MAX_MONTH_DAY) % MAX_MONTH_DAY + 1
+// Clamped, never wrapped: rolling day 1 back to 31 would skip every month without a 31st, so a
+// schedule that crosses a month boundary keeps its day and fires a day either side instead.
+const clampMonthDay = (day: number) => Math.min(MAX_MONTH_DAY, Math.max(1, day))
 
 // Whether the UTC calendar day of `moment` is behind, level with, or ahead of its local day.
 const dayOffset = (moment: Date) => {
@@ -41,7 +38,12 @@ const dayOffset = (moment: Date) => {
   return difference
 }
 
-/** The UTC cron expression that fires at the local time these picks describe. */
+/** The UTC cron expression that fires at the local time these picks describe.
+ *
+ * Cron entries run in the server's timezone, which Pilot keeps as UTC, while the pickers work in
+ * the browser's local time. The offset is the one in effect on `reference`, so a fixed expression
+ * cannot follow a later DST transition; that needs a timezone stored alongside the schedule.
+ */
 export const picksToCron = (picks: SchedulePicks, reference = new Date()): string => {
   const moment = new Date(reference.getTime())
   moment.setHours(picks.hour, picks.minute, 0, 0)
@@ -49,7 +51,7 @@ export const picksToCron = (picks: SchedulePicks, reference = new Date()): strin
   const time = `${moment.getUTCMinutes()} ${moment.getUTCHours()}`
   const offset = dayOffset(moment)
   if (picks.frequency === 'weekly') return `${time} * * ${wrapWeekday(picks.weekday + offset)}`
-  if (picks.frequency === 'monthly') return `${time} ${wrapMonthDay(picks.monthDay + offset)} * *`
+  if (picks.frequency === 'monthly') return `${time} ${clampMonthDay(picks.monthDay + offset)} * *`
   return `${time} * * *`
 }
 
@@ -69,7 +71,7 @@ export const cronToPicks = (cron: string, reference = new Date()): SchedulePicks
   }
   if (monthDayField !== '*') {
     picks.frequency = 'monthly'
-    picks.monthDay = wrapMonthDay(toInt(monthDayField, 1) + offset)
+    picks.monthDay = clampMonthDay(toInt(monthDayField, 1) + offset)
   } else if (weekdayField !== '*') {
     picks.frequency = 'weekly'
     picks.weekday = wrapWeekday(toInt(weekdayField) + offset)

--- a/pilot/core/registry_cache.py
+++ b/pilot/core/registry_cache.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import re
-import shlex
 import subprocess
 import sys
 import time
@@ -12,7 +11,7 @@ from pathlib import Path
 
 from pilot.exceptions import CommandError, RegistryUnavailableError
 from pilot.internal.git import GitRepo
-from pilot.managers.cron import CronManager
+from pilot.managers.cron import CronManager, cron_module_command
 from pilot.utils import run_command
 
 REGISTRY_URL = "https://github.com/frappe/marketplace"
@@ -163,8 +162,7 @@ class RegistryCache:
         """Register the daily cache refresh cron entry."""
         log_file = self._cli_root / "system" / "registry-cache.log"
         log_file.parent.mkdir(parents=True, exist_ok=True)
-        python, cli_root, log = (shlex.quote(str(p)) for p in (sys.executable, self._cli_root, log_file))
-        command = f"{python} -m pilot.core.registry_cache {cli_root} >> {log} 2>&1"
+        command = cron_module_command("pilot.core.registry_cache", [self._cli_root], log_file)
         CronManager(self._cli_root).set_schedule(_CRON_JOB_KEY, _CRON_SCHEDULE, command)
 
 

--- a/pilot/core/site/backups.py
+++ b/pilot/core/site/backups.py
@@ -1,8 +1,6 @@
 """Apply a retention policy to one site's backups, local and offsite."""
 
 import re
-import shlex
-import sys
 from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -155,11 +153,13 @@ class SiteBackups:
         return OffsiteBackup.from_config(self.site.bench.config.s3, self.site.bench.path)
 
     def _cron_command(self) -> str:
-        log_file = self.site.bench.logs_path / f"backup-{self.site.config.name}.log"
-        python, bench, site, log = (
-            shlex.quote(str(p)) for p in (sys.executable, self.site.bench.path, self.site.config.name, log_file)
+        from pilot.managers.cron import cron_module_command
+
+        return cron_module_command(
+            "pilot.tasks.backup_site",
+            [self.site.bench.path, self.site.config.name, "--with-files"],
+            self.site.bench.logs_path / f"backup-{self.site.config.name}.log",
         )
-        return f"{python} -m pilot.tasks.backup_site {bench} {site} --with-files >> {log} 2>&1"
 
 
 def retention_from_payload(block: dict | None):

--- a/pilot/managers/cron.py
+++ b/pilot/managers/cron.py
@@ -1,9 +1,30 @@
 from __future__ import annotations
 
+import shlex
 import subprocess
+import sys
 from pathlib import Path
 
 _MARKER_PREFIX = "# bench-cron:"
+
+
+def cron_module_command(module: str, arguments: list, log_file: Path) -> str:
+    """A `python -m <module>` line safe to run from cron.
+
+    Cron starts in the user's home directory, which holds the source tree. That directory shadows
+    the real `pilot` package as an empty namespace package, so PYTHONPATH pins the source root.
+    `pilot` itself has no third-party dependencies, so a path is all any interpreter needs.
+    """
+    from pilot.utils import cli_root
+
+    parts = [
+        f"PYTHONPATH={shlex.quote(str(cli_root()))}",
+        shlex.quote(sys.executable),
+        "-m",
+        module,
+        *(shlex.quote(str(argument)) for argument in arguments),
+    ]
+    return f"{' '.join(parts)} >> {shlex.quote(str(log_file))} 2>&1"
 
 
 class CronManager:

--- a/tests/e2e/flows/admin.py
+++ b/tests/e2e/flows/admin.py
@@ -6,11 +6,18 @@ from harness.tasks import run_task_action, wait_for_task
 from playwright.sync_api import Page, expect
 
 
+def open_root(page: Page, base_url: str) -> None:
+    """`/` redirects to `/sites` in the router, so waiting for load races that redirect and
+    Playwright reports the navigation as interrupted. Return once the document commits instead;
+    the callers' own locators wait for whichever page the redirect chain settles on."""
+    page.goto(f"{base_url}/", wait_until="commit")
+
+
 def login(page: Page, base_url: str, password: str) -> None:
     # The wizard's own sign-in carries over in this shared browser context, so without
     # clearing it the login form would never render. Drop it to exercise real login.
     page.context.clear_cookies()
-    page.goto(f"{base_url}/")
+    open_root(page, base_url)
     page.get_by_placeholder("Password").fill(password)
     page.get_by_role("button", name="Continue").click()
     # Landed on the Sites page once the header action is mounted.
@@ -18,7 +25,7 @@ def login(page: Page, base_url: str, password: str) -> None:
 
 
 def create_site(page: Page, base_url: str, site_name: str) -> None:
-    page.goto(f"{base_url}/")
+    open_root(page, base_url)
     page.get_by_role("button", name="New site").click()
 
     dialog = page.get_by_role("dialog")

--- a/tests/e2e/specs/test_bench_lifecycle.py
+++ b/tests/e2e/specs/test_bench_lifecycle.py
@@ -10,6 +10,7 @@ from flows.admin import (
     drop_site,
     installed_apps,
     login,
+    open_root,
     site_exists,
 )
 from flows.wizard import complete_dev_wizard
@@ -25,7 +26,7 @@ BENCH_NAME = f"e2e-{DB_TYPE}"
 SITE = "site1.localhost"
 
 def test_completes_setup_wizard(bench, page):
-    page.goto(bench.admin_url)
+    open_root(page, bench.admin_url)
     try:
         complete_dev_wizard(
             page,

--- a/tests/pilot/managers/test_cron.py
+++ b/tests/pilot/managers/test_cron.py
@@ -73,3 +73,39 @@ def test_remove_schedule_deletes_marker_and_entry() -> None:
 
     write_call = mock_run.call_args_list[-1]
     assert write_call.args[0] == ["crontab", "-r"]
+
+
+def test_cron_module_command_pins_pythonpath_to_the_source_root() -> None:
+    """Cron starts in the home directory, where the source tree shadows the `pilot` package."""
+    from pilot.managers.cron import cron_module_command
+    from pilot.utils import cli_root
+
+    command = cron_module_command(
+        "pilot.tasks.backup_site", ["/benches/b1", "site.localhost"], Path("/tmp/b.log")
+    )
+
+    assert command.startswith(f"PYTHONPATH={cli_root()} ")
+    assert " -m pilot.tasks.backup_site /benches/b1 site.localhost " in command
+    assert command.endswith(">> /tmp/b.log 2>&1")
+
+
+def test_cron_module_command_quotes_paths_with_spaces() -> None:
+    from pilot.managers.cron import cron_module_command
+
+    command = cron_module_command(
+        "pilot.core.registry_cache", [Path("/root dir/cli")], Path("/log dir/out.log")
+    )
+
+    assert "'/root dir/cli'" in command
+    assert "'/log dir/out.log'" in command
+
+
+def test_get_schedule_reads_the_expression_ahead_of_the_environment_prefix() -> None:
+    """The five cron fields still lead the line once the command carries a PYTHONPATH prefix."""
+    manager = make_manager()
+    marker = manager._marker("job1")
+    entry = "30 14 * * * PYTHONPATH=/home/frappe/pilot /usr/bin/python -m pilot.tasks.backup_site"
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = _crontab_result(f"{marker}\n{entry}\n")
+        assert manager.get_schedule("job1") == "30 14 * * *"


### PR DESCRIPTION
Scheduled backups never ran on a bench. Two separate causes, both fixed here.

- **Cron could not import pilot.** Cron starts in the home directory, which holds the source tree. That directory shadowed the `pilot` package as an empty namespace package, so every generated entry died with `ModuleNotFoundError: No module named 'pilot.tasks'`. Registry refresh failed the same way. The command builder now pins `PYTHONPATH` to the source root, and both call sites share it.
- **Schedules were saved in the wrong timezone.** The pickers sent the chosen hour straight through, so a time picked in a non-UTC browser landed in cron as server time — 8:00 PM IST was stored as 20:00 UTC. Local picks are now converted to UTC on save and back to local on load and display, including the minute field that half-hour offsets need.

Verified on staging: the fixed command form completes a full backup for a site that had produced none, through database dump, files, S3 upload and retention.