### PR TITLE
refactor: name every host-wide unit pilot-*, reserve only that name

### DIFF
--- a/admin/backend/api/v1/sites/storage.py
+++ b/admin/backend/api/v1/sites/storage.py
@@ -21,7 +21,7 @@ from pilot.tasks.refresh_storage_usage import RefreshStorageUsageTask
 
 @sites_bp.get("/storage")
 def get_storage():
-    """Every site's files and database usage, from the report the site-storage
+    """Every site's files and database usage, from the report the pilot-storage
     timer refreshes. Measured here only when there is no report yet."""
     bench_root = Path(current_app.config["BENCH_ROOT"])
     try:

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -88,7 +88,7 @@ Both operations re-point any matching `central.hostname_aliases` entry, so a VM 
 
 `GET /sites/storage` returns every site's `private_bytes`, `public_bytes`, `database_bytes`, and `total_bytes`, plus the `collected_at` of the reading. `database_bytes` is what the schema holds on disk, allocated-but-freed pages included, since nothing else can use that space until the tables are rebuilt.
 
-Measuring means a `du` per site directory and one schema-size query, so the route serves `logs/site-storage.json` instead - written by the `site-storage` systemd timer every six hours (`pilot.core.site.storage`). Reading never measures, however old the report is; the route falls back to measuring only when there is no report at all, which is the first read on a bench whose timer has not run yet.
+Measuring means a `du` per site directory and one schema-size query, so the route serves `logs/site-storage.json` instead - written by the `pilot-storage` systemd timer every six hours (`pilot.core.site.storage`). Reading never measures, however old the report is; the route falls back to measuring only when there is no report at all, which is the first read on a bench whose timer has not run yet.
 
 `POST /sites/<name>/actions/refresh-storage` queues `refresh-storage-usage` to measure again on demand. One report covers every site on the bench, so the task re-measures all of them and concurrent requests fold into one run.
 

--- a/pilot/config/bench.py
+++ b/pilot/config/bench.py
@@ -39,10 +39,9 @@ from pilot.internal.atomic_file import (
 from pilot.internal.toml import ConfigDict, Toml
 
 _BENCH_NAME_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9_-]*$")
-# Host-wide user units are named "<prefix>-<what>.service" - pilot-mariadb,
-# bench-monitor, site-uptime. A bench of the same name owns "<name>-*", so its
-# units would be indistinguishable from theirs.
-_RESERVED_BENCH_NAMES = frozenset({"bench", "pilot", "site"})
+# Every host-wide user unit is named "pilot-<what>.service". A bench owns
+# "<name>-*", so a bench named pilot could not be told apart from them.
+_RESERVED_BENCH_NAMES = frozenset({"pilot"})
 _PORT_MIN = 1
 _PORT_MAX = 65535
 
@@ -291,9 +290,9 @@ class BenchConfig:
             )
         if self.name in _RESERVED_BENCH_NAMES:
             raise ConfigError(
-                f"bench.name '{self.name}' is reserved: host-wide services are named "
+                f"bench.name '{self.name}' is reserved: this host's own services are named "
                 f"'{self.name}-<service>', so a bench of this name could not be told apart "
-                f"from them. Reserved names are {', '.join(sorted(_RESERVED_BENCH_NAMES))}."
+                f"from them."
             )
 
     def _validate_app_names_unique(self) -> None:

--- a/pilot/core/server/monitoring_config.py
+++ b/pilot/core/server/monitoring_config.py
@@ -55,8 +55,8 @@ class MonitorConfigurator(SystemdUserMixin):
 
     def __init__(self, bench: "Bench | None" = None):
         self.bench = bench
-        self.unit_name = "bench-monitor.service"
-        self.timer_unit_name = "bench-monitor.timer"
+        self.unit_name = "pilot-monitor.service"
+        self.timer_unit_name = "pilot-monitor.timer"
         self.monitor_dir = cli_root() / "system" / "monitor"
 
     def install(self) -> None:

--- a/pilot/core/site/storage/__init__.py
+++ b/pilot/core/site/storage/__init__.py
@@ -35,7 +35,7 @@ class SiteStorageReport:
 
 class SiteStorageCollector:
     """Every site's files and database size, kept in one file so the Admin API
-    answers without walking the disk. The site-storage timer refreshes it;
+    answers without walking the disk. The pilot-storage timer refreshes it;
     reach it as `bench.site_storage`."""
 
     def __init__(self, bench: "Bench") -> None:

--- a/pilot/core/site/storage/systemd.py
+++ b/pilot/core/site/storage/systemd.py
@@ -27,8 +27,8 @@ Type=oneshot
 WorkingDirectory={cli_root}
 Environment=PYTHONPATH={cli_root}
 ExecStart={python} -m pilot.core.site.storage
-StandardOutput=append:{cli_root}/system/logs/site-storage.log
-StandardError=append:{cli_root}/system/logs/site-storage.error.log
+StandardOutput=append:{cli_root}/system/logs/pilot-storage.log
+StandardError=append:{cli_root}/system/logs/pilot-storage.error.log
 
 [Install]
 WantedBy=default.target
@@ -41,8 +41,8 @@ class SiteStorageConfigurator(SystemdUserMixin):
     set up. The measuring lives in pilot.core.site.storage."""
 
     def __init__(self) -> None:
