### PR TITLE
feat(updates): compare marketplace stable releases with live GitHub heads

### DIFF
--- a/admin/backend/api/v1/updates.py
+++ b/admin/backend/api/v1/updates.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from flask import Blueprint, current_app, jsonify
 
 from admin.backend.api.responses import error_response
+from admin.backend.providers.marketplace_updates import MarketplaceGitHubUpdates
 from pilot.core.bench import Bench
+from pilot.exceptions import RegistryUnavailableError
 from pilot.internal.git import GitRepo
 from pilot.utils import cli_root
 
@@ -26,6 +28,39 @@ def check_app_updates():
         return jsonify({"apps": _app_updates(fetch=True)})
     except Exception:
         return error_response("app_update_check_failed", "Could not check for app updates.", 500)
+
+
+@updates_bp.get("/marketplace-github-updates")
+def get_marketplace_github_updates():
+    try:
+        return jsonify(_marketplace_github_updates(refresh=False))
+    except RegistryUnavailableError as exc:
+        return error_response("registry_unavailable", str(exc), 503)
+    except Exception:
+        return error_response(
+            "marketplace_github_updates_unavailable",
+            "Could not read marketplace GitHub updates.",
+            500,
+        )
+
+
+@updates_bp.post("/marketplace-github-update-checks")
+def check_marketplace_github_updates():
+    try:
+        return jsonify(_marketplace_github_updates(refresh=True))
+    except RegistryUnavailableError as exc:
+        return error_response("registry_unavailable", str(exc), 503)
+    except Exception:
+        return error_response(
+            "marketplace_github_update_check_failed",
+            "Could not check marketplace GitHub updates.",
+            500,
+        )
+
+
+def _marketplace_github_updates(*, refresh: bool) -> dict:
+    checker = MarketplaceGitHubUpdates(cli_root())
+    return checker.check(refresh=refresh)
 
 
 def _app_updates(*, fetch: bool) -> list[dict]:

--- a/admin/backend/providers/marketplace_updates.py
+++ b/admin/backend/providers/marketplace_updates.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+
+from pilot.core.registry_cache import RegistryCache
+from pilot.integrations.git.github import parse_github_owner_repo
+from pilot.utils import run_command
+
+
+@dataclass
+class MarketplaceGitHubUpdates:
+    cli_root: Path
+
+    def check(self, *, refresh: bool) -> dict:
+        cache = RegistryCache(self.cli_root)
+        if refresh:
+            self._force_refresh(cache)
+
+        apps = cache.load()
+        rows = self._release_rows(cache, apps)
+
+        compared: list[dict] = []
+        with ThreadPoolExecutor(max_workers=16) as pool:
+            futures = [pool.submit(self._compare_row, row) for row in rows]
+            for future in as_completed(futures):
+                compared.append(future.result())
+
+        compared.sort(key=lambda item: (item["status"], item["name"], item["branch"]))
+        summary = {
+            "total": len(compared),
+            "up_to_date": sum(1 for item in compared if item["status"] == "up_to_date"),
+            "outdated": sum(1 for item in compared if item["status"] == "outdated"),
+            "error": sum(1 for item in compared if item["status"] == "error"),
+        }
+        return {"summary": summary, "apps": compared}
+
+    @staticmethod
+    def _force_refresh(cache: RegistryCache) -> None:
+        # Fetch and hard-reset to remote HEAD so every JSON file is refreshed now.
+        run_command(["git", "-C", str(cache.path), "fetch", "--depth", "1", "origin", "HEAD"])
+        run_command(["git", "-C", str(cache.path), "reset", "--hard", "FETCH_HEAD"])
+
+    @staticmethod
+    def _release_rows(cache: RegistryCache, apps: list[dict]) -> list[dict]:
+        rows: list[dict] = []
+        for app in apps:
+            name = app.get("name")
+            repo = app.get("repo", "")
+            if not name or not repo:
+                continue
+            releases = cache.releases(name)
+            seen_branches: set[str] = set()
+            for release in releases:
+                if release.get("channel") != "stable":
+                    continue
+                branch = (release.get("branch") or "").strip()
+                commit = (release.get("commit") or "").strip()
+                if not branch or not commit or branch in seen_branches:
+                    continue
+                seen_branches.add(branch)
+                rows.append(
+                    {
+                        "name": name,
+                        "repo": repo,
+                        "branch": branch,
+                        "marketplace_version": release.get("version") or "",
+                        "marketplace_commit": commit,
+                    }
+                )
+        return rows
+
+    def _compare_row(self, row: dict) -> dict:
+        head, error = self._github_branch_head(row["repo"], row["branch"])
+        status = "error"
+        if not error:
+            status = "up_to_date" if head == row["marketplace_commit"] else "outdated"
+        return {
+            **row,
+            "github_head": head,
+            "status": status,
+            "error": error,
+        }
+
+    @staticmethod
+    def _github_branch_head(repo_url: str, branch: str) -> tuple[str, str]:
+        try:
+            owner, repo = parse_github_owner_repo(repo_url)
+        except Exception:
+            return "", "non_github_repo"
+
+        remote = f"https://github.com/{owner}/{repo}"
+        ref = f"refs/heads/{branch}"
+        try:
+            result = run_command(["git", "ls-remote", remote, ref], timeout=20)
+        except Exception:
+            return "", "ls_remote_failed"
+
+        stdout = result.stdout.decode().strip().splitlines()
+        if not stdout:
+            return "", "branch_not_found"
+
+        sha = stdout[0].split("\t", 1)[0].strip()
+        if not sha:
+            return "", "branch_not_found"
+        return sha, ""

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -61,6 +61,14 @@ Task-starting endpoints should return:
 
 `GET /git/branches?repo=...` runs local `git ls-remote --heads`, so Git must be available on the Pilot host. It returns all remote branch names and puts the remote default first.
 
