### PR TITLE
feat: restore a backup into a new site from the admin UI

### DIFF
--- a/admin/backend/api/v1/sites/backups.py
+++ b/admin/backend/api/v1/sites/backups.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+import contextlib
+import hashlib
+import os
+import secrets
+import shutil
 from pathlib import Path
 
 from flask import current_app, jsonify, request, send_file
@@ -10,17 +15,20 @@ from admin.backend.api.v1.sites.shared import (
     internal_error,
     invalid_fields,
     malformed_body,
+    new_site_name_error,
     site_name,
+    site_name_failure,
     site_not_found,
     task_failure,
     text_fields,
 )
 from admin.backend.middleware import require_scope
 from pilot.core.bench import Bench
-from pilot.exceptions import BenchError
+from pilot.exceptions import BenchError, TaskConflictError
 from pilot.internal.site_paths import site_exists
-from pilot.internal.validators import validate_cron_expression
+from pilot.internal.validators import validate_cron_expression, validate_site_name
 from pilot.tasks.backup_site import BackupSiteTask
+from pilot.tasks.new_site_from_backup import NewSiteFromBackupTask
 
 _DEFAULT_BACKUPS_PAGE_SIZE = 20
 
@@ -55,17 +63,25 @@ def list_backups(name: str):
 @sites_bp.get("/<name>/backups/<timestamp>")
 @require_scope(site_name)
 def get_backup(name: str, timestamp: str):
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    match, failure = _find_backup_set(bench_root, name, timestamp)
+    if failure:
+        return failure
+    return jsonify(_backup_set_resource(match))
+
+
+def _find_backup_set(bench_root: Path, name: str, timestamp: str):
+    """The site's backup set for `timestamp` as (set, error_response) - one is None."""
     from admin.backend.providers.backups import BackupProvider
 
-    bench_root = Path(current_app.config["BENCH_ROOT"])
     try:
         sets = BackupProvider(bench_root, name).get_all()
     except Exception:
-        return internal_error("Could not read site backups.")
+        return None, internal_error("Could not read site backups.")
     match = next((s for s in sets if s.timestamp == timestamp), None)
     if match is None:
-        return error_response("backup_not_found", "Backup not found.", 404)
-    return jsonify(_backup_set_resource(match))
+        return None, error_response("backup_not_found", "Backup not found.", 404)
+    return match, None
 
 
 def _backup_set_resource(s) -> dict:
@@ -83,6 +99,113 @@ def _backup_set_resource(s) -> dict:
             for f in s.files
         ],
     }
