### PR TITLE
feat(init): add --no-dev to skip apps' dev extras

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,7 +8,7 @@ Use `pilot --help` and `pilot <command> --help` for exact flags.
 
 - `pilot new NAME`: create a new bench. Sets the Admin password from `--admin-password`, else prompts on a terminal, else generates and prints one.
 - `pilot start` on an uninitialized bench serves the setup wizard and prints a one-hour `?sid=` sign-in link for it.
-- `pilot init`: initialize a bench from `bench.toml`. This is what the setup wizard runs.
+- `pilot init`: initialize a bench from `bench.toml`. This is what the setup wizard runs. `--no-dev` skips apps' `dev` extras.
 - `pilot ls`: list benches in the fixed benches directory.
 - `pilot drop --bench NAME`: remove a bench.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -49,6 +49,7 @@ The `[bench]` table supports:
 | `default_branch` | Default branch for new apps. |
 | `allow_developer_mode` | Allows per-site developer mode changes. |
 | `watch_apps_js`, `watch_admin_js`, `reload_python` | Development reload settings. |
+| `install_dev_extra` | Install apps' `dev` extras on a non-production bench. Defaults to true; `pilot init --no-dev` sets it to false. |
 
 Applications use `[[apps]]` entries. `branches` can list branches available to the app:
 

--- a/pilot/commands/bench/initialize.py
+++ b/pilot/commands/bench/initialize.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import Annotated, ClassVar
 
-from pilot.commands import BenchMode, Command
+from pilot.commands import Arg, BenchMode, Command
 
 
 @dataclass(kw_only=True)
@@ -13,5 +13,13 @@ class InitCommand(Command):
     # Heavy/irreversible - never guess the target bench.
     bench_mode: ClassVar[BenchMode] = BenchMode.EXPLICIT
 
+    no_dev: Annotated[
+        bool,
+        Arg(help="Skip apps' dev extras. Stored as bench.install_dev_extra for later installs."),
+    ] = False
+
     def run(self) -> None:
+        if self.no_dev:
+            self.bench.config.install_dev_extra = False
+            self.bench.config.write(self.bench.path)
         self.bench.initialize(on_progress=self.report)

--- a/pilot/config/bench.py
+++ b/pilot/config/bench.py
@@ -124,6 +124,8 @@ class BenchConfig:
     default_branch: str = ""
     # Gates whether developer mode can be toggled per site; sets nothing itself.
     allow_developer_mode: bool = False
+    # Whether `uv pip install -e` pulls an app's `dev` extra, such as frappe's watchdog.
+    install_dev_extra: bool = True
     production: ProductionConfig = field(default_factory=ProductionConfig)
     lite_mode: LiteModeConfig = field(default_factory=LiteModeConfig)
     nginx: NginxConfig = field(default_factory=NginxConfig)
@@ -215,6 +217,7 @@ class BenchConfig:
             db_type=bench_data.get("db_type", "mariadb"),
             default_branch=bench_data.get("default_branch", ""),
             allow_developer_mode=bench_data.get("allow_developer_mode", False),
+            install_dev_extra=bench_data.get("install_dev_extra", True),
             apps=apps,
             mariadb=common.mariadb,
             postgres=common.postgres,
@@ -516,6 +519,7 @@ class BenchConfig:
             "watch_admin_js": self.watch_admin_js,
             "db_type": self.db_type,
             "allow_developer_mode": self.allow_developer_mode,
+            "install_dev_extra": self.install_dev_extra,
         }
         if self.default_branch:
             bench["default_branch"] = self.default_branch
@@ -858,6 +862,7 @@ _BENCH_KEYS = {
     "db_type",
     "default_branch",
     "allow_developer_mode",
+    "install_dev_extra",
 }
 # Keys older Pilot versions wrote that the parser still tolerates.
 _PRODUCTION_LEGACY = {"lightweight", "nginx", "use_companion_manager"}

