### PR TITLE
fix(nginx): serve public files of every extension

### DIFF
--- a/pilot/managers/nginx/templates/bench.conf.template
+++ b/pilot/managers/nginx/templates/bench.conf.template
@@ -30,9 +30,27 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
-    location ~ ^/files/.*\.(jpg|jpeg|png|gif|svg|webp|pdf|docx?|xlsx?)$ {
+    {# frappe's FORCE_DOWNLOAD_EXTENSIONS; inline markup would be stored XSS #}
+    location ~* ^/files/.*\.(svg|svgz|html|htm|xhtml|xht|shtml|shtm|mhtml|mht|xml|xsl|xslt|swf)$ {
         root {{ alias.public_root }};
-        try_files $uri =404;
+        add_header Content-Disposition "attachment";
+        try_files $uri @app;
+    }
+
+    location /files/ {
+        root {{ alias.public_root }};
+        try_files $uri @app;
+    }
+
+    location @app {
+        proxy_pass         {{ alias.proxy_pass }};
+        proxy_read_timeout 120;
+        proxy_redirect     off;
+        proxy_set_header   Host               $host;
+        proxy_set_header   X-Real-IP          $remote_addr;
+        proxy_set_header   X-Forwarded-For    $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto  $scheme;
+        proxy_set_header   X-Frappe-Site-Name {{ alias.site }};
     }
 
     location /socket.io {
@@ -228,9 +246,27 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
-    location ~ ^/files/.*\.(jpg|jpeg|png|gif|svg|webp|pdf|docx?|xlsx?)$ {
+    {# frappe's FORCE_DOWNLOAD_EXTENSIONS; inline markup would be stored XSS #}
+    location ~* ^/files/.*\.(svg|svgz|html|htm|xhtml|xht|shtml|shtm|mhtml|mht|xml|xsl|xslt|swf)$ {
         root {{ vhost.public_root }};
-        try_files $uri =404;
+        add_header Content-Disposition "attachment";
+        try_files $uri @app;
+    }
+
+    location /files/ {
+        root {{ vhost.public_root }};
+        try_files $uri @app;
+    }
+
+    location @app {
+        proxy_pass         http://bench-{{ upstream_name }};
+        proxy_read_timeout 120;
+        proxy_redirect     off;
+        proxy_set_header   Host               $host;
+        proxy_set_header   X-Real-IP          $remote_addr;
+        proxy_set_header   X-Forwarded-For    {% if proxy_servers %}$http_x_forwarded_for{% else %}$proxy_add_x_forwarded_for{% endif %};
+        proxy_set_header   X-Forwarded-Proto  $scheme;
+        proxy_set_header   X-Frappe-Site-Name {{ vhost.name }};
     }
 
     {# realtime (socket.io) #}

--- a/tests/pilot/managers/test_nginx_config.py
+++ b/tests/pilot/managers/test_nginx_config.py
@@ -119,6 +119,65 @@ def test_dual_stack_listeners(tmp_path: Path) -> None:
         assert line in config
 
 
+# --- public files -----------------------------------------------------------
+
+
+def test_public_files_are_served_regardless_of_extension(tmp_path: Path) -> None:
+    """An extension allowlist used to drop anything but images and documents,
+    so kernels, disk images and archives 404ed even though they were on disk."""
+    config = _site_config(tmp_path, _BASE_SITE)
+
+    assert "location /files/ {" in config
+    assert f"root {tmp_path}/sites/site1.example.com/public;" in config
+    # No extension list guards the prefix location.
+    assert "jpg|jpeg|png" not in config
+
+
+def test_public_files_fall_back_to_the_app(tmp_path: Path) -> None:
+    config = _site_config(tmp_path, _BASE_SITE)
+
+    assert "try_files $uri @app;" in config
+    assert "location @app {" in config
+    assert "proxy_pass         http://bench-test-bench;" in config
+    assert "proxy_set_header   X-Frappe-Site-Name site1.example.com;" in config
+
+
+def test_markup_uploads_are_forced_to_download(tmp_path: Path) -> None:
+    """nginx serves public files off disk, so it must repeat the attachment
+    header frappe would have sent. Inline user markup is stored XSS."""
+    config = _site_config(tmp_path, _BASE_SITE)
+    matcher = next(line for line in config.splitlines() if "location ~* ^/files/" in line)
+
+    assert 'add_header Content-Disposition "attachment";' in config
+    for extension in ("svg", "svgz", "html", "xhtml", "xml", "swf"):
+        assert f"{extension}|" in matcher or f"{extension})" in matcher
+
+
+def test_force_download_match_is_case_insensitive(tmp_path: Path) -> None:
+    """A case-sensitive match would let evil.SVG render inline."""
+    config = _site_config(tmp_path, _BASE_SITE)
+
+    assert "location ~* ^/files/" in config
+
+
+def test_force_download_location_precedes_the_prefix_location(tmp_path: Path) -> None:
+    """nginx prefers a regex location over a prefix one, but only the first
+    regex that matches, so this block has to come before any other /files regex."""
+    config = _site_config(tmp_path, _BASE_SITE)
+
+    assert config.index("location ~* ^/files/") < config.index("location /files/ {")
+
+
+def test_every_files_fallback_has_a_named_location(tmp_path: Path) -> None:
+    """try_files pointing at an undeclared @app fails nginx at startup, which a
+    template test is the only cheap place to catch."""
+    config = _site_config(tmp_path, _BASE_SITE, ssl=True)
+
+    for block in config.split("server {")[1:]:
+        if "try_files $uri @app;" in block:
+            assert "location @app {" in block
+
+
 # --- trusted proxy ----------------------------------------------------------
 
 
@@ -764,6 +823,22 @@ def test_a_serving_alias_serves_static_files(tmp_path: Path) -> None:
     assert "location /socket.io" in alias_block
     assert f"root {tmp_path}/sites/{_PLACEHOLDER_SITE.name}/public;" in alias_block
     assert "return 301" not in alias_block
+
+
+def test_a_serving_alias_serves_public_files_of_any_extension(tmp_path: Path) -> None:
+    config = _cloud_config(
+        tmp_path,
+        [(_PLACEHOLDER_SITE, False)],
+        hostname_mappings={_SITE_GLOB: _PLACEHOLDER_SITE.name},
+        redirect=False,
+    )
+
+    alias_block = _alias_block(config)
+    assert "location /files/ {" in alias_block
+    assert "location ~* ^/files/" in alias_block
+    assert 'add_header Content-Disposition "attachment";' in alias_block
+    assert "location @app {" in alias_block
+    assert f"proxy_set_header   X-Frappe-Site-Name {_PLACEHOLDER_SITE.name};" in alias_block
 
 
 def test_a_redirecting_alias_has_no_static_locations(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`/files/` was served off disk only for an extension allowlist (`jpg|jpeg|png|gif|svg|webp|pdf|docx?|xlsx?`). Anything else was proxied to the app, and Frappe has no handler for public files in production — nginx is meant to serve them — so the website router returned its 404 page.

Found on a live bench where all 7 uploaded artifacts 404ed despite being on disk (kernels, 4 GiB `.ext4` images, `.tar` bundles). Not niche: the list has no `csv`, `txt`, `json`, `zip`, `mp4`, so a user attaching a CSV can't download it on **any** deployed bench.

The list mirrors Frappe's `ALLOWED_MIMETYPES`, which gates what a Guest may *upload* through one legacy endpoint — an inbound control repurposed as a serving rule. A public file is public by definition, and Frappe ships no nginx config for the list to have come from.

## Change

```nginx
location ~* ^/files/.*\.(svg|svgz|html|...|swf)$ {   # frappe's FORCE_DOWNLOAD_EXTENSIONS
    root {{ vhost.public_root }};
    add_header Content-Disposition "attachment";
    try_files $uri @app;
}

location /files/ {
    root {{ vhost.public_root }};
    try_files $uri @app;
}
```

Serving the whole prefix means nginx now answers markup uploads that used to reach the app, so it must repeat the attachment header Frappe would have sent — inline user-uploaded SVG/HTML from the site origin is stored XSS.

Three details that matter:
- **`~*` not `~`** — case-sensitive would let `evil.SVG` render inline.
- **Regex block first** — nginx takes the first matching regex location.
- **`@app` not `=404`** — matches bench's `@webserver`, so a route an app registers under `/files/` still resolves. Only fires on a miss; an on-disk file is served by `sendfile` with the app never contacted.

Both the site vhost and the Central alias block are updated. Template + tests only, no Python.

## Verification

Deployed to a production bench: all 7 artifacts 200 with `content-length` matching disk (first bytes `\x7fELF`, `accept-ranges: bytes` on the 4 GiB images); `.svg`/`.html`/`.SVG` get `content-disposition: attachment`; `.csv` serves where it used to 404; misses fall through to Frappe. Measured on-box: 6ms nginx hit vs 19ms app miss — strictly less app load than before, when every non-allowlisted request hit the app. `/assets`, admin vhost and app routes unaffected. Rendered config also checked with a real `nginx -t`.

## Tests

7 cases in `test_nginx_config.py`, which had **no** assertions on this block before — how it survived three refactors. Covers any-extension serving, the `@app` fallback, force-download presence and case-insensitivity, regex-before-prefix ordering, that every `try_files @app` has a matching named location (else nginx fails at startup), and the alias vhost.

`ruff` clean on changed files; full suite `2757 passed` vs `2750` on develop, same 45 pre-existing failures either way.

## Out of scope

Separate upstream bug found while tracing this: `frappe/middlewares.py:35` resolves the site from raw `HTTP_HOST` ignoring `X-Frappe-Site-Name`, and `raise NotFound` breaks werkzeug's `(None, None)` loader contract, escaping as a 500. Only fires when the runner serves statics (`FRAPPE_SERVE_ASSETS`). Needs a PR to frappe/frappe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y13VMMdFUdaJgqxE4DXFpS