+
+
+@sites_bp.post("/<name>/backups/<timestamp>/actions/restore")
+@require_scope(site_name)
+def restore_backup(name: str, timestamp: str):
+    """Create a new site from this backup set. Restoring to a fresh name keeps
+    the source site untouched, which also covers copying a site."""
+    bench_root = Path(current_app.config["BENCH_ROOT"])
+    if not site_exists(bench_root, name):
+        return site_not_found()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return malformed_body()
+    fields = text_fields(data, "new_site_name")
+    if fields is None:
+        return invalid_fields()
+
+    new_site_name = fields["new_site_name"]
+    err = validate_site_name(new_site_name) or new_site_name_error(bench_root, new_site_name)
+    if err:
+        return site_name_failure(err)
+
+    match, failure = _find_backup_set(bench_root, name, timestamp)
+    if failure:
+        return failure
+
+    files = {f.kind: f for f in match.files if f.path}
+    if "database" not in files:
+        return error_response(
+            "backup_file_missing",
+            "This backup's database file is not on this server. Download it from offsite storage first.",
+            422,
+        )
+
+    try:
+        task_id = _queue_restore(bench_root, name, timestamp, new_site_name, files.values())
+    except Exception as error:
+        return task_failure(error)
+    return accepted_task_response(bench_root, task_id)
+
+
+def _queue_restore(bench_root: Path, name: str, timestamp: str, new_site_name: str, files) -> str:
+    """Stage the archives and queue the restore. Staging this call created is
+    discarded when queueing fails; a directory that already existed belongs to
+    an accepted restore for the same parameters - the usual cause of a
+    conflict here - and must survive for that task to read."""
+    paths, staging_dir, created = _stage_restore_files(bench_root, name, timestamp, new_site_name, files)
+    try:
+        return NewSiteFromBackupTask.queue(
+            Bench(bench_root),
+            name=new_site_name,
+            db_file=paths["database"],
+            admin_password=secrets.token_urlsafe(16),
+            public_files=paths.get("public-file"),
+            private_files=paths.get("private-file"),
+            staging_dir=staging_dir,
+            idempotency_key=request.headers.get("Idempotency-Key"),
+            # Both locks: the destination is being created, and holding the source
+            # keeps site-level tasks (drop, reinstall, backup) from mutating the
+            # backup files this restore is about to read.
+            resource_key=[f"site:{name.lower()}", f"site:{new_site_name.lower()}"],
+        )
+    except TaskConflictError:
+        # A conflict means an active task holds these locks - a same-parameter
+        # restore that may be reading this staging. Never delete it here; the
+        # winning task removes it on success.
+        raise
+    except Exception:
+        if created and staging_dir:
+            shutil.rmtree(staging_dir, ignore_errors=True)
+        raise
+
+
+def _stage_restore_files(
+    bench_root: Path, name: str, timestamp: str, new_site_name: str, files
+) -> tuple[dict[str, str], str | None, bool]:
+    """Hardlink the selected archives so a backup or retention run cannot delete
+    them out from under the queued restore. The directory is derived from the
+    restore's parameters, keeping Idempotency-Key retries on the same task
+    fingerprint. Falls back to the originals when the filesystem refuses the
+    links (e.g. backups on another device). Returns (paths, staging_dir,
+    created) - `created` says whether this call made the directory."""
+    digest = hashlib.sha256(f"{name}:{timestamp}:{new_site_name}".encode()).hexdigest()[:16]
+    staging = bench_root / "backups-staging" / digest
+    staged = {}
+    created = False
+    try:
+        # mkdir itself decides ownership: overlapping same-parameter requests
+        # cannot both observe "absent" and later delete each other's staging.
+        try:
+            staging.mkdir(parents=True)
+            created = True
+        except FileExistsError:
+            pass
+        for file in files:
+            target = staging / file.filename
+            # Already staged by an equivalent request - same source, same
+            # inode. Concurrent stagers must not fall back to the unprotected
+            # originals over this.
+            with contextlib.suppress(FileExistsError):
+                os.link(file.path, target)
+            staged[file.kind] = str(target)
+    except OSError:
+        if created:
+            shutil.rmtree(staging, ignore_errors=True)
+        return {file.kind: file.path for file in files}, None, False
+    return staged, str(staging), created
 
 
 @sites_bp.get("/<name>/backups/<timestamp>/files/<file_id>/content")

--- a/admin/frontend/dashboard/src/api/sites.ts
+++ b/admin/frontend/dashboard/src/api/sites.ts
@@ -85,6 +85,13 @@ export const sitesApi = {
         .get(`sites/${encodeURIComponent(name)}/backups`, { searchParams: limit ? { limit } : {} })
         .json(),
     create: (name) => request.post(`sites/${encodeURIComponent(name)}/backups`).json(),
+    restore: (name, timestamp, newSiteName) =>
+      request
+        .post(
+          `sites/${encodeURIComponent(name)}/backups/${encodeURIComponent(timestamp)}/actions/restore`,
+          { json: { new_site_name: newSiteName } },
+        )
+        .json(),
     download: (name, timestamp, fileId) =>
       apiUrl(
         `sites/${encodeURIComponent(name)}/backups/${encodeURIComponent(timestamp)}/files/${encodeURIComponent(fileId)}/content`,

--- a/admin/frontend/dashboard/src/components/sites/Backups.vue
+++ b/admin/frontend/dashboard/src/components/sites/Backups.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
 import { computed, onMounted, ref } from 'vue'
-import { Badge, Button, Dialog, Dropdown, ErrorMessage, Select } from 'frappe-ui'
+import { Badge, Button, Dialog, Dropdown, ErrorMessage, Select, TextInput } from 'frappe-ui'
 
 import EmptyState from '@/components/common/EmptyState.vue'
 import ListSkeleton from '@/components/common/ListSkeleton.vue'
@@ -118,6 +118,20 @@ const menuOptions = (set) => {
         icon: 'lucide-download',
         onClick: () => downloadFile(set, k),
       })),
