### PR TITLE
fix: point letsencrypt.email errors at common_config.toml

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -27,6 +27,8 @@ pilot setup production --admin-domain admin.example.com
 pilot setup letsencrypt
 ```
 
+`pilot setup letsencrypt` needs `letsencrypt.email`, which is host-shared and lives in `common_config.toml` next to the bench folders (see [Common Config](configuration.md#common-config)), not in `bench.toml`. `pilot setup production --tls --letsencrypt-email <email>` sets it for you.
+
 `pilot setup production` writes process manager config and nginx integration. `pilot remove production` removes production deployment files and services while keeping logs, certificates, and admin domain config.
 
 ## Process Managers

--- a/pilot/commands/setup/production.py
+++ b/pilot/commands/setup/production.py
@@ -35,7 +35,7 @@ class SetupProductionCommand(Command):
     letsencrypt_email: Annotated[
         str | None,
         Arg(
-            help="Contact email for Let's Encrypt (required with --tls unless letsencrypt.email is already set in bench.toml)."
+            help="Contact email for Let's Encrypt (required with --tls unless letsencrypt.email is already set in common_config.toml)."
         ),
     ] = None
     best_effort_tls: Annotated[bool, Arg(cli=False)] = False

--- a/pilot/core/bench/production.py
+++ b/pilot/core/bench/production.py
@@ -99,7 +99,9 @@ class BenchProduction:
         from pilot.managers.nginx import NginxManager
 
         if not self.bench.config.letsencrypt.email:
-            raise ConfigError("letsencrypt.email must be set in bench.toml to run setup letsencrypt.")
+            raise ConfigError(
+                "letsencrypt.email must be set in common_config.toml (next to your benches) to run setup letsencrypt."
+            )
         letsencrypt_manager = LetsEncryptManager(self.bench)
         nginx_manager = NginxManager(self.bench)
         letsencrypt_manager.install()

--- a/pilot/core/bench/setup.py
+++ b/pilot/core/bench/setup.py
@@ -112,7 +112,8 @@ class ProductionSetup:
             )
         if letsencrypt_email_required(self.bench) and not self.bench.config.letsencrypt.email:
             raise BenchError(
-                "A contact email is required with --tls for Let's Encrypt. Pass --letsencrypt-email <email>, or set letsencrypt.email in bench.toml."
+                "A contact email is required with --tls for Let's Encrypt. Pass --letsencrypt-email <email>, "
+                "or set letsencrypt.email in common_config.toml next to your benches."
             )
 
     def _installed_manager(self) -> str | None:


### PR DESCRIPTION
The `setup letsencrypt` error told users to set `letsencrypt.email` in `bench.toml`, but the letsencrypt section is host-shared and only read from `common_config.toml` (`BenchConfig` merges `common.letsencrypt` on every read). Following the message put the email where it is silently ignored.

Fixes the `ConfigError` in `setup_letsencrypt`, the `--tls` preflight error in `ProductionSetup`, and the `--letsencrypt-email` CLI help, and notes the `common_config.toml` location in `docs/production.md`.