### PR TITLE
fix: handle out-of-sync Yarn lockfiles during app install

### DIFF
--- a/pilot/managers/python_assets.py
+++ b/pilot/managers/python_assets.py
@@ -87,11 +87,23 @@ class PythonAssetBuilder:
         app_name = path.name
         print(f"  Installing JS dependencies for {app_name}...")
         sys.stdout.flush()
-        run_command(
-            [get_yarn_bin(), "install", "--frozen-lockfile"],
-            cwd=path,
-            stream_output=True,
-        )
+        try:
+            run_command(
+                [get_yarn_bin(), "install", "--frozen-lockfile"],
+                cwd=path,
+                stream_output=True,
+            )
+        except Exception:
+            print(
+                f"  Frozen lockfile install failed for {app_name}; "
+                "retrying without modifying yarn.lock..."
+            )
+            sys.stdout.flush()
+            run_command(
+                [get_yarn_bin(), "install", "--pure-lockfile"],
+                cwd=path,
+                stream_output=True,
+            )
 
     def try_download_prebuilt_assets(
         self,

--- a/tests/pilot/managers/test_python_assets.py
+++ b/tests/pilot/managers/test_python_assets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +14,11 @@ def make_app(app_path: Path, name: str = "gameplan") -> MagicMock:
     app.path = app_path
     app.config.name = name
     return app
+
+
+def make_builder() -> PythonAssetBuilder:
+    manager = MagicMock()
+    return PythonAssetBuilder(manager)
 
 
 def test_build_assets_for_app_installs_js_deps_before_frappe_build_runs(tmp_path: Path) -> None:
@@ -45,3 +51,55 @@ def test_build_assets_for_app_installs_js_deps_before_frappe_build_runs(tmp_path
         builder.build_assets_for_app(make_app(app_path))
 
     assert events.index("ensure_yarn_install:frontend") < events.index("run_command")
+
+
+def test_ensure_yarn_install_uses_frozen_lockfile_first(tmp_path: Path) -> None:
+    """A healthy lockfile should keep the reproducible frozen install path."""
+    (tmp_path / "yarn.lock").write_text("lockfile")
+
+    with (
+        patch("pilot.managers.python_assets.get_yarn_bin", return_value="yarn"),
+        patch("pilot.managers.python_assets.run_command") as run_command,
+    ):
+        make_builder().ensure_yarn_install(tmp_path)
+
+    run_command.assert_called_once_with(
+        ["yarn", "install", "--frozen-lockfile"],
+        cwd=tmp_path,
+        stream_output=True,
+    )
+
+
+def test_ensure_yarn_install_falls_back_to_pure_lockfile(tmp_path: Path) -> None:
+    """An out-of-sync lockfile should retry without modifying yarn.lock."""
+    (tmp_path / "yarn.lock").write_text("lockfile")
+
+    with (
+        patch("pilot.managers.python_assets.get_yarn_bin", return_value="yarn"),
+        patch(
+            "pilot.managers.python_assets.run_command",
+            side_effect=[RuntimeError("lockfile needs update"), None],
+        ) as run_command,
+    ):
+        make_builder().ensure_yarn_install(tmp_path)
+
+    assert run_command.call_count == 2
+    assert run_command.call_args_list[0].args[0] == ["yarn", "install", "--frozen-lockfile"]
+    assert run_command.call_args_list[1].args[0] == ["yarn", "install", "--pure-lockfile"]
+    assert run_command.call_args_list[1].kwargs == {"cwd": tmp_path, "stream_output": True}
+
+
+def test_ensure_yarn_install_skips_when_integrity_is_current(tmp_path: Path) -> None:
+    """Do not reinstall when node_modules integrity is newer than yarn.lock."""
+    lock = tmp_path / "yarn.lock"
+    integrity = tmp_path / "node_modules" / ".yarn-integrity"
+    integrity.parent.mkdir()
+    lock.write_text("lockfile")
+    integrity.write_text("integrity")
+    os.utime(lock, (1, 1))
+    os.utime(integrity, (2, 2))
+
+    with patch("pilot.managers.python_assets.run_command") as run_command:
+        make_builder().ensure_yarn_install(tmp_path)
+
+    run_command.assert_not_called()


### PR DESCRIPTION
Fixes: https://github.com/frappe/pilot/issues/341

## Summary

Pilot currently installs app JS dependencies with `yarn install --frozen-lockfile`. Apps such as `frappe/crm` can fail installation when their `package.json` requires a lockfile update.

This change keeps the frozen install as the preferred path and, if it fails, retries with `yarn install --pure-lockfile` so dependencies can be resolved without modifying the checked-in `yarn.lock`.

## Testing

Added unit coverage for:
- dependency installation occurring before the Frappe asset build
- successful `--frozen-lockfile` installation remaining the default path
- fallback to `--pure-lockfile` when the frozen install fails
- skipping Yarn installation when `.yarn-integrity` is newer than `yarn.lock`

The original failure can be reproduced by installing CRM at commit `966705a9`, which previously failed with `Your lockfile needs to be updated, but yarn was run with --frozen-lockfile`.

Tests were added to the existing `tests/pilot/managers/test_python_assets.py` test module.