### PR TITLE
fix: Use --dev flag instead of --serve-assets for frappe runner

### DIFF
--- a/pilot/core/app/__init__.py
+++ b/pilot/core/app/__init__.py
@@ -217,19 +217,35 @@ class App:
         """Check out a specific commit SHA, refetching it from origin if needed."""
         self._repository.checkout_pinned_commit(sha)
 
+    def _pyproject(self) -> dict:
+        """Parsed pyproject.toml, or an empty dict when it is missing or malformed."""
+        import tomllib
+
+        try:
+            return tomllib.loads((self.path / "pyproject.toml").read_text())
+        except (tomllib.TOMLDecodeError, OSError):
+            return {}
+
+    @property
+    def has_dev_extra(self) -> bool:
+        """Whether pyproject declares a `dev` extra, such as frappe's watchdog group."""
+        return "dev" in self._pyproject().get("project", {}).get("optional-dependencies", {})
+
+    @property
+    def editable_target(self) -> str:
+        """Target for `uv pip install -e`. A dev bench also pulls the app's dev extra,
+        which is where frappe keeps watchdog, the reloader `--dev` refuses to start
+        without."""
+        if self.bench.config.production.enabled or not self.has_dev_extra:
+            return str(self.path)
+        return f"{self.path}[dev]"
+
     @property
     def module_name(self) -> str:
         """Return the importable package name, preferring pyproject.toml."""
-        pyproject = self.path / "pyproject.toml"
-        if pyproject.exists():
-            import tomllib
-
-            try:
-                name = tomllib.loads(pyproject.read_text()).get("project", {}).get("name")
-            except (tomllib.TOMLDecodeError, OSError):
-                name = None
-            if name:
-                return name.replace("-", "_")
+        name = self._pyproject().get("project", {}).get("name")
+        if name:
+            return name.replace("-", "_")
 
         conventional = self.config.name.replace("-", "_")
         if (self.path / conventional / "hooks.py").exists():

--- a/pilot/core/bench/runtime.py
+++ b/pilot/core/bench/runtime.py
@@ -243,7 +243,7 @@ class BenchRuntime:
                 continue
             on_progress(f"Installing Python requirements for {app.config.name}...")
             run_command(
-                [uv, "pip", "install", "--python", python, "-e", str(app.path)],
+                [uv, "pip", "install", "--python", python, "-e", app.editable_target],
                 stream_output=True,
             )
 

--- a/pilot/managers/environment.py
+++ b/pilot/managers/environment.py
@@ -168,7 +168,7 @@ class PythonEnvManager:
         uv = ensure_uv()
         python = str(self.bench.env_path / "bin" / "python")
         run_command(
-            [uv, "pip", "install", "--python", python, "-e", str(app.path)],
+            [uv, "pip", "install", "--python", python, "-e", app.editable_target],
             stream_output=True,
             env=self._build_env(),
         )

--- a/pilot/managers/processes/definitions.py
+++ b/pilot/managers/processes/definitions.py
@@ -135,6 +135,7 @@ class ProcessDefinitionBuilder:
         ]
         if dev:
             argv.append("--dev")
+            argv.append("--verbose")
         return ProcessDefinition(
             name="web",
             argv=argv,

--- a/pilot/managers/processes/definitions.py
+++ b/pilot/managers/processes/definitions.py
@@ -134,8 +134,7 @@ class ProcessDefinitionBuilder:
             f"--job-drain-seconds={lite_mode.job_drain_seconds}",
         ]
         if dev:
