### PR TITLE
fix: Apply Central credentials during host boot

### DIFF
--- a/admin/backend/central_bootstrap.py
+++ b/admin/backend/central_bootstrap.py
@@ -44,6 +44,7 @@ class CentralBootstrapWatcher:
             return False
 
     def run_until_applied(self) -> None:
+        """Retry until the Central credential is applied."""
         while not self.check_once():
             time.sleep(self.interval)
 

--- a/admin/backend/central_bootstrap.py
+++ b/admin/backend/central_bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import logging
 import threading
 import time
@@ -42,10 +43,12 @@ class CentralBootstrapWatcher:
             logging.exception("Central bootstrap attempt failed")
             return False
 
-    def _watch(self) -> None:
-        # Never backs off: a host waiting on its credential is a signup waiting.
+    def run_until_applied(self) -> None:
         while not self.check_once():
             time.sleep(self.interval)
+
+    def _watch(self) -> None:
+        self.run_until_applied()
         logging.info("Central bootstrap applied; this host is configured.")
 
 
@@ -70,3 +73,25 @@ def install_central_bootstrap_watcher(app: Flask, bench_root: Path) -> CentralBo
     app.extensions["central_bootstrap_watcher"] = watcher
     watcher.install(app)
     return watcher
+
+
+def main() -> None:
+    """Apply the Central credential at boot."""
+    parser = argparse.ArgumentParser(description="Apply this host's Central credential.")
+    parser.add_argument("--bench-root", required=True, type=Path, help="Path of the bench directory.")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    from pilot.config import BenchConfig
+
+    config = BenchConfig.read(args.bench_root, validate=False)
+    if not config.central.is_awaiting_bootstrap:
+        logging.info("This host is not awaiting a Central credential.")
+        return
+
+    CentralBootstrapWatcher(args.bench_root).run_until_applied()
+    logging.info("Central bootstrap applied; this host is configured.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/production.md
+++ b/docs/production.md
@@ -76,6 +76,7 @@ Firewall and WAF config are bench settings. Settings apply code should delegate 
 ## Operational Notes
 
 - Production changes may need non-interactive sudo.
+- Central-enabled systemd benches retry the metadata credential at boot until it is applied.
 - Generated config belongs under the bench `config/` directory or system config locations managed by the relevant manager.
 - Logs should remain available after production removal.
 - Database services are selected by `bench.db_type` and configured in `bench.toml`.

--- a/install.sh
+++ b/install.sh
@@ -263,8 +263,8 @@ install_node() {
 }
 
 # The distro packages auto-start services on their default ports. Benches run
-# their own instances, so free the ports and the memory right away. nginx is
-# started by `pilot setup production`, which a sudoers grant already allows.
+# their own instances, so free the ports and the memory right away. `pilot setup
+# production` starts nginx and enables it at boot, which a sudoers grant allows.
 disable_system_services() {
     case "$DISTRO" in
         macos|unknown) return 0 ;;
@@ -465,7 +465,7 @@ install_sudoers_grants() {
 
     echo "Granting '$1' passwordless sudo for nginx and certbot..."
     write_sudoers_file "$1-pilot-nginx" \
-"$1 ALL=(ALL) NOPASSWD: $nginx_bin -t,$nginx_bin -T,$systemctl_bin start nginx,$systemctl_bin stop nginx,$systemctl_bin reload nginx"
+"$1 ALL=(ALL) NOPASSWD: $nginx_bin -t,$nginx_bin -T,$systemctl_bin start nginx,$systemctl_bin stop nginx,$systemctl_bin reload nginx,$systemctl_bin enable nginx"
     # Domain and email tokens stay wildcarded (sites arrive long after this is
     # written), but each wildcard is anchored between fixed literal text, so no
     # extra flag can be smuggled in before or after the match.

--- a/pilot/core/bench/production.py
+++ b/pilot/core/bench/production.py
@@ -91,6 +91,7 @@ class BenchProduction:
         nginx_manager.generate_config(ssl_ready=True)
         nginx_manager.install_config()
         nginx_manager.setup_sudoers()
+        nginx_manager.enable_at_boot()
         self._report_site_urls(nginx_manager, on_progress)
 
     def setup_letsencrypt(self) -> None:

--- a/pilot/managers/nginx/__init__.py
+++ b/pilot/managers/nginx/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import logging
 import pwd
 import re
 import shutil
@@ -20,6 +21,7 @@ from pilot.managers.platform import (
     default_nginx_config_dir,
     is_linux,
     service_command,
+    service_enable_command,
     service_running,
     which,
 )
@@ -176,6 +178,7 @@ class NginxConfigRenderer:
             redirect=f"{scheme}://{mapping.target}" if mapping.redirect else "",
             proxy_pass=f"http://bench-{self.bench.config.name}",
             site=site.name,
+            public_root=f"{self.bench.path}/sites/{site.name}/public",
         )
 
     def generate_server_config(self, error_dir: Path) -> str:
@@ -299,6 +302,7 @@ class NginxManager:
                 f"{systemctl} start nginx",
                 f"{systemctl} stop nginx",
                 f"{systemctl} reload nginx",
+                f"{systemctl} enable nginx",
             ],
         )
 
