### PR TITLE
fix(e2e): tolerate the root-redirect race in open_root

### DIFF
--- a/tests/e2e/flows/admin.py
+++ b/tests/e2e/flows/admin.py
@@ -3,14 +3,24 @@
 from __future__ import annotations
 
 from harness.tasks import run_task_action, wait_for_task
+from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page, expect
 
 
 def open_root(page: Page, base_url: str) -> None:
     """`/` redirects to `/sites` in the router, so waiting for load races that redirect and
     Playwright reports the navigation as interrupted. Return once the document commits instead;
-    the callers' own locators wait for whichever page the redirect chain settles on."""
-    page.goto(f"{base_url}/", wait_until="commit")
+    the callers' own locators wait for whichever page the redirect chain settles on.
+
+    Even at "commit" the race is only narrowed, not closed: when the router's redirect
+    lands before the initial navigation commits, goto still raises "interrupted by
+    another navigation". The page is on its way to the redirect target either way, so
+    that specific error is safe to swallow - anything else still raises."""
+    try:
+        page.goto(f"{base_url}/", wait_until="commit")
+    except PlaywrightError as error:
+        if "interrupted by another navigation" not in str(error):
+            raise
 
 
 def login(page: Page, base_url: str, password: str) -> None:

--- a/tests/e2e/flows/admin.py
+++ b/tests/e2e/flows/admin.py
@@ -12,10 +12,7 @@ def open_root(page: Page, base_url: str) -> None:
     Playwright reports the navigation as interrupted. Return once the document commits instead;
     the callers' own locators wait for whichever page the redirect chain settles on.
 
-    Even at "commit" the race is only narrowed, not closed: when the router's redirect
-    lands before the initial navigation commits, goto still raises "interrupted by
-    another navigation". The page is on its way to the redirect target either way, so
-    that specific error is safe to swallow - anything else still raises."""
+    """
     try:
         page.goto(f"{base_url}/", wait_until="commit")
     except PlaywrightError as error:

--- a/tests/e2e/flows/admin.py
+++ b/tests/e2e/flows/admin.py
@@ -16,7 +16,9 @@ def open_root(page: Page, base_url: str) -> None:
     try:
         page.goto(f"{base_url}/", wait_until="commit")
     except PlaywrightError as error:
-        if "interrupted by another navigation" not in str(error):
+        # Only the known redirect is benign: anything else interrupting the
+        # navigation is a real failure and must surface here, not as a later timeout.
+        if f'interrupted by another navigation to "{base_url}/sites"' not in str(error):
             raise
 
 


### PR DESCRIPTION
`test_logs_into_admin` fails intermittently with `Page.goto: Navigation to ".../" is interrupted by another navigation to ".../sites"` — seen on runs [33044249546](https://github.com/frappe/pilot/actions/runs/33044249546) (#417) and [33066117230](https://github.com/frappe/pilot/actions/runs/33066117230) (#421), both passing unchanged on rerun.

`open_root` already navigates with `wait_until="commit"` for exactly this reason, but that only narrows the race: when the router's `/` → `/sites` redirect lands before the initial navigation commits, Playwright still reports the goto as interrupted. The page is on its way to the redirect target either way, and every caller's locators wait for the settled page — so this swallows exactly that error and lets anything else raise.