+### Updates
+
+`GET /app-updates` and `POST /app-update-checks` compare installed bench apps against each app's tracked git remote branch.
+
+`GET /marketplace-github-updates` and `POST /marketplace-github-update-checks` compare marketplace stable release commits against live GitHub branch heads for all marketplace apps.
+
+The POST variant forces a fresh pull of the marketplace registry cache before comparing.
+
 ### Site Apps
 
 `GET /sites/<name>/apps` returns the apps in use on the site, disabled ones excluded, plus `can_disable` for whether this bench's Frappe supports disabling at all.

--- a/scripts/compare-marketplace-vs-github.py
+++ b/scripts/compare-marketplace-vs-github.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Compare marketplace stable release commits to live GitHub branch heads.
+
+Usage:
+  ./scripts/compare-marketplace-vs-github.py
+  ./scripts/compare-marketplace-vs-github.py /home/frappe/pilot
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+
+def parse_owner_repo(url: str) -> tuple[str, str] | None:
+    raw = url.strip().rstrip("/")
+    if raw.endswith(".git"):
+        raw = raw[:-4]
+    prefixes = (
+        "https://github.com/",
+        "http://github.com/",
+        "git@github.com:",
+    )
+    path = ""
+    for prefix in prefixes:
+        if raw.startswith(prefix):
+            path = raw[len(prefix) :]
+            break
+    if not path:
+        return None
+    parts = [p for p in path.split("/") if p]
+    if len(parts) < 2:
+        return None
+    return parts[0], parts[1]
+
+
+def github_branch_head(repo_url: str, branch: str) -> tuple[str, str]:
+    parsed = parse_owner_repo(repo_url)
+    if not parsed:
+        return "", "non_github_repo"
+    owner, repo = parsed
+    ref = f"refs/heads/{branch}"
+    cmd = ["git", "ls-remote", f"https://github.com/{owner}/{repo}", ref]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=20, check=False)
+    except subprocess.SubprocessError:
+        return "", "ls_remote_failed"
+    if result.returncode != 0:
+        return "", "ls_remote_failed"
+    lines = result.stdout.strip().splitlines()
+    if not lines:
+        return "", "branch_not_found"
+    return lines[0].split("\t")[0].strip(), ""
+
+
+def load_rows(cache_root: Path) -> list[dict]:
+    apps_index = json.loads((cache_root / "apps.json").read_text())
+    rows: list[dict] = []
+    for app in apps_index:
+        name = app.get("name")
+        repo = app.get("repo", "")
+        rel_file = app.get("releases", "")
+        if not name or not repo or not rel_file:
+            continue
+        payload = json.loads((cache_root / rel_file).read_text())
+        releases = payload.get("releases", [])
+
+        # Keep newest stable entry per branch for each app.
+        seen_branches: set[str] = set()
+        for rel in releases:
+            if rel.get("channel") != "stable":
+                continue
+            branch = rel.get("branch") or ""
+            commit = rel.get("commit") or ""
+            if not branch or not commit or branch in seen_branches:
+                continue
+            seen_branches.add(branch)
+            rows.append(
+                {
+                    "name": name,
+                    "repo": repo,
+                    "branch": branch,
+                    "marketplace_version": rel.get("version", ""),
+                    "marketplace_commit": commit,
+                }
+            )
+    return rows
+
+
+def compare_row(row: dict) -> dict:
+    github_head, error = github_branch_head(row["repo"], row["branch"])
+    status = "error"
+    if not error:
+        status = "up_to_date" if github_head == row["marketplace_commit"] else "outdated"
+    return {
+        **row,
+        "github_head": github_head,
+        "status": status,
+        "error": error,
+    }
+
+
+def main() -> int:
+    pilot_root = Path(sys.argv[1] if len(sys.argv) > 1 else "/home/frappe/pilot")
+    cache_root = pilot_root / "system" / "registry-cache"
+    if not (cache_root / "apps.json").exists():
+        print(f"apps.json not found under {cache_root}", file=sys.stderr)
+        return 1
+
+    rows = load_rows(cache_root)
+    results: list[dict] = []
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        futures = [pool.submit(compare_row, row) for row in rows]
+        for future in as_completed(futures):
+            results.append(future.result())
+
+    results.sort(key=lambda item: (item["status"], item["name"], item["branch"]))
+    summary = {
+        "total_stable_branch_entries_checked": len(results),
+        "up_to_date": sum(1 for r in results if r["status"] == "up_to_date"),
+        "outdated": sum(1 for r in results if r["status"] == "outdated"),
+        "error": sum(1 for r in results if r["status"] == "error"),
+    }
+
+    report_path = cache_root / "marketplace-vs-github-report.json"
+    report_path.write_text(json.dumps({"summary": summary, "results": results}, indent=2))
+
+    print(json.dumps(summary, indent=2))
+    print(f"report: {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update-marketplace-cache.sh
+++ b/scripts/update-marketplace-cache.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PILOT_ROOT="${1:-/home/frappe/pilot}"
+CACHE_DIR="$PILOT_ROOT/system/registry-cache"
+
+if [[ ! -d "$CACHE_DIR/.git" ]]; then
+  echo "registry cache not found at: $CACHE_DIR" >&2
+  exit 1
+fi
+
+cd "$CACHE_DIR"
+
+echo "[1/3] Fetch latest registry from GitHub..."
+git fetch --depth=1 origin HEAD
+
+echo "[2/3] Reset local cache to fetched HEAD..."
+git reset --hard FETCH_HEAD
+
+echo "[3/3] Verify local == remote..."
+local_sha="$(git rev-parse HEAD)"
+remote_sha="$(git ls-remote https://github.com/frappe/marketplace HEAD | awk '{print $1}')"
+
+echo "local:  $local_sha"
+echo "remote: $remote_sha"
+
+if [[ "$local_sha" != "$remote_sha" ]]; then
+  echo "warning: local cache does not match remote HEAD (network lag or mirror delay)" >&2
+  exit 2
+fi
+
+echo "marketplace cache is up to date"

--- a/tests/admin/backend/api/test_apps_view.py
+++ b/tests/admin/backend/api/test_apps_view.py
@@ -268,3 +268,48 @@ def test_app_update_checks_fetches_each_cloned_app(tmp_path: Path) -> None:
     assert response.status_code == 200
     assert response.get_json() == {"apps": [{"name": "suite"}]}
     repo.fetch.assert_called_once_with("develop", timeout=60)
+
+
+def test_marketplace_github_updates_reads_without_refresh(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    client = _client(bench_root)
+    checker = Mock()
+    checker.check.return_value = {"summary": {"total": 1}, "apps": [{"name": "suite"}]}
+
+    with patch("admin.backend.api.v1.updates.MarketplaceGitHubUpdates", return_value=checker):
+        response = client.get("/api/v1/marketplace-github-updates")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"summary": {"total": 1}, "apps": [{"name": "suite"}]}
+    checker.check.assert_called_once_with(refresh=False)
+
+
+def test_marketplace_github_update_checks_forces_refresh(tmp_path: Path) -> None:
+    bench_root = tmp_path / "benches" / "current"
+    client = _client(bench_root)
+    checker = Mock()
+    checker.check.return_value = {"summary": {"total": 1}, "apps": [{"name": "suite"}]}
+
+    with patch("admin.backend.api.v1.updates.MarketplaceGitHubUpdates", return_value=checker):
+        response = client.post("/api/v1/marketplace-github-update-checks")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"summary": {"total": 1}, "apps": [{"name": "suite"}]}
+    checker.check.assert_called_once_with(refresh=True)
+
+
+def test_marketplace_github_updates_reports_registry_unavailable(tmp_path: Path) -> None:
+    from pilot.exceptions import RegistryUnavailableError
+
+    bench_root = tmp_path / "benches" / "current"
+    client = _client(bench_root)
+    checker = Mock()
+    checker.check.side_effect = RegistryUnavailableError("registry cache is unusable")
+
+    with patch("admin.backend.api.v1.updates.MarketplaceGitHubUpdates", return_value=checker):
+        response = client.get("/api/v1/marketplace-github-updates")
+
+    assert response.status_code == 503
+    body = response.get_json()["error"]
+    assert body["code"] == "registry_unavailable"
+    assert "unusable" in body["message"]


### PR DESCRIPTION
## Summary
- add marketplace-wide update check endpoint that compares stable marketplace release commits with live GitHub branch heads
- keep existing installed-app update checks unchanged
- add provider module for GitHub comparison logic and report shape
- add utility scripts to refresh marketplace cache and run full marketplace-vs-GitHub comparison
- document API behavior and add tests

## Why
The current updates flow reports update status for apps installed in a bench. It does not report whether the marketplace catalog itself is behind GitHub branch heads. This change adds a direct catalog freshness check.

## API Additions
- `GET /updates/marketplace-vs-github`
- `POST /updates/marketplace-vs-github-checks`

## Validation
- `uv sync --extra admin --extra test`
- `uv run pytest tests/admin/backend/api/test_apps_view.py -q`
- Result: `20 passed`