--- a/pilot/core/app/__init__.py
+++ b/pilot/core/app/__init__.py
@@ -235,8 +235,10 @@ class App:
     def editable_target(self) -> str:
         """Target for `uv pip install -e`. A dev bench also pulls the app's dev extra,
         which is where frappe keeps watchdog, the reloader `--dev` refuses to start
-        without."""
-        if self.bench.config.production.enabled or not self.has_dev_extra:
+        without. `bench.install_dev_extra = false` opts out on a bench that will never
+        run the reloader."""
+        config = self.bench.config
+        if config.production.enabled or not config.install_dev_extra or not self.has_dev_extra:
             return str(self.path)
         return f"{self.path}[dev]"
 

--- a/tests/pilot/commands/test_init_command.py
+++ b/tests/pilot/commands/test_init_command.py
@@ -1,13 +1,18 @@
-"""BenchInitializer._provision_or_verify: existing database handling."""
+"""`pilot init`: existing database handling and the --no-dev opt-out."""
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from pilot.commands.bench.initialize import InitCommand
+from pilot.config import BenchConfig
+from pilot.core.bench import Bench
 from pilot.core.bench.initializer import BenchInitializer
 from pilot.exceptions import BenchError
+from tests.pilot.commands.test_commands import make_bench
 
 
 def _initializer() -> BenchInitializer:
@@ -92,3 +97,24 @@ def test_ensure_database_credentials_skips_sqlite() -> None:
     BenchInitializer(bench)._ensure_database_credentials()
 
     bench.config.write.assert_not_called()
+
+
+def test_no_dev_persists_the_opt_out_before_initialising(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    bench.config.write(tmp_path)
+
+    with patch.object(Bench, "initialize") as initialize:
+        InitCommand(bench=bench, no_dev=True).run()
+
+    initialize.assert_called_once()
+    assert BenchConfig.read(tmp_path).install_dev_extra is False
+
+
+def test_init_keeps_the_dev_extra_by_default(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    bench.config.write(tmp_path)
+
+    with patch.object(Bench, "initialize"):
+        InitCommand(bench=bench).run()
+
+    assert BenchConfig.read(tmp_path).install_dev_extra is True

--- a/tests/pilot/core/test_app_editable_target.py
+++ b/tests/pilot/core/test_app_editable_target.py
@@ -74,3 +74,13 @@ def test_malformed_pyproject_installs_plainly(tmp_path: Path) -> None:
     assert not app.has_dev_extra
     assert app.editable_target == str(app.path)
     assert app.module_name == "broken"
+
+
+def test_install_dev_extra_false_skips_the_dev_extra(tmp_path: Path) -> None:
+    bench = make_bench(tmp_path)
+    bench.config.production.enabled = False
+    bench.config.install_dev_extra = False
+    app = _make_app(bench, "frappe", _WITH_DEV_EXTRA)
+
+    assert app.has_dev_extra
+    assert app.editable_target == str(app.path)


### PR DESCRIPTION
## Why

`App.editable_target` appends `[dev]` to every editable install on a non-production bench. That exists because frappe keeps `watchdog` in its `dev` extra and the `--dev` reloader will not start without it — useful on a laptop bench, useless on a bench that only ever runs production.

It also breaks installs on frappe `develop` right now: `pyproject.toml` pins PyPika to `0.51.1` while the `dev` extra's `pypika-stubs` requires `pypika>=0.48.9,<0.49.0`, so `frappe[dev]` is unresolvable. Any flow that runs `pilot init` before `pilot setup production` (the atlas-vm setup does) hits it, since `production.enabled` is still false at init time.

## What

- New bench setting `bench.install_dev_extra` (default `true`). `editable_target` consults it alongside `production.enabled`, so the dev extra is explicit config rather than something inferred only from the production flag.
- `pilot init --no-dev` writes `install_dev_extra = false` before initialising, so later app installs on that bench skip the extra too.
- Docs for the new key and flag.

Behaviour is unchanged for existing benches: a dev bench still gets `[dev]`, a production bench still does not.

## Tests

- `tests/pilot/core/test_app_editable_target.py`: `install_dev_extra = false` skips the extra even when the app declares one.
- `tests/pilot/commands/test_init_command.py`: `--no-dev` persists the opt-out before initialising; default init leaves it on.

`uv run pytest` and `uv run ruff check admin pilot tests` were run; the failures and lint errors that remain are pre-existing on `develop` in this environment (dev-checkout-dependent admin tests, and two unrelated test-file lint errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)