@@ -424,6 +428,21 @@ class NginxManager:
             self._ensure_modsecurity_module()
         self.install_default_server()
         self._reload_or_rollback(symlink_path)
+
+    def enable_at_boot(self) -> None:
+        """A reboot must bring nginx back, or the host serves nothing.
+
+        The distro package is disabled at install time to free port 80, so
+        production setup owns the enabled state. A host installed before the
+        grant carried the enable verb keeps its running nginx, and the failure
+        is reported rather than ending the deploy.
+        """
+        if not is_linux():
+            return
+        try:
+            run_command(service_enable_command("nginx"))
+        except CommandError as error:
+            logging.warning("Could not enable nginx at boot: %s", error)
 
     def _stage_and_copy(self, content: str, target: Path, validate: list[str] | None = None) -> None:
         """Sudo-copy content into a root-owned target via a bench-owned staging file."""

--- a/pilot/managers/nginx/templates/bench.conf.template
+++ b/pilot/managers/nginx/templates/bench.conf.template
@@ -20,6 +20,32 @@ server {
         return 301 {{ alias.redirect }}$request_uri;
     }
     {% else %}
+    {% if alias.site %}
+    root {{ sites_root }};
+    client_max_body_size {{ client_max_body_size }};
+
+    location /assets {
+        try_files $uri =404;
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location ~ ^/files/.*\.(jpg|jpeg|png|gif|svg|webp|pdf|docx?|xlsx?)$ {
+        root {{ alias.public_root }};
+        try_files $uri =404;
+    }
+
+    location /socket.io {
+        proxy_pass         http://127.0.0.1:{{ socketio_port }};
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_set_header   X-Frappe-Site-Name {{ alias.site }};
+        proxy_set_header   Origin $scheme://$http_host;
+        proxy_set_header   Host $host;
+    }
+
+    {% endif %}
     location / {
         proxy_pass         {{ alias.proxy_pass }};
         proxy_read_timeout 120;

--- a/pilot/managers/processes/systemd.py
+++ b/pilot/managers/processes/systemd.py
@@ -58,6 +58,14 @@ class SystemdProcessManager(SystemdUserMixin, ManagedProcessManager):
                 (self.systemd_conf_dir / self._unit_name(pd.name)).write_text(renderer.render(pd))
                 workload_units.append(self._unit_name(pd.name))
         (self.systemd_conf_dir / self._target_name()).write_text(renderer.render_target(workload_units))
+        if self.bench.config.central.enabled:
+            (self.systemd_conf_dir / self._central_bootstrap_name()).write_text(
+                renderer.render_central_bootstrap(
+                    str(AdminEnvManager(cli_root()).python),
+                    str(self.bench.path),
+                    str(self.bench.logs_path / "central-bootstrap.log"),
+                )
+            )
         self.admin_units_changed = self._admin_unit_text() != admin_units_before
 
     def _admin_unit_text(self) -> list[str]:
@@ -72,10 +80,11 @@ class SystemdProcessManager(SystemdUserMixin, ManagedProcessManager):
 
         self.user_unit_dir.mkdir(parents=True, exist_ok=True)
         defs = self._prod_process_definitions()
-        units = set(self._unit_name(pd.name) for pd in defs) | {
-            self._target_name(),
-            self._admin_socket_name(),
-        }
+        units = (
+            set(self._unit_name(pd.name) for pd in defs)
+            | {self._target_name(), self._admin_socket_name()}
+            | self._central_bootstrap_units()
+        )
 
         # Stop dropped units so they release ports before relinking.
         self._reap_stale_units(units)
@@ -104,6 +113,7 @@ class SystemdProcessManager(SystemdUserMixin, ManagedProcessManager):
         # reset-failed clears rate-limit state so re-deploys can restart the admin socket.
         subprocess.run(self._systemctl("reset-failed", *units), capture_output=True, env=env)
         run_command(self._systemctl("enable", self._target_name()), env=env)
+        self._enable_central_bootstrap(env)
         # Re-activating admin costs a graceful gunicorn stop; a workload-only change
         # must not pay for it.
         if self.admin_units_changed or not self.are_units_running(UnitGroup.ADMIN):
@@ -202,6 +212,18 @@ class SystemdProcessManager(SystemdUserMixin, ManagedProcessManager):
 
     def _unit_name(self, service_name: str) -> str:
         return f"{self.bench.config.name}-{service_name}.service"
+
+    def _central_bootstrap_name(self) -> str:
+        return f"{self.bench.config.name}-central-bootstrap.service"
+
+    def _central_bootstrap_units(self) -> set[str]:
+        if not self.bench.config.central.enabled:
+            return set()
+        return {self._central_bootstrap_name()}
+
+    def _enable_central_bootstrap(self, env: dict) -> None:
+        for unit in self._central_bootstrap_units():
+            run_command(self._systemctl("enable", "--now", unit), env=env)
 
     def _admin_socket_name(self) -> str:
         return f"{self.bench.config.name}-admin.socket"

--- a/pilot/managers/processes/systemd.py
+++ b/pilot/managers/processes/systemd.py
@@ -62,6 +62,7 @@ class SystemdProcessManager(SystemdUserMixin, ManagedProcessManager):
             (self.systemd_conf_dir / self._central_bootstrap_name()).write_text(
                 renderer.render_central_bootstrap(
                     str(AdminEnvManager(cli_root()).python),
+                    str(cli_root()),
                     str(self.bench.path),
                     str(self.bench.logs_path / "central-bootstrap.log"),
                 )

--- a/pilot/managers/processes/systemd_render.py
+++ b/pilot/managers/processes/systemd_render.py
@@ -63,6 +63,7 @@ class SystemdRenderer(ServiceRenderer):
     def render_central_bootstrap(
         self, python: str, cli_root: str, bench_root: str, log_file: str
     ) -> str:
+        """Render the boot-time Central credential service."""
         return (
             f"[Unit]\n"
             f"Description={self.bench_name} central bootstrap\n\n"

--- a/pilot/managers/processes/systemd_render.py
+++ b/pilot/managers/processes/systemd_render.py
@@ -60,6 +60,21 @@ class SystemdRenderer(ServiceRenderer):
             f"StandardError=append:{pd.log_file}.error.log\n"
         )
 
+    def render_central_bootstrap(self, python: str, bench_root: str, log_file: str) -> str:
+        return (
+            f"[Unit]\n"
+            f"Description={self.bench_name} central bootstrap\n"
+            f"After=network-online.target\n"
+            f"Wants=network-online.target\n\n"
+            f"[Service]\n"
+            f"Type=oneshot\n"
+            f"ExecStart={python} -m admin.backend.central_bootstrap --bench-root {bench_root}\n"
+            f"StandardOutput=append:{log_file}\n"
+            f"StandardError=append:{log_file}.error.log\n\n"
+            f"[Install]\n"
+            f"WantedBy=default.target\n"
+        )
+
     def render_target(self, unit_names: list[str]) -> str:
         return (
             f"[Unit]\n"

--- a/pilot/managers/processes/systemd_render.py
+++ b/pilot/managers/processes/systemd_render.py
@@ -60,15 +60,20 @@ class SystemdRenderer(ServiceRenderer):
             f"StandardError=append:{pd.log_file}.error.log\n"
         )
 
-    def render_central_bootstrap(self, python: str, bench_root: str, log_file: str) -> str:
+    def render_central_bootstrap(
+        self, python: str, cli_root: str, bench_root: str, log_file: str
+    ) -> str:
         return (
             f"[Unit]\n"
-            f"Description={self.bench_name} central bootstrap\n"
-            f"After=network-online.target\n"
-            f"Wants=network-online.target\n\n"
+            f"Description={self.bench_name} central bootstrap\n\n"
             f"[Service]\n"
-            f"Type=oneshot\n"
+            f"Type=simple\n"
+            f"WorkingDirectory={cli_root}\n"
+            f"Environment=PYTHONUNBUFFERED=1\n"
+            f"Environment=PYTHONPATH={cli_root}\n"
             f"ExecStart={python} -m admin.backend.central_bootstrap --bench-root {bench_root}\n"
+            f"Restart=on-failure\n"
+            f"RestartSec=5s\n"
             f"StandardOutput=append:{log_file}\n"
             f"StandardError=append:{log_file}.error.log\n\n"
             f"[Install]\n"

--- a/tests/admin/backend/test_central_bootstrap.py
+++ b/tests/admin/backend/test_central_bootstrap.py
@@ -10,6 +10,7 @@ from flask import Flask
 from admin.backend.central_bootstrap import (
     CentralBootstrapWatcher,
     install_central_bootstrap_watcher,
+    main,
 )
 from pilot.config import BenchConfig
 from pilot.config.common import CommonConfig
@@ -212,3 +213,21 @@ def test_a_config_that_cannot_be_read_at_all_is_reported(tmp_path: Path, caplog)
         assert install_central_bootstrap_watcher(Flask(__name__), bench_root) is None
 
     assert "awaiting a Central credential" in caplog.text
+
+
+def test_boot_run_applies_the_credential(tmp_path: Path) -> None:
+    bench_root = _awaiting_host(tmp_path)
+
+    with _staged(json.dumps(_ATTRIBUTE)), patch("sys.argv", ["central_bootstrap", "--bench-root", str(bench_root)]):
+        main()
+
+    assert BenchConfig.read(bench_root).central.bootstrapped is True
+
+
+def test_boot_run_skips_non_central_hosts(tmp_path: Path) -> None:
+    bench = _bench(tmp_path)
+
+    with _staged(None), patch("sys.argv", ["central_bootstrap", "--bench-root", str(bench.path)]):
+        main()
+
+    assert BenchConfig.read(bench.path).central.bootstrapped is False

--- a/tests/pilot/managers/test_managers_extra.py
+++ b/tests/pilot/managers/test_managers_extra.py
@@ -317,6 +317,23 @@ def test_systemd_unit_renders_working_dir(tmp_path: Path) -> None:
     assert "cd /sites" not in unit
 
 
+def test_central_bootstrap_unit_runs_once_at_boot(tmp_path: Path) -> None:
+    from pilot.managers.processes.systemd import SystemdRenderer
+
+    unit = SystemdRenderer("test-bench").render_central_bootstrap(
+        "/cli/.admin-venv/bin/python",
+        "/home/frappe/pilot/benches/test-bench",
+        str(tmp_path / "logs" / "central-bootstrap.log"),
+    )
+
+    assert "Type=oneshot" in unit
+    assert "WantedBy=default.target" in unit
+    assert (
+        "ExecStart=/cli/.admin-venv/bin/python -m admin.backend.central_bootstrap "
+        "--bench-root /home/frappe/pilot/benches/test-bench" in unit
+    )
+
+
 def test_systemd_unit_renders_env_vars(tmp_path: Path) -> None:
     from pilot.managers.processes.local import ProcessDefinition
     from pilot.managers.processes.systemd import SystemdRenderer

--- a/tests/pilot/managers/test_managers_extra.py
+++ b/tests/pilot/managers/test_managers_extra.py
@@ -322,12 +322,15 @@ def test_central_bootstrap_unit_runs_once_at_boot(tmp_path: Path) -> None:
 
     unit = SystemdRenderer("test-bench").render_central_bootstrap(
         "/cli/.admin-venv/bin/python",
+        "/cli",
         "/home/frappe/pilot/benches/test-bench",
         str(tmp_path / "logs" / "central-bootstrap.log"),
     )
 
-    assert "Type=oneshot" in unit
+    assert "Type=simple" in unit
     assert "WantedBy=default.target" in unit
+    assert "Environment=PYTHONPATH=/cli" in unit
+    assert "WorkingDirectory=/cli" in unit
     assert (
         "ExecStart=/cli/.admin-venv/bin/python -m admin.backend.central_bootstrap "
         "--bench-root /home/frappe/pilot/benches/test-bench" in unit

--- a/tests/pilot/managers/test_nginx_config.py
+++ b/tests/pilot/managers/test_nginx_config.py
@@ -529,7 +529,31 @@ def test_stage_and_copy_validates_staged_file_before_copying(tmp_path: Path) -> 
     assert cp_call[-3:] == ["cp", str(staged), str(target)]
 
 
-def test_setup_sudoers_grants_only_start_stop_reload(tmp_path: Path) -> None:
+def test_production_enables_nginx_at_boot(tmp_path: Path) -> None:
+    """The distro package is disabled at install time, so a reboot needs this."""
+    manager = NginxManager(_make_bench(tmp_path, _BASE_DATA))
+
+    with (
+        patch("pilot.managers.nginx.is_linux", return_value=True),
+        patch("pilot.managers.nginx.run_command") as mock_run,
+    ):
+        manager.enable_at_boot()
+
+    assert mock_run.call_args.args[0][-3:] == ["systemctl", "enable", "nginx"]
+
+
+def test_an_older_sudo_grant_does_not_end_the_deploy(tmp_path: Path) -> None:
+    """A host installed before the grant carried the enable verb keeps deploying."""
+    manager = NginxManager(_make_bench(tmp_path, _BASE_DATA))
+
+    with (
+        patch("pilot.managers.nginx.is_linux", return_value=True),
+        patch("pilot.managers.nginx.run_command", side_effect=CommandError("a password is required")),
+    ):
+        manager.enable_at_boot()
+
+
+def test_setup_sudoers_grants_only_the_needed_nginx_verbs(tmp_path: Path) -> None:
     bench = _make_bench(tmp_path, _BASE_DATA)
     manager = NginxManager(bench)
     sudoers_file = Path("/etc/sudoers.d/runner-pilot-nginx")
@@ -551,7 +575,8 @@ def test_setup_sudoers_grants_only_start_stop_reload(tmp_path: Path) -> None:
     assert "-T," in content
     assert "start nginx," in content
     assert "stop nginx," in content
-    assert content.rstrip().endswith("reload nginx")
+    assert "reload nginx," in content
+    assert content.rstrip().endswith("enable nginx")
     assert "ALL=(ALL) NOPASSWD: ALL" not in content
 
     mock_run.assert_called_once()
@@ -624,6 +649,7 @@ def _cloud_config(
     sites: list[tuple[SiteConfig, bool]],
     central_enabled: bool = True,
     hostname_mappings: dict[str, str] | None = None,
+    redirect: bool = True,
 ) -> str:
     data = copy.deepcopy(_BASE_DATA)
     data["admin"] = {"domain": "admin.example.com"}
@@ -636,6 +662,7 @@ def _cloud_config(
             type="admin" if pattern.startswith(CLOUD_ADMIN_PREFIX) else "site",
             pattern=pattern,
             target=target,
+            redirect=redirect,
         )
         for pattern, target in (hostname_mappings or {}).items()
     ]
@@ -711,6 +738,44 @@ def test_aliases_are_http_only(tmp_path: Path) -> None:
     alias_block = config.split(_SITE_PATTERN)[1].split("}\n\nserver")[0]
     assert "listen 443" not in alias_block
     assert "return 301 https://shop.example.com$request_uri;" in alias_block
+
+
+def _alias_block(config: str) -> str:
+    """The site alias server block, which ends at the unindented closing brace."""
+    return config.split(f"server_name {_SITE_PATTERN};")[1].split("\n}\n")[0]
+
+
+def test_a_serving_alias_serves_static_files(tmp_path: Path) -> None:
+    """An alias that serves the site needs the static locations of a site vhost.
+
+    With only the application upstream, every /assets request reaches gunicorn,
+    which does not serve them.
+    """
+    config = _cloud_config(
+        tmp_path,
+        [(_PLACEHOLDER_SITE, False)],
+        hostname_mappings={_SITE_GLOB: _PLACEHOLDER_SITE.name},
+        redirect=False,
+    )
+
+    alias_block = _alias_block(config)
+    assert f"root {tmp_path}/sites;" in alias_block
+    assert "location /assets" in alias_block
+    assert "location /socket.io" in alias_block
+    assert f"root {tmp_path}/sites/{_PLACEHOLDER_SITE.name}/public;" in alias_block
+    assert "return 301" not in alias_block
+
+
+def test_a_redirecting_alias_has_no_static_locations(tmp_path: Path) -> None:
+    config = _cloud_config(
+        tmp_path,
+        [(_PLACEHOLDER_SITE, False)],
+        hostname_mappings={_SITE_GLOB: _PLACEHOLDER_SITE.name},
+    )
+
+    alias_block = _alias_block(config)
+    assert "location /assets" not in alias_block
+    assert "return 301" in alias_block
 
 
 def test_self_hosted_bench_has_no_vm_hostnames(tmp_path: Path) -> None:


### PR DESCRIPTION
### Summary

Apply Central credentials during host boot instead of waiting for the first Admin request.

### Changes

- Add a boot-time central-bootstrap.service for Central-managed benches.
- Run credential discovery as a systemd oneshot service after network availability.
- Keep the existing request-time watcher as a fallback.
- Skip bootstrap cleanly for self-hosted benches.
- Add coverage for boot-time credential application and systemd unit rendering.