### PR TITLE
fix: raise the descriptor limit on bench units

### DIFF
--- a/docs/production.md
+++ b/docs/production.md
@@ -37,6 +37,10 @@ A new bench deploys one bench process plus admin and the two redis servers, beca
 `[lite_mode] enabled` is the default. Turn lite mode off and the set becomes web,
 socketio, admin, workers, and redis - see [Lite Mode](configuration.md#lite-mode).
 
+Each workload unit sets `LimitNOFILE=65535`. A systemd user unit gets 1024
+descriptors by default, which is too few for a lite-mode bench process and for
+redis under load.
+
 Runtime commands:
 
 - `pilot start`

--- a/pilot/managers/processes/systemd_render.py
+++ b/pilot/managers/processes/systemd_render.py
@@ -23,6 +23,9 @@ class SystemdRenderer(ServiceRenderer):
             f"{working_dir}{env}"
             f"ExecStart={shlex.join(pd.argv)}\n"
             f"Restart=on-failure\n"
+            # A user unit gets 1024 descriptors by default. That is too few for a
+            # long-lived process that re-execs itself, and for redis under load.
+            f"LimitNOFILE=65535\n"
             f"{stop}"
             f"StandardOutput=append:{pd.log_file}\n"
             f"StandardError=append:{pd.log_file}.error.log\n"

--- a/pilot/managers/processes/systemd_render.py
+++ b/pilot/managers/processes/systemd_render.py
@@ -23,8 +23,6 @@ class SystemdRenderer(ServiceRenderer):
             f"{working_dir}{env}"
             f"ExecStart={shlex.join(pd.argv)}\n"
             f"Restart=on-failure\n"
-            # A user unit gets 1024 descriptors by default. That is too few for a
-            # long-lived process that re-execs itself, and for redis under load.
             f"LimitNOFILE=65535\n"
             f"{stop}"
             f"StandardOutput=append:{pd.log_file}\n"

--- a/tests/pilot/managers/test_managers_extra.py
+++ b/tests/pilot/managers/test_managers_extra.py
@@ -365,6 +365,18 @@ def test_systemd_unit_redis_gets_stop_timeout(tmp_path: Path) -> None:
     assert "TimeoutStopSec=300" in unit
 
 
+def test_systemd_unit_raises_descriptor_limit(tmp_path: Path) -> None:
+    """A workload unit gets more descriptors than the default of a user unit."""
+    from pilot.managers.processes.local import ProcessDefinition
+    from pilot.managers.processes.systemd import SystemdRenderer
+
+    pd = ProcessDefinition(
+        name="web", argv=["/env/bin/python", "serve"], log_file=tmp_path / "logs" / "web.log"
+    )
+    unit = SystemdRenderer("test-bench").render(pd)
+    assert "LimitNOFILE=65535" in unit
+
+
 def test_systemd_target_wanted_by_default(tmp_path: Path) -> None:
     from pilot.managers.processes.systemd import SystemdRenderer
 


### PR DESCRIPTION
A systemd user unit gets 1024 file descriptors by default. The lite-mode web process re-execs itself on an idle timer, and each generation inherits one more descriptor that the `ctypes` import leaves open without `O_CLOEXEC`. After about a thousand restarts the process runs out and every request fails with `unable to open database file`.

Sets `LimitNOFILE=65535`, the value the MariaDB unit already uses.

This raises the ceiling; it does not stop the leak. The leak itself is in `frappe.runner`, which re-execs without clearing inherited descriptors.