### PR TITLE
fix: link app node_modules for prebuilt assets

### DIFF
--- a/pilot/managers/python_assets.py
+++ b/pilot/managers/python_assets.py
@@ -189,6 +189,8 @@ class PythonAssetBuilder:
         node_modules_link = app_link / "node_modules"
 
         if app_node_modules.is_dir():
+            if node_modules_link.is_symlink():
+                node_modules_link.unlink()
             node_modules_link.symlink_to(app_node_modules.resolve())
 
         self.write_assets_json(app_name, dist_dir, assets_dir)

--- a/pilot/managers/python_assets.py
+++ b/pilot/managers/python_assets.py
@@ -185,6 +185,12 @@ class PythonAssetBuilder:
             shutil.rmtree(str(app_link))
         app_link.symlink_to(app_public_dir.resolve())
 
+        app_node_modules = app_public_dir.parent.parent / "node_modules"
+        node_modules_link = app_link / "node_modules"
+
+        if app_node_modules.is_dir():
+            node_modules_link.symlink_to(app_node_modules.resolve())
+
         self.write_assets_json(app_name, dist_dir, assets_dir)
         print(f"  Linked {app_link} -> {app_public_dir.resolve()}")
 

--- a/tests/pilot/managers/test_python_assets.py
+++ b/tests/pilot/managers/test_python_assets.py
@@ -103,3 +103,27 @@ def test_ensure_yarn_install_skips_when_integrity_is_current(tmp_path: Path) -> 
         make_builder().ensure_yarn_install(tmp_path)
 
     run_command.assert_not_called()
+
+def test_setup_prebuilt_assets_links_node_modules(tmp_path: Path) -> None:
+    app_path = tmp_path / "gameplan"
+    app_public_dir = app_path / "gameplan" / "public"
+    dist_dir = app_public_dir / "dist"
+    node_modules = app_path / "node_modules"
+
+    dist_dir.mkdir(parents=True)
+    node_modules.mkdir(parents=True)
+
+    manager = MagicMock()
+    manager.bench.sites_path = tmp_path / "sites"
+    manager.bench.sites_path.mkdir()
+    builder = PythonAssetBuilder(manager)
+
+    with patch.object(builder, "write_assets_json"):
+        builder.setup_prebuilt_assets("gameplan", app_public_dir, dist_dir)
+
+    assert (tmp_path / "sites" / "assets" / "gameplan").is_symlink()
+    assert (tmp_path / "sites" / "assets" / "gameplan" / "node_modules").is_symlink()
+    assert (
+        (tmp_path / "sites" / "assets" / "gameplan" / "node_modules").resolve()
+        == node_modules.resolve()
+    )

--- a/tests/pilot/managers/test_python_assets.py
+++ b/tests/pilot/managers/test_python_assets.py
@@ -127,3 +127,28 @@ def test_setup_prebuilt_assets_links_node_modules(tmp_path: Path) -> None:
         (tmp_path / "sites" / "assets" / "gameplan" / "node_modules").resolve()
         == node_modules.resolve()
     )
+
+def test_setup_prebuilt_assets_can_be_called_twice(tmp_path: Path) -> None:
+    app_path = tmp_path / "gameplan"
+    app_public_dir = app_path / "gameplan" / "public"
+    dist_dir = app_public_dir / "dist"
+    node_modules = app_path / "node_modules"
+
+    dist_dir.mkdir(parents=True)
+    node_modules.mkdir(parents=True)
+
+    manager = MagicMock()
+    manager.bench.sites_path = tmp_path / "sites"
+    manager.bench.sites_path.mkdir()
+    builder = PythonAssetBuilder(manager)
+
+    with patch.object(builder, "write_assets_json"):
+        builder.setup_prebuilt_assets("gameplan", app_public_dir, dist_dir)
+        builder.setup_prebuilt_assets("gameplan", app_public_dir, dist_dir)
+
+    node_modules_link = (
+        tmp_path / "sites" / "assets" / "gameplan" / "node_modules"
+    )
+
+    assert node_modules_link.is_symlink()
+    assert node_modules_link.resolve() == node_modules.resolve()


### PR DESCRIPTION
## Description

Fixes #443.

When creating a new site with Pilot, prebuilt Frappe assets are downloaded and linked under `sites/assets/<app>`. However, the app's `node_modules` directory was not linked there.

Frappe's asset watcher expects frontend dependencies to be available through this path when building assets. Without the symlink, the CSS build can fail with an error such as:

```text
ENOENT: no such file or directory, open
'.../frappe/public/node_modules/highlight.js/styles/tomorrow.css'
```

The JS build can still remove the old prebuilt bundles before the overall asset build fails. Since the manifest is not updated when the build fails, `assets.json` can continue pointing to the removed bundle, resulting in 404s for Frappe assets.

### Changes

* Link the app's `node_modules` into `sites/assets/<app>/node_modules` when setting up prebuilt assets.
* Add a regression test to verify that the symlink is created and points to the app's `node_modules`.