### PR TITLE
feat(admin): hide Central surfaces on a self-hosted bench

### DIFF
--- a/admin/backend/api/v1/core.py
+++ b/admin/backend/api/v1/core.py
@@ -67,6 +67,7 @@ def bootstrap():
                 "production": config.production.enabled,
                 "native_process_manager": native_process_manager(),
                 "allow_bench_management": config.admin.allow_bench_management,
+                "central": config.central.enabled,
                 "developer_mode": config.allow_developer_mode,
                 "task_worker": TaskActivityReader(bench_root).read().public_dict,
             },

--- a/admin/frontend/dashboard/src/components/navigation/useAppMenu.ts
+++ b/admin/frontend/dashboard/src/components/navigation/useAppMenu.ts
@@ -21,10 +21,8 @@ export const useAppMenu = () => {
   }
 
   const menuItems = computed(() => [
-    {
-      label: 'Central',
-      icon: 'lucide-cloud',
-    },
+    // Nothing behind it on a self-hosted bench.
+    ...(session.centralEnabled ? [{ label: 'Central', icon: 'lucide-cloud' }] : []),
     {
       label: 'Settings',
       icon: 'lucide-settings',

--- a/admin/frontend/dashboard/src/components/navigation/useAppMenu.ts
+++ b/admin/frontend/dashboard/src/components/navigation/useAppMenu.ts
@@ -21,7 +21,6 @@ export const useAppMenu = () => {
   }
 
   const menuItems = computed(() => [
-    // Nothing behind it on a self-hosted bench.
     ...(session.centralEnabled ? [{ label: 'Central', icon: 'lucide-cloud' }] : []),
     {
       label: 'Settings',

--- a/admin/frontend/dashboard/src/components/settings/Notifications.vue
+++ b/admin/frontend/dashboard/src/components/settings/Notifications.vue
@@ -5,6 +5,9 @@ import { apiErrorMessage } from '@/api/client'
 import { settingsApi } from '@/api/settings'
 import EmptyState from '@/components/common/EmptyState.vue'
 import SettingsSwitch from '@/components/settings/SettingsSwitch.vue'
+import { useSession } from '@/composables/auth/useSession'
+
+const { session } = useSession()
 
 // Every resource alert starts off; site uptime is the only one on by default.
 const RESOURCE_ALERTS = [
@@ -260,7 +263,8 @@ onMounted(async () => {
         </div>
 
         <p class="text-ink-gray-5 text-p-sm">
-          Alerts go to Central. Endpoints listed here receive them too, as a POST carrying an
+          <template v-if="session.centralEnabled">Alerts go to Central. Endpoints listed here receive them too, as a POST carrying an</template>
+          <template v-else>Endpoints listed here receive alerts as a POST carrying an</template>
           <code>Authorization: Bearer</code>
           header, so the token stays out of the URL.
         </p>
@@ -270,7 +274,11 @@ onMounted(async () => {
           v-if="!webhooks.length"
           icon="lucide-webhook"
           title="No webhook endpoints"
-          description="Alerts are only reported to Central. Add an endpoint to receive them yourself."
+          :description="
+            session.centralEnabled
+              ? 'Alerts are only reported to Central. Add an endpoint to receive them yourself.'
+              : 'Nothing receives alerts yet. Add an endpoint to receive them.'
+          "
         />
 
         <div v-else class="space-y-3">

--- a/admin/frontend/dashboard/src/composables/auth/useSession.ts
+++ b/admin/frontend/dashboard/src/composables/auth/useSession.ts
@@ -11,6 +11,7 @@ const session = reactive({
   benchName: '',
   allowBenchManagement: false,
   developerMode: false,
+  centralEnabled: false,
 })
 
 const loadSession = async () => {
@@ -23,6 +24,7 @@ const loadSession = async () => {
     session.benchName = bootstrap.name || ''
     session.allowBenchManagement = bootstrap.allow_bench_management === true
     session.developerMode = bootstrap.developer_mode === true
+    session.centralEnabled = bootstrap.central === true
   } catch {
     session.authenticated = false
     session.wizard = false
@@ -31,6 +33,7 @@ const loadSession = async () => {
     session.benchName = ''
     session.allowBenchManagement = false
     session.developerMode = false
+    session.centralEnabled = false
   }
   session.loaded = true
 }

--- a/admin/frontend/dashboard/src/pages/settings/Settings.vue
+++ b/admin/frontend/dashboard/src/pages/settings/Settings.vue
@@ -44,7 +44,10 @@ const themeOptions = [
     <div
       class="flex flex-col divide-y divide-outline-gray-1 rounded-6 border border-outline-gray-1"
     >
-      <div class="flex items-center gap-3 px-3 py-2.5  text-ink-gray-8">
+      <div
+        v-if="session.centralEnabled"
+        class="flex items-center gap-3 px-3 py-2.5  text-ink-gray-8"
+      >
         <span class="size-4 text-ink-gray-6 lucide-cloud" />
         Central
       </div>

--- a/admin/frontend/dashboard/src/pages/storage/Storage.vue
+++ b/admin/frontend/dashboard/src/pages/storage/Storage.vue
@@ -6,11 +6,14 @@ import FCLogo from '@/components/icons/FC.vue'
 import AppStorageCard from '@/components/storage/AppStorageCard.vue'
 import DBStorageCard from '@/components/storage/DatabaseStorageCard.vue'
 
+import { useSession } from '@/composables/auth/useSession'
+
 import { apiErrorMessage } from '@/api/client'
 import { monitorApi } from '@/api/monitor'
 import type { StorageBreakdown } from '@/types/storage'
 import { formatBytes } from '@/utils/format'
 
+const { session } = useSession()
 const storageData = ref<StorageBreakdown | null>(null)
 const loading = ref(false)
 const error = ref('')
@@ -55,7 +58,9 @@ onMounted(load)
         @click="load"
       />
 
-      <Button :iconLeft="h(FCLogo, { class: 'size-4' })"> Manage Storage </Button>
+      <Button v-if="session.centralEnabled" :iconLeft="h(FCLogo, { class: 'size-4' })">
+        Manage Storage
+      </Button>
     </div>
 
     <div

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -214,7 +214,7 @@ Datum sends collected metrics only when both endpoint and token are set and the 
 
 `[resource_limits]` sets when an alert is raised and where it goes. A usage percentage of `0` disables that alert; `site_uptime` covers sites that stop answering their ping. A condition must hold for five minutes before anything is sent.
 
-Alerts always go to Central. Each entry in `webhook_endpoints` receives them too, as a POST with an `Authorization: Bearer` header. Mail is a third sink, off until a mail server is configured and `email_recipients` is set.
+Where an alert goes depends on what is configured. A Central-managed host reports every alert to Central; a self-hosted one does not, and the dashboard drops the Central wording along with it. Each entry in `webhook_endpoints` receives alerts either way, as a POST with an `Authorization: Bearer` header. Mail is a third sink, off until a mail server is configured and `email_recipients` is set.
 
 Outgoing mail lives in the bench's `sites/common_site_config.json`, under the keys the framework's Email Account already reads, so a site picks the same mailbox up without any further setup:
 

--- a/pilot/core/alerts.py
+++ b/pilot/core/alerts.py
@@ -174,6 +174,9 @@ def notify(bench: "Bench", payload: dict[str, typing.Any]) -> bool:
         else:
             delivered = True
 
+    if not bench.config.central.enabled:
+        return delivered
+
     try:
         CentralClient().notify_central(**payload)
     except CentralClientError:

--- a/tests/admin/backend/test_admin_session.py
+++ b/tests/admin/backend/test_admin_session.py
@@ -1296,3 +1296,24 @@ def test_discarding_an_unknown_jti_does_not_rewrite(tmp_path: Path) -> None:
     ActiveTokens(bench).discard("never-existed")
 
     assert path.stat().st_mtime_ns == before
+
+
+def test_bootstrap_tells_the_ui_central_is_off_by_default(tmp_path: Path) -> None:
+    """The dashboard hides its Central surfaces on a self-hosted bench, so it has
+    to be told which one this is."""
+    client = _signed_in_client(tmp_path)
+
+    assert client.get("/api/v1/bootstrap").get_json()["central"] is False
+
+
+def test_bootstrap_reports_central_when_it_is_managed(tmp_path: Path) -> None:
+    from pilot.config.common import CommonConfig
+
+    client = _signed_in_client(tmp_path)
+    with CommonConfig.open(tmp_path / "benches") as common:
+        # Enabled but not yet bootstrapped is the pending screen, which tells the
+        # caller nothing else - this is a host already configured.
+        common.central.enabled = True
+        common.central.bootstrapped = True
+
+    assert client.get("/api/v1/bootstrap").get_json()["central"] is True

--- a/tests/admin/backend/test_admin_session.py
+++ b/tests/admin/backend/test_admin_session.py
@@ -1311,8 +1311,7 @@ def test_bootstrap_reports_central_when_it_is_managed(tmp_path: Path) -> None:
 
     client = _signed_in_client(tmp_path)
     with CommonConfig.open(tmp_path / "benches") as common:
-        # Enabled but not yet bootstrapped is the pending screen, which tells the
-        # caller nothing else - this is a host already configured.
+        # Enabled but not bootstrapped is the pending screen, which says nothing else.
         common.central.enabled = True
         common.central.bootstrapped = True
 

--- a/tests/pilot/core/test_alert_mail.py
+++ b/tests/pilot/core/test_alert_mail.py
@@ -359,3 +359,32 @@ def test_a_damaged_site_config_reads_as_no_mailbox(tmp_path: Path) -> None:
     (tmp_path / "common_site_config.json").write_text("{ truncated")
 
     assert MailConfig.read(tmp_path).is_configured is False
+
+
+def test_alerts_skip_central_on_a_self_hosted_bench(tmp_path: Path) -> None:
+    """Nothing to report to, and asking would read instance metadata per alert."""
+    from unittest.mock import patch
+
+    from pilot.core import alerts
+
+    bench = _bench(tmp_path, MailConfig())
+    bench.config.central.enabled = False
+
+    with patch.object(alerts, "CentralClient") as client:
+        alerts.notify(bench, {"event": "cpu", "message": "high", "context": {}})
+
+    client.assert_not_called()
+
+
+def test_alerts_reach_central_when_it_is_managed(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    from pilot.core import alerts
+
+    bench = _bench(tmp_path, MailConfig())
+    bench.config.central.enabled = True
+
+    with patch.object(alerts, "CentralClient") as client:
+        assert alerts.notify(bench, {"event": "cpu", "message": "high", "context": {}}) is True
+
+    client.return_value.notify_central.assert_called_once()


### PR DESCRIPTION
The dashboard showed Central-only surfaces on every bench: a "Central" menu item and settings header with nothing behind them, a "Manage Storage" button that leads to Central, and alert copy claiming "Alerts go to Central". A self-hosted bench now shows none of it.

`/api/v1/bootstrap` reports `central` to an authenticated caller, and the dashboard gates on it. Alerts also stop calling Central when it is disabled — the call could only fail, after a metadata read per alert.

Nothing changes on a Central-managed host.