-        self.unit_name = "site-storage.service"
-        self.timer_unit_name = "site-storage.timer"
+        self.unit_name = "pilot-storage.service"
+        self.timer_unit_name = "pilot-storage.timer"
         self.storage_dir = cli_root() / "system" / "storage"
 
     def install(self) -> None:

--- a/pilot/core/site/uptime_monitoring.py
+++ b/pilot/core/site/uptime_monitoring.py
@@ -1,5 +1,5 @@
 """Pings every production site's /api/method/ping and appends the result to
-that site's bench's uptime log. Invoked by the shared site-uptime systemd
+that site's bench's uptime log. Invoked by the shared pilot-uptime systemd
 timer (pilot.core.site.uptime_monitoring_config); one pass per invocation,
 covering every sibling bench - the timer itself controls the interval."""
 

--- a/pilot/core/site/uptime_monitoring_config.py
+++ b/pilot/core/site/uptime_monitoring_config.py
@@ -51,8 +51,8 @@ class UptimeMonitorConfigurator(SystemdUserMixin):
 
     def __init__(self, bench: "Bench | None" = None):
         self.bench = bench
-        self.unit_name = "site-uptime.service"
-        self.timer_unit_name = "site-uptime.timer"
+        self.unit_name = "pilot-uptime.service"
+        self.timer_unit_name = "pilot-uptime.timer"
         self.uptime_dir = cli_root() / "system" / "uptime"
 
     def install(self) -> None:

--- a/tests/pilot/core/test_monitoring_config.py
+++ b/tests/pilot/core/test_monitoring_config.py
@@ -19,8 +19,8 @@ def test_monitor_install_is_idempotent(tmp_path: Path) -> None:
             configurator.install()
         install.assert_not_called()
 
-    assert (unit_dir / "bench-monitor.service").exists()
-    assert (unit_dir / "bench-monitor.timer").exists()
+    assert (unit_dir / "pilot-monitor.service").exists()
+    assert (unit_dir / "pilot-monitor.timer").exists()
 
 
 def test_uptime_install_is_idempotent(tmp_path: Path) -> None:
@@ -37,8 +37,8 @@ def test_uptime_install_is_idempotent(tmp_path: Path) -> None:
             configurator.install()
         install.assert_not_called()
 
-    assert (unit_dir / "site-uptime.service").exists()
-    assert (unit_dir / "site-uptime.timer").exists()
+    assert (unit_dir / "pilot-uptime.service").exists()
+    assert (unit_dir / "pilot-uptime.timer").exists()
 
 
 def test_site_storage_install_is_idempotent(tmp_path: Path) -> None:
@@ -57,7 +57,7 @@ def test_site_storage_install_is_idempotent(tmp_path: Path) -> None:
             configurator.install()
         install.assert_not_called()
 
-    assert (unit_dir / "site-storage.service").exists()
-    timer = (unit_dir / "site-storage.timer").read_text()
+    assert (unit_dir / "pilot-storage.service").exists()
+    timer = (unit_dir / "pilot-storage.timer").read_text()
     assert "OnCalendar=00/6:00:00" in timer
     assert "Persistent=true" in timer


### PR DESCRIPTION
Follow-up to #481, which merged reserving `bench`, `pilot` and `site`. Reserving the first and last broke 35 tests whose fixtures build a bench named `bench` — so this removes the need for them.

Host-wide user units were spread over three prefixes — `bench-monitor`, `site-storage`, `site-uptime` — alongside `pilot-mariadb`, `pilot-postgres` and `pilot-fluent-bit`. All six live under `cli_root()/system/` and belong to the host, not to any bench.

A bench owns `<name>-*`, so each prefix was a name a bench could take and then be indistinguishable from: `_installed_bench_units()` lists that glob and `_reap_stale_units()` stops and disables everything in it the bench does not want. On a bench named `pilot` that disabled the host's own MariaDB.

| bench named | glob | would reap |
|---|---|---|
| `pilot` | `pilot-*` | mariadb, postgres, fluent-bit |
| `bench` | `bench-*` | monitor |
| `site` | `site-*` | storage, uptime |

Moving the last three into one namespace leaves `pilot` as the only name worth reserving:

- `bench-monitor.{service,timer}` → `pilot-monitor.{service,timer}`
- `site-storage.{service,timer}` → `pilot-storage.{service,timer}`
- `site-uptime.{service,timer}` → `pilot-uptime.{service,timer}`
- `_RESERVED_BENCH_NAMES` narrowed to `{"pilot"}`, which restores those 35 tests

`site-storage.json` keeps its name — it is the report the Admin API serves, not a unit.

**Upgrade note:** `install()` is guarded by `user_timer_installed(<new name>)`, so an existing host installs the renamed timers while the old ones stay enabled and keep firing. They need disabling once — say the word and I will add that here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