+    ...(fileOf(set, 'database')?.path
+      ? [
+          {
+            label: 'Restore to new site',
+            icon: 'lucide-archive-restore',
+            onClick: () => {
+              restoreTarget.value = set
+              restoreName.value = ''
+              restoreError.value = ''
+              showRestore.value = true
+            },
+          },
+        ]
+      : []),
     {
       label: 'Delete backup',
       icon: 'lucide-trash-2',
@@ -153,6 +167,32 @@ const downloadFile = async (set, kind) => {
     window.open(url, '_blank')
   } catch (e) {
     error.value = e.message || 'Failed to get offsite download link.'
+  }
+}
+
+const showRestore = ref(false)
+const restoreTarget = ref(null)
+const restoring = ref(false)
+const restoreError = ref('')
+const restoreName = ref('')
+
+const confirmRestore = async () => {
+  restoring.value = true
+  restoreError.value = ''
+  try {
+    const data = await sitesApi.backups.restore(
+      props.siteName,
+      restoreTarget.value.timestamp,
+      restoreName.value.trim(),
+    )
+    if (data.task_id) {
+      showRestore.value = false
+      openTaskDetailPage(router, data.task_id)
+    } else restoreError.value = apiErrorMessage(data, 'Restore failed.')
+  } catch (e) {
+    restoreError.value = e.message || 'Restore failed.'
+  } finally {
+    restoring.value = false
   }
 }
 
