### PR TITLE
Fix setup finish check for managed process managers

### DIFF
--- a/admin/backend/api/v1/setup/__init__.py
+++ b/admin/backend/api/v1/setup/__init__.py
@@ -224,7 +224,7 @@ def _validate_finished_setup_task(bench_root: Path, task_id: str):
         conflict = _check_marker_claims_this_task(bench_root, marker, task_id)
         if conflict is not None:
             return conflict
-        if not (bench_root / "config" / "Procfile").exists():
+        if not Bench(bench_root).python.exists():
             return error_response(
                 "setup_not_initialized",
                 "Bench setup has not finished.",

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -98,6 +98,8 @@ Every `/setup/*` route needs a session, like the rest of the API. The Admin pass
 
 `PUT /setup/configuration` accepts only the fields the wizard owns: `app_repo`, `app_branch`, `db_type`, `db_mode`, and the `mariadb_*`/`postgres_*` connection fields. Any other key gets a 422 - including `admin_password`. Change the remaining `bench.toml` settings through the settings API.
 
+`POST /setup/actions/finish` treats the bench as initialized when its bench Python executable exists (`Bench(...).python`, normally `env/bin/python`). This completion check is intentionally independent of the configured process manager: local benches may use `config/Procfile`, while managed systemd or Supervisor benches generate their own service configuration. Do not use Procfile existence as the setup-completion invariant.
+
 ## Errors
 
 Raise HTTP errors at the route boundary. Core objects should raise domain exceptions such as config or bench errors.

--- a/tests/admin/backend/api/test_setup_finish_managed.py
+++ b/tests/admin/backend/api/test_setup_finish_managed.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from admin.backend.app import create_app
+from pilot.config import BenchConfig
+from pilot.core.bench import Bench
+from pilot.internal.tasks.store import TaskStore
+from pilot.managers.task.models import TaskStatus
+
+
+def _setup_client(bench_root: Path):
+    from admin.backend.internal.session import Session
+
+    bench_root.mkdir(parents=True, exist_ok=True)
+    BenchConfig.write_flat(
+        bench_root,
+        bench_root.name,
+        {"admin_enabled": True, "admin_password": "admin-secret"},
+    )
+    app = create_app(bench_root)
+    app.config["TESTING"] = True
+    client = app.test_client()
+    client.set_cookie("sid", Session(Bench(bench_root)).issue_session_token()[0])
+    return client
+
+
+def _start_and_complete_setup(client, bench_root: Path) -> str:
+    assert client.put(
+        "/api/v1/setup/configuration",
+        json={"mariadb_password": "database-secret"},
+    ).status_code == 200
+
+    with patch("pilot.internal.tasks.runner.task_workers.wake"):
+        response = client.post(
+            "/api/v1/setup/actions/start",
+            headers={"Idempotency-Key": "managed-process-setup"},
+        )
+    assert response.status_code == 202
+    task_id = response.get_json()["task_id"]
+
+    store = TaskStore(bench_root)
+    store.transition(
+        task_id,
+        TaskStatus.QUEUED,
+        TaskStatus.RUNNING,
+        {"started_at": "2026-09-07T09:00:00+00:00"},
+    )
+    store.transition(
+        task_id,
+        TaskStatus.RUNNING,
+        TaskStatus.SUCCESS,
+        {
+            "finished_at": "2026-09-07T09:01:00+00:00",
+            "exit_code": 0,
+        },
+    )
+    return task_id
+
+
+def test_finish_accepts_initialized_bench_without_procfile(tmp_path: Path) -> None:
+    """Managed process managers do not use config/Procfile.
+
+    A successful wizard setup should finish when the bench Python environment
+    exists even when no Procfile was generated.
+    """
+    client = _setup_client(tmp_path)
+    task_id = _start_and_complete_setup(client, tmp_path)
+
+    python = Bench(tmp_path).python
+    python.parent.mkdir(parents=True, exist_ok=True)
+    python.touch()
+
+    assert not (tmp_path / "config" / "Procfile").exists()
+
+    response = client.post(
+        "/api/v1/setup/actions/finish",
+        json={"task_id": task_id},
+    )
+
+    assert response.status_code == 204
+    assert response.data == b""
+    assert not (tmp_path / ".wizard-active").exists()
+
+
+def test_finish_still_rejects_bench_without_python_environment(tmp_path: Path) -> None:
+    client = _setup_client(tmp_path)
+    task_id = _start_and_complete_setup(client, tmp_path)
+
+    response = client.post(
+        "/api/v1/setup/actions/finish",
+        json={"task_id": task_id},
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["error"]["code"] == "setup_not_initialized"
+    assert (tmp_path / ".wizard-active").exists()


### PR DESCRIPTION
## Summary

Fixes the setup wizard failing to complete for benches using managed process managers such as **systemd**, where `config/Procfile` is not generated.

Previously, `/api/v1/setup/actions/finish` treated the existence of `config/Procfile` as proof that bench initialization had completed. This assumption is only valid for the local process manager.

For a systemd-managed production bench, the wizard could successfully complete all initialization steps and start all services, but **Finish** would still return:

```text
409 Conflict
setup_not_initialized
Bench setup has not finished.
```

## Root Cause

The setup finish validation contained a hard-coded check:

```python
if not (bench_root / "config" / "Procfile").exists():
```

Managed process managers do not necessarily generate a Procfile.

For example, the systemd process manager generates its service and target units under:

```text
config/services/
```

As a result, a correctly initialized and running systemd bench could not complete the setup wizard.

This was reproduced on a production installation where all generated systemd services were active, but `config/Procfile` did not exist.

Creating an empty Procfile manually immediately allowed the wizard to finish, confirming the Procfile check as the blocker.

## Changes

The setup completion validation now uses the bench Python environment as the initialization indicator:

```python
Bench(bench_root).python.exists()
```

instead of requiring:

```text
config/Procfile
```

This makes the check independent of the configured process manager and aligns it with Pilot's existing bench initialization logic.

## Tests

Added regression coverage for both cases:

* An initialized bench with `env/bin/python` but **without a Procfile** can successfully finish setup and returns `204`.
* A bench without its Python environment is still considered uninitialized and continues to return `409 setup_not_initialized`.

## Impact

This allows the setup wizard to complete normally for systemd-managed and other managed-process benches without requiring an unused placeholder Procfile.

The existing protection against finishing a genuinely incomplete bench remains in place.

## Scope

The change is intentionally narrow.

Process-manager-specific configuration detection is left unchanged because systemd and Supervisor already provide their own `is_configured()` implementations. This PR only removes the incorrect process-manager-specific assumption from the setup finish validation.