-            # No nginx in front, so the process serves /assets and /files itself.
-            argv.append("--serve-assets")
+            argv.append("--dev")
         return ProcessDefinition(
             name="web",
             argv=argv,

--- a/pilot/managers/processes/local.py
+++ b/pilot/managers/processes/local.py
@@ -51,6 +51,10 @@ _RELOAD_REQUEST_FILE = "reload.request"
 # Both must survive it, so only app-code processes are restarted.
 _NON_RELOADABLE = frozenset({"admin", "admin-ui", "redis_cache", "redis_queue", "watch"})
 
+# Stopped last, so their clients are already gone and cannot log a lost connection.
+_DATASTORES = frozenset({"redis_cache", "redis_queue"})
+_STOP_GRACE_SECONDS = 5
+
 _COLORS = [
     "\033[36m",
     "\033[32m",
@@ -234,7 +238,7 @@ class ProcessManager:
         with contextlib.suppress(ProcessLookupError, OSError):
             os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
         try:
-            proc.wait(timeout=5)
+            proc.wait(timeout=_STOP_GRACE_SECONDS)
         except subprocess.TimeoutExpired:
             with contextlib.suppress(ProcessLookupError, OSError):
                 os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
@@ -299,16 +303,25 @@ class ProcessManager:
             sys.stdout.flush()
 
     def _stop_all(self) -> None:
-        for proc in self._procs.values():
+        """Drain the workload before redis. Killing them together leaves the workers
+        and the realtime bridge retrying a socket that is already closed."""
+        names = list(self._procs)
+        self._stop_group([name for name in names if name not in _DATASTORES])
+        self._stop_group([name for name in names if name in _DATASTORES])
+        self.reload_request_file.unlink(missing_ok=True)
+
+    def _stop_group(self, names: list[str]) -> None:
+        """SIGTERM the whole group, then reap it, so the grace period is shared."""
+        procs = [self._procs[name] for name in names if name in self._procs]
+        for proc in procs:
             with contextlib.suppress(ProcessLookupError, OSError):
                 os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-        for proc in self._procs.values():
+        for proc in procs:
             try:
-                proc.wait(timeout=5)
+                proc.wait(timeout=_STOP_GRACE_SECONDS)
             except subprocess.TimeoutExpired:
                 with contextlib.suppress(ProcessLookupError, OSError):
                     os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        self.reload_request_file.unlink(missing_ok=True)
 
     def _cleanup_proc_pid_files(self) -> None:
         for name in self._procs:

--- a/tests/pilot/core/test_app_editable_target.py
+++ b/tests/pilot/core/test_app_editable_target.py
@@ -1,0 +1,76 @@
+"""Tests for App.editable_target: dev benches pull an app's `dev` extra."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pilot.config import AppConfig
+from pilot.core.app import App
+from tests.pilot.commands.test_commands import make_bench
+
+
+def _make_app(bench, name: str, pyproject: str | None) -> App:
+    app = App(AppConfig(name=name, repo=f"https://example.com/{name}.git", branch="main"), bench)
+    app.path.mkdir(parents=True)
+    if pyproject is not None:
+        (app.path / "pyproject.toml").write_text(pyproject)
+    return app
+
+
+_WITH_DEV_EXTRA = """
+[project]
+name = "frappe"
+
+[project.optional-dependencies]
+dev = ["watchdog~=6.0.0"]
+"""
+
+_WITHOUT_DEV_EXTRA = """
+[project]
+name = "myapp"
+"""
+
+
+def test_dev_bench_installs_the_dev_extra(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    bench.config.production.enabled = False
+    app = _make_app(bench, "frappe", _WITH_DEV_EXTRA)
+
+    assert app.has_dev_extra
+    assert app.editable_target == f"{app.path}[dev]"
+
+
+def test_production_bench_skips_the_dev_extra(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    bench.config.production.enabled = True
+    app = _make_app(bench, "frappe", _WITH_DEV_EXTRA)
+
+    assert app.editable_target == str(app.path)
+
+
+def test_app_without_a_dev_extra_installs_plainly(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    bench.config.production.enabled = False
+    app = _make_app(bench, "myapp", _WITHOUT_DEV_EXTRA)
+
+    assert not app.has_dev_extra
+    assert app.editable_target == str(app.path)
+
+
+def test_missing_pyproject_installs_plainly(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    bench.config.production.enabled = False
+    app = _make_app(bench, "legacy", None)
+
+    assert not app.has_dev_extra
+    assert app.editable_target == str(app.path)
+
+
+def test_malformed_pyproject_installs_plainly(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    bench.config.production.enabled = False
+    app = _make_app(bench, "broken", "[project\nname =")
+
+    assert not app.has_dev_extra
+    assert app.editable_target == str(app.path)
+    assert app.module_name == "broken"

--- a/tests/pilot/managers/test_lite_mode.py
+++ b/tests/pilot/managers/test_lite_mode.py
@@ -168,11 +168,12 @@ def test_lite_stop_timeout_covers_both_drains(tmp_path: Path) -> None:
     assert _web(bench).stop_timeout == 690
 
 
-def test_lite_serves_assets_only_in_dev(tmp_path: Path) -> None:
+def test_lite_reloads_and_serves_assets_only_in_dev(tmp_path: Path) -> None:
+    """frappe.runner folds asset serving into --dev; there is no --serve-assets."""
     bench = make_bench(tmp_path)
 
-    assert "--serve-assets" not in _web(bench).argv
-    assert "--serve-assets" in _web(bench, dev=True).argv
+    assert "--dev" not in _web(bench).argv
+    assert "--dev" in _web(bench, dev=True).argv
 
 
 def test_lite_dev_keeps_the_single_process(tmp_path: Path) -> None:

--- a/tests/pilot/managers/test_process_reload.py
+++ b/tests/pilot/managers/test_process_reload.py
@@ -159,3 +159,16 @@ def test_get_and_install_reloads_before_installing_on_the_site(tmp_path: Path) -
         task.run()
 
     assert order.mock_calls == [call.reload(), call.install(ANY)]
+
+
+def test_stop_all_stops_redis_after_the_workload(tmp_path: Path, monkeypatch) -> None:
+    """Redis outlives its clients; killing it first makes them log a lost connection."""
+    manager = _manager(tmp_path, monkeypatch)
+    manager._procs = dict.fromkeys(("web", "redis_cache", "admin", "redis_queue"), "running")
+
+    waves: list[list[str]] = []
+    monkeypatch.setattr(manager, "_stop_group", lambda names: waves.append(names))
+
+    manager._stop_all()
+
+    assert waves == [["web", "admin"], ["redis_cache", "redis_queue"]]


### PR DESCRIPTION
- fix: Use --dev flag instead of --serve-assets for frappe runner
- fix(bench): install an app's dev extra on dev benches
- fix(processes): stop redis after the workload in dev