@@ -264,6 +304,32 @@ onMounted(() => {
       <Button v-if="backupsHasMore" class="ml-auto" @click="loadMoreBackups">Load more</Button>
     </div>
   </template>
+
+  <Dialog v-model="showRestore" title="Restore Backup" size="sm">
+    <p class="text-ink-gray-7 text-sm">
+      Create a new site from the backup of
+      <strong>{{ restoreTarget ? fmtDateTime(restoreTarget.created_at) : '' }}</strong
+      >. {{ siteName }} itself is not touched.
+    </p>
+
+    <TextInput v-model="restoreName" placeholder="new-name.example.com" class="mt-3 w-full">
+      <template #label>
+        <span class="text-sm">New site name</span>
+      </template>
+    </TextInput>
+
+    <ErrorMessage v-if="restoreError" :message="restoreError" class="mt-2" />
+    <div class="flex justify-end gap-2 mt-4">
+      <Button variant="ghost" @click="showRestore = false">Cancel</Button>
+      <Button
+        variant="solid"
+        :loading="restoring"
+        :disabled="!restoreName.trim() || restoreName.trim() === siteName"
+        @click="confirmRestore"
+        >Restore</Button
+      >
+    </div>
+  </Dialog>
 
   <Dialog v-model="showDelete" title="Delete Backup" size="sm">
     <p class="text-ink-gray-7 text-sm">

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -84,6 +84,10 @@ Measuring means a `du` per site directory and one schema-size query, so the rout
 
 `POST /sites/<name>/actions/refresh-storage` queues `refresh-storage-usage` to measure again on demand. One report covers every site on the bench, so the task re-measures all of them and concurrent requests fold into one run.
 
+### Backup Restore
+
+`POST /sites/<name>/backups/<timestamp>/actions/restore` takes `new_site_name`, validated like a new-site name, and queues `new-site-from-backup` holding both the source and destination site locks. The backup's database file must be local to this server (offsite-only sets answer 422); public/private file archives are included when present. The selected archives are hardlinked into a staging directory at submit time, so a later backup or retention run cannot delete the restore's inputs. The source site is not modified - restoring under a fresh name is also how you copy a site.
+
 ### Setup
 
 Every `/setup/*` route needs a session, like the rest of the API. The Admin password is set when the bench is created (`pilot new`), so there is no unauthenticated window: a browser reaches the wizard through the `?sid=` link that `pilot start` prints, or by signing in with that password. `POST /benches` returns a `setup_link` token for the same purpose.

--- a/pilot/tasks/new_site_from_backup.py
+++ b/pilot/tasks/new_site_from_backup.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from dataclasses import dataclass
 from typing import Annotated, ClassVar
 
@@ -16,10 +17,15 @@ class NewSiteFromBackupTask(Task):
     admin_password: Annotated[str, Arg(cli=False)]
     public_files: str | None = None
     private_files: str | None = None
+    # Directory of archives hardlinked for this restore; removed once it succeeds.
+    # Kept on failure so a retry still has its inputs.
+    staging_dir: str | None = None
 
     def run(self) -> None:
         self.require_production_privileges()
         self.restore()
+        if self.staging_dir:
+            shutil.rmtree(self.staging_dir, ignore_errors=True)
 
     @step("restore", lambda self: f"Restore site {self.name} from backup")
     def restore(self) -> None:

--- a/tests/admin/backend/api/test_site_backups_view.py
+++ b/tests/admin/backend/api/test_site_backups_view.py
@@ -251,3 +251,220 @@ def test_backup_schedule_delete_returns_no_content(tmp_path: Path) -> None:
     assert response.status_code == 204
     assert response.data == b""
     remove_schedule.assert_called_once_with("site.localhost")
+
+
+def test_restore_backup_queues_a_new_site_task(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    _make_site(bench_root, "site.localhost")
+    db_file = _make_backup_file(bench_root, "site.localhost", "20240101_000000", "database.sql.gz")
+    files = _make_backup_file(bench_root, "site.localhost", "20240101_000000", "files.tar")
+    client = _client(bench_root)
+
+    response = _request(
+        client,
+        "post",
+        "/api/v1/sites/site.localhost/backups/20240101_000000/actions/restore",
+        json={"new_site_name": "copy.localhost"},
+    )
+
+    body = response.get_json()
+    assert response.status_code == 202
+    assert body["command"] == "new-site-from-backup"
+    assert body["args"]["name"] == "copy.localhost"
+    # File paths ride in the task argv and the password in its private secrets;
+    # neither lands in the public task resource.
+    meta = json.loads((bench_root / "tasks" / body["task_id"] / "meta.json").read_text())
+    assert meta["args"]["admin_password"] == "[redacted]"
+    assert set(meta["resource_keys"]) == {"site:site.localhost", "site:copy.localhost"}
+    # The archives are hardlinked into a staging dir, so a backup or retention
+    # run deleting the originals cannot take the restore's inputs with it.
+    staged = [
+        Path(arg) for arg in meta["command_argv"] if "backups-staging" in arg
+    ]
+    assert {db_file.name, files.name} <= {p.name for p in staged}
+    db_file.unlink()
+    staged_db = next(p for p in staged if p.name == db_file.name)
+    assert staged_db.read_text() == "data"
+
+
+def test_restore_backup_falls_back_to_originals_when_linking_fails(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    _make_site(bench_root, "site.localhost")
+    db_file = _make_backup_file(bench_root, "site.localhost", "20240101_000000", "database.sql.gz")
+    client = _client(bench_root)
+
+    with patch("admin.backend.api.v1.sites.backups.os.link", side_effect=OSError):
+        response = _request(
+            client,
+            "post",
+            "/api/v1/sites/site.localhost/backups/20240101_000000/actions/restore",
+            json={"new_site_name": "copy.localhost"},
+        )
+
+    body = response.get_json()
+    assert response.status_code == 202
+    meta = json.loads((bench_root / "tasks" / body["task_id"] / "meta.json").read_text())
+    assert str(db_file) in meta["command_argv"]
+    assert not (bench_root / "backups-staging").exists() or not any(
+        (bench_root / "backups-staging").iterdir()
+    )
+
+
+def test_restore_backup_404s_for_an_unknown_timestamp(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    _make_site(bench_root, "site.localhost")
+    client = _client(bench_root)
+
+    response = _request(
+        client,
+        "post",
+        "/api/v1/sites/site.localhost/backups/20240101_000000/actions/restore",
+        json={"new_site_name": "copy.localhost"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_restore_backup_rejects_an_occupied_new_name(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    _make_site(bench_root, "site.localhost")
+    _make_site(bench_root, "taken.localhost")
+    _make_backup_file(bench_root, "site.localhost", "20240101_000000", "database.sql.gz")
+    client = _client(bench_root)
+
+    response = _request(
+        client,
+        "post",
+        "/api/v1/sites/site.localhost/backups/20240101_000000/actions/restore",
+        json={"new_site_name": "taken.localhost"},
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["error"]["code"] == "site_name_conflict"
+
+
+def test_restore_backup_rejects_an_invalid_new_name(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    _make_site(bench_root, "site.localhost")
+    _make_backup_file(bench_root, "site.localhost", "20240101_000000", "database.sql.gz")
+    client = _client(bench_root)
+
+    response = _request(
+        client,
+        "post",
+        "/api/v1/sites/site.localhost/backups/20240101_000000/actions/restore",
+        json={"new_site_name": "bad name!"},
+    )
+
+    assert response.status_code == 422
+
+
+def test_restore_backup_retries_idempotently(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    _make_site(bench_root, "site.localhost")
+    _make_backup_file(bench_root, "site.localhost", "20240101_000000", "database.sql.gz")
+    client = _client(bench_root)
+
+    def submit():
+        return _request(
+            client,
+            "post",
+            "/api/v1/sites/site.localhost/backups/20240101_000000/actions/restore",
+            json={"new_site_name": "copy.localhost"},
+            headers={"Idempotency-Key": "restore-once"},
+        )
+
+    first = submit()
+    second = submit()
+
+    assert first.status_code == 202
+    assert second.status_code == 202
+    assert first.get_json()["task_id"] == second.get_json()["task_id"]
+
+
+def test_conflicting_restore_keeps_the_accepted_restores_staging(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    _make_site(bench_root, "site.localhost")
+    db_file = _make_backup_file(bench_root, "site.localhost", "20240101_000000", "database.sql.gz")
+    client = _client(bench_root)
+    url = "/api/v1/sites/site.localhost/backups/20240101_000000/actions/restore"
+    body = {"new_site_name": "copy.localhost"}
+
+    first = _request(client, "post", url, json=body)
+    assert first.status_code == 202
+    meta = json.loads((bench_root / "tasks" / first.get_json()["task_id"] / "meta.json").read_text())
+    staged_db = next(Path(a) for a in meta["command_argv"] if a.endswith(db_file.name))
+    assert staged_db.exists()
+
+    # Same parameters, no idempotency key: the destination lock is held, so the
+    # second submission conflicts - and must not take the first one's inputs.
+    second = _request(client, "post", url, json=body)
+
+    assert second.status_code == 409
+    assert staged_db.exists()
+
+
+def test_overlapping_restores_cannot_both_claim_staging_ownership(tmp_path: Path) -> None:
+    """mkdir decides ownership atomically: a request that finds the directory
+    already present never deletes it, even when the pre-check raced."""
+    from admin.backend.api.v1.sites.backups import _stage_restore_files
+
+    bench_root = tmp_path / "benches" / "current"
+    _make_site(bench_root, "site.localhost")
+    db_file = _make_backup_file(bench_root, "site.localhost", "20240101_000000", "database.sql.gz")
+
+    class _File:
+        kind = "database"
+        filename = db_file.name
+        path = str(db_file)
+
+    first = _stage_restore_files(bench_root, "site.localhost", "20240101_000000", "copy.localhost", [_File()])
+    second = _stage_restore_files(bench_root, "site.localhost", "20240101_000000", "copy.localhost", [_File()])
+
+    assert first[2] is True
+    assert second[2] is False
+    assert first[1] == second[1]
+
+
+def test_a_conflicting_creator_does_not_delete_the_winners_staging(tmp_path: Path) -> None:
+    """The staging creator can lose the queue race to a same-parameter request
+    that reused its directory; the resulting conflict must not delete it."""
+    from admin.backend.api.v1.sites.backups import _queue_restore
+
+    bench_root = tmp_path / "benches" / "current"
+    _make_site(bench_root, "site.localhost")
+    db_file = _make_backup_file(bench_root, "site.localhost", "20240101_000000", "database.sql.gz")
+    client = _client(bench_root)
+    url = "/api/v1/sites/site.localhost/backups/20240101_000000/actions/restore"
+
+    accepted = _request(client, "post", url, json={"new_site_name": "copy.localhost"})
+    assert accepted.status_code == 202
+    meta = json.loads(
+        (bench_root / "tasks" / accepted.get_json()["task_id"] / "meta.json").read_text()
+    )
+    staged_db = next(Path(a) for a in meta["command_argv"] if a.endswith(db_file.name))
+
+    class _File:
+        kind = "database"
+        filename = db_file.name
+        path = str(db_file)
+
+    # Simulate the racing creator: it made the directory (created=True in its
+    # view), then loses the queue to the accepted task's locks.
+    import pytest
+
+    from pilot.exceptions import TaskConflictError
+
+    with (
+        patch(
+            "admin.backend.api.v1.sites.backups._stage_restore_files",
+            return_value=({"database": str(staged_db)}, str(staged_db.parent), True),
+        ),
+        client.application.test_request_context(),
+        pytest.raises(TaskConflictError),
+    ):
+        _queue_restore(
+            bench_root, "site.localhost", "20240101_000000", "copy.localhost", [_File()]
+        )
+
+    assert staged_db.exists()


### PR DESCRIPTION
Second slice of #374: restoring a backup from the admin UI. `NewSiteFromBackupTask` existed but nothing could reach it — no CLI command, no API route, no UI.

- `POST /sites/<name>/backups/<timestamp>/actions/restore` validates the new site name like site creation, resolves the backup set's local files (database required; public/private files included when present), and queues the task. Restoring into a fresh name keeps the source site untouched — which also covers the "copy site for staging" ask in the issue.
- The set-by-timestamp lookup shared with `GET /backups/<timestamp>` moved into a `_find_backup_set` helper.
- The backup row menu gains **Restore to new site** with a dialog asking for the new name. Offsite-only sets don't offer it, since the database file must be on this server.

Verified live: submitting the dialog queues a `new-site-from-backup` task ("Restore Site") and lands on its task page. 4 new API tests; `uv run pytest tests/admin tests/pilot` green (2488 passed).

![restore backup dialog](https://raw.githubusercontent.com/badal8381/pilot/pr-assets/pr-restore-backup-dialog.jpg)

Part of #374
