### PR TITLE
fix(fluentbit): tail bench log dir only, not the site mirror

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,3 +115,5 @@ Shared database services use per-user state managed by database managers. The be
 Domain provider binaries are wrapped by `pilot/core/adapters/domain_provider.py`. They expose DNS/domain behavior without leaking provider-specific code into `Site`.
 
 Nginx, systemd, supervisor, Redis, Python environments, and databases are implemented by managers. Core objects use managers to keep system integration code away from command and API layers.
+
+Fluent Bit (`pilot/managers/fluentbit`) tails `benches/*/logs/*.log` only, not the per-site log mirror under `benches/*/sites/*/logs/`. Frappe copies every site-context line into both byte-for-byte, so tailing both would ship each line twice.

--- a/pilot/managers/fluentbit/templates/fluent-bit.conf.template
+++ b/pilot/managers/fluentbit/templates/fluent-bit.conf.template
@@ -14,10 +14,9 @@
 #
 #   {{ cli_root }}/benches/<bench>/logs/*.log
 #
-# Frappe mirrors every site-context line into the site log dir
-# byte-for-byte, so we tail the bench dir only to avoid shipping
-# each line twice. Broad *.log pattern; formats with their own
-# parser or that we skip are excluded below.
+# Broad *.log pattern; formats with their own parser or that we
+# skip are excluded below. See docs/architecture.md for why the
+# site log mirror is not tailed here.
 # ============================================================
 
 [INPUT]

--- a/pilot/managers/fluentbit/templates/fluent-bit.conf.template
+++ b/pilot/managers/fluentbit/templates/fluent-bit.conf.template
@@ -12,24 +12,21 @@
 # ============================================================
 # Python / Frappe logs
 #
-# Bench-level:
 #   {{ cli_root }}/benches/<bench>/logs/*.log
 #
-# Site-level:
-#   {{ cli_root }}/benches/<bench>/sites/<site>/logs/*.log
-#
-# We intentionally use a broad *.log pattern here and exclude
-# formats that have their own dedicated parser or that we have
-# decided not to ingest.
+# Frappe mirrors every site-context line into the site log dir
+# byte-for-byte, so we tail the bench dir only to avoid shipping
+# each line twice. Broad *.log pattern; formats with their own
+# parser or that we skip are excluded below.
 # ============================================================
 
 [INPUT]
     Name              tail
     Tag               pilot.python
 
-    Path              {{ cli_root }}/benches/*/logs/*.log,{{ cli_root }}/benches/*/sites/*/logs/*.log
+    Path              {{ cli_root }}/benches/*/logs/*.log
 
-    Exclude_Path      {{ cli_root }}/benches/*/logs/nginx-access.log,{{ cli_root }}/benches/*/logs/nginx-error.log,{{ cli_root }}/benches/*/logs/*.json.log,{{ cli_root }}/benches/*/logs/redis_*.log,{{ cli_root }}/benches/*/logs/worker_pool.log,{{ cli_root }}/benches/*/logs/*.error.log,{{ cli_root }}/benches/*/logs/socketio.log,{{ cli_root }}/benches/*/logs/web.log,{{ cli_root }}/benches/*/logs/cssutils.log,{{ cli_root }}/benches/*/logs/render-template.log,{{ cli_root }}/benches/*/sites/*/logs/*.json.log,{{ cli_root }}/benches/*/sites/*/logs/redis_*.log,{{ cli_root }}/benches/*/sites/*/logs/worker_pool.log,{{ cli_root }}/benches/*/sites/*/logs/*.error.log,{{ cli_root }}/benches/*/sites/*/logs/socketio.log,{{ cli_root }}/benches/*/sites/*/logs/web.log,{{ cli_root }}/benches/*/sites/*/logs/cssutils.log,{{ cli_root }}/benches/*/sites/*/logs/render-template.log
+    Exclude_Path      {{ cli_root }}/benches/*/logs/nginx-access.log,{{ cli_root }}/benches/*/logs/nginx-error.log,{{ cli_root }}/benches/*/logs/*.json.log,{{ cli_root }}/benches/*/logs/redis_*.log,{{ cli_root }}/benches/*/logs/worker_pool.log,{{ cli_root }}/benches/*/logs/*.error.log,{{ cli_root }}/benches/*/logs/socketio.log,{{ cli_root }}/benches/*/logs/web.log,{{ cli_root }}/benches/*/logs/cssutils.log,{{ cli_root }}/benches/*/logs/render-template.log
 
     Path_Key          filename
 

--- a/tests/pilot/managers/test_fluentbit.py
+++ b/tests/pilot/managers/test_fluentbit.py
@@ -58,6 +58,26 @@ def test_logs_install_writes_config_parsers_lua_and_unit(tmp_path: Path) -> None
     assert str(tmp_path / "system" / "fluent-bit" / "fluent-bit.conf") in unit_text
 
 
+def test_python_input_tails_bench_dir_only(tmp_path: Path) -> None:
+    """Site dir mirrors the bench log verbatim; tailing both ships each line twice."""
+    configurator = _configurator(tmp_path)
+    config = LogsConfig(endpoint="https://datum.internal", token="secret")
+
+    with (
+        patch("pilot.managers.fluentbit.cli_root", return_value=tmp_path),
+        patch("pilot.managers.fluentbit.shutil.which", return_value="/usr/bin/fluent-bit"),
+        patch("pilot.managers.fluentbit.user_service_installed", return_value=False),
+        patch("pilot.managers.fluentbit.install_user_service"),
+        patch("pilot.managers.fluentbit.run_command"),
+    ):
+        configurator.install(config)
+
+    conf = (tmp_path / "system" / "fluent-bit" / "fluent-bit.conf").read_text()
+    python_block = conf.split("Tag               pilot.python", 1)[1].split("[INPUT]", 1)[0]
+    assert f"{tmp_path}/benches/*/logs/*.log" in python_block
+    assert "/sites/*/logs/*.log" not in python_block
+
+
 def test_logs_install_disables_tls_for_http_endpoint(tmp_path: Path) -> None:
     configurator = _configurator(tmp_path)
     config = LogsConfig(endpoint="http://datum.internal", token="secret")


### PR DESCRIPTION
Fixes #441

Fluent Bit tailed both bench-level and site-level log files. Frappe
writes each site-context line to both, byte-identical, so every such
line reached datum.logs twice. Dropped the site-level path — the
bench-level glob already has every line. Confirmed live: one marker
line went from 2 rows in datum.logs to 